### PR TITLE
Fix taxonomy-venue template: align block name with registered namespace

### DIFF
--- a/templates/taxonomy-venue.html
+++ b/templates/taxonomy-venue.html
@@ -8,7 +8,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-kinds-for-indieweb/venue-detail {"showMap":true,"showAddress":true,"showCheckins":true,"checkinCount":10} /-->
+	<!-- wp:post-kinds-indieweb/venue-detail {"showMap":true,"showAddress":true,"showCheckins":true,"checkinCount":10} /-->
 
 	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
 		<!-- wp:query-pagination-previous /-->


### PR DESCRIPTION
## The bug

On every venue archive page, the front-end shows:

> Your site doesn't include support for the "post-kinds-for-indieweb/venue-detail" block. You can leave it as-is or remove it.

## Root cause

`templates/taxonomy-venue.html` references `<!-- wp:post-kinds-for-indieweb/venue-detail -->` (with `-for-`), but every block.json in the plugin registers under `post-kinds-indieweb/` (without `-for-`). All 20 blocks confirmed via repo search — `name` and `category` fields uniformly use `post-kinds-indieweb/`.

WordPress can't find the block under the template's referenced namespace, so it renders the standard missing-block placeholder.

## The fix

One-line change in `templates/taxonomy-venue.html` to match the registered namespace.

## Why this minimum-disruption shape

Existing post_content across deployed sites already has block markup using `post-kinds-indieweb/` (matching the registered names). Renaming the block registry to `post-kinds-for-indieweb/` (matching the plugin slug) would be more conventional but would invalidate every existing post and require a migration shim. Out of scope here.

## Larger naming issue worth a follow-up

WordPress convention is that a plugin's block namespace matches its slug. This plugin's slug is `post-kinds-for-indieweb` but blocks register under `post-kinds-indieweb`. Files affected if you choose to standardize:

- 20 `src/blocks/*/block.json` files (name + category fields)
- All pattern files in `patterns/` referencing the namespace
- The `block_categories_all` filter in `includes/class-plugin.php`
- A content migration that rewrites existing block markup, OR a `block_type_metadata_settings` filter that aliases the old name to the new for legacy content

Worth tracking as a separate issue. Today's PR just stops the bleeding on venue archives.

## Test plan

- [ ] Merge → deploy to a site with the plugin active.
- [ ] Visit any venue taxonomy archive page.
- [ ] Confirm the venue-detail block renders (map + address + recent check-ins) instead of the placeholder error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)