### PR TITLE
Micropub-to-block content bridge: render cards on Outpost/Quill/etc. posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Micropub-to-block content bridge** (`includes/class-micropub-content-builder.php`). Hooks `after_micropub` priority 30 and rewrites Micropub-created `post_content` from plain text to the registered card blocks (Checkin Card, Eat Card, Drink Card, Listen Card, Watch Card, Read Card, Play Card, RSVP Card, Mood Card) when the incoming h-entry shape matches a recognized post kind. Bridges any Micropub client (Outpost, Quill, Indigenous, etc.) to this plugin's block-editor cards without requiring the client to know about Gutenberg block markup.
+  - **Idempotent.** Sets a `_pkiw_block_content_generated` post meta marker on first generation; subsequent Micropub updates leave (potentially user-edited) content alone.
+  - **h-entry envelope.** Wraps each card in a `wp:group` with `class="h-entry"` and an inner `e-content` group for the user's typed body text, so microformats2 readers see one h-entry root and the body in `e-content`.
+  - **Geo extraction.** Parses `location: geo:lat,lon` (RFC 5870) into `latitude`/`longitude` (or `geoLatitude`/`geoLongitude` for Eat/Drink) attributes on the card block.
+  - **Outpost-friendly.** Recognizes Outpost's `mp-place-name` extension property as the venue name attribute. Outpost-made checkin/eat/drink/listen posts now render with proper card UI on the front-end.
+  - 17 PHPUnit unit tests covering kind detection, geo parsing, per-kind builders, idempotency, and the plain-note skip path.
 - Jam Card, Eat Card, Drink Card, Favorite Card, Wish Card, Mood Card, Acquisition Card blocks
 - Play Card block with RAWG integration
 - Checkin Dashboard block for location overview

--- a/includes/class-micropub-content-builder.php
+++ b/includes/class-micropub-content-builder.php
@@ -1,0 +1,466 @@
+<?php
+/**
+ * Micropub content builder — converts h-entry properties into block markup.
+ *
+ * The Micropub plugin (David Shanske) creates a wp_posts row whose
+ * `post_content` is the literal `content` property string. Front-end render
+ * is then "whatever the user typed" — no card, no map, no venue detail.
+ *
+ * This bridge listens on the `after_micropub` action and rewrites
+ * `post_content` to use this plugin's registered card blocks (Checkin Card,
+ * Eat Card, Drink Card, Listen Card, Watch Card, Read Card, Mood Card,
+ * etc.) when the incoming h-entry shape matches a known post kind. The
+ * user's typed body content is preserved as an `e-content` paragraph
+ * inside the same h-entry group so microformats2 + block rendering both
+ * work.
+ *
+ * Idempotent — once a post has been auto-generated, the
+ * `_pkiw_block_content_generated` post meta marker is set and subsequent
+ * Micropub updates leave the (potentially user-edited) post_content alone.
+ *
+ * @package PostKindsForIndieWeb
+ * @since   1.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PostKindsForIndieWeb;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds block-editor post_content from incoming Micropub h-entry properties.
+ *
+ * Hook order: this class registers at `after_micropub` priority 30, deliberately
+ * AFTER any Micropub bridge that writes post meta (Outpost's bridges run at
+ * priority 20). That way card-block attributes can read post meta written
+ * earlier in the same request — though for the initial implementation
+ * everything is read directly from the `$input` properties array.
+ */
+final class Micropub_Content_Builder {
+
+	/**
+	 * Post meta key indicating the bridge already generated content for this post.
+	 *
+	 * @var string
+	 */
+	private const GENERATED_META_KEY = '_pkiw_block_content_generated';
+
+	/**
+	 * Hook the bridge into Micropub's post-creation flow.
+	 */
+	public static function register(): void {
+		add_action( 'after_micropub', array( self::class, 'apply' ), 30, 2 );
+	}
+
+	/**
+	 * Replace post_content with card-block markup when the incoming Micropub
+	 * request matches a known post kind. Skipped when:
+	 *   - the post ID is missing (request shape malformed)
+	 *   - the post already has a generated marker (re-edits don't clobber)
+	 *   - the h-entry doesn't match any of the recognized kinds.
+	 *
+	 * @param array<string, mixed> $input Original parsed Micropub request body.
+	 * @param array<string, mixed> $args  wp_insert_post args including 'ID'.
+	 */
+	public static function apply( $input, $args ): void {
+		if ( ! is_array( $input ) || ! is_array( $args ) || empty( $args['ID'] ) ) {
+			return;
+		}
+
+		$post_id = (int) $args['ID'];
+
+		// Idempotency — once we've written block content for this post, leave it alone.
+		// Users who manually edit the post in Gutenberg afterwards keep their changes.
+		if ( '' !== (string) get_post_meta( $post_id, self::GENERATED_META_KEY, true ) ) {
+			return;
+		}
+
+		$properties = self::extract_properties( $input );
+		if ( empty( $properties ) ) {
+			return;
+		}
+
+		$block_content = self::build_block_content( $properties );
+		if ( null === $block_content ) {
+			// Post kind didn't match any of the recognized shapes — leave the
+			// Micropub plugin's plain-text post_content alone.
+			return;
+		}
+
+		// Replace post_content with the block markup.
+		// `wp_update_post` triggers `save_post` which can recursively fire
+		// `after_micropub` filters in some edge cases; mark the post as
+		// generated FIRST so the recursion short-circuits at the idempotency
+		// check above.
+		update_post_meta( $post_id, self::GENERATED_META_KEY, '1' );
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $block_content,
+			)
+		);
+	}
+
+	/**
+	 * Extract the `properties` array from the Micropub request shape.
+	 *
+	 * Form-encoded Micropub puts properties at the top level of $input.
+	 * JSON Micropub nests them under `properties`. Try both.
+	 *
+	 * @param array<string, mixed> $input
+	 * @return array<string, mixed>
+	 */
+	private static function extract_properties( array $input ): array {
+		if ( isset( $input['properties'] ) && is_array( $input['properties'] ) ) {
+			return $input['properties'];
+		}
+		// Form-encoded shape — properties live at the top level. Strip the
+		// non-property keys (`h`, `action`, etc.).
+		$out = $input;
+		unset( $out['h'], $out['action'], $out['url'], $out['type'], $out['mp-syndicate-to'] );
+		return $out;
+	}
+
+	/**
+	 * Map the h-entry properties to a card block + content paragraph.
+	 * Returns null when no recognized post kind is detected.
+	 *
+	 * @param array<string, mixed> $properties
+	 * @return string|null Block markup ready for post_content, or null to skip.
+	 */
+	private static function build_block_content( array $properties ): ?string {
+		$kind = self::detect_kind( $properties );
+		if ( null === $kind ) {
+			return null;
+		}
+
+		$card_markup = self::card_for_kind( $kind, $properties );
+		if ( null === $card_markup ) {
+			return null;
+		}
+
+		$body = self::flatten_scalar( $properties, 'content' );
+
+		return self::wrap_h_entry( $card_markup, $body );
+	}
+
+	/**
+	 * Identify which post kind a property bag represents.
+	 *
+	 * Detection order matters — eat-of/drink-of takes precedence over
+	 * `location` because Eat/Drink posts may include both. The first match
+	 * wins.
+	 */
+	private static function detect_kind( array $properties ): ?string {
+		if ( self::has_property( $properties, 'eat-of' ) ) {
+			return 'eat';
+		}
+		if ( self::has_property( $properties, 'drink-of' ) ) {
+			return 'drink';
+		}
+		if ( self::has_property( $properties, 'listen-of' ) ) {
+			return 'listen';
+		}
+		if ( self::has_property( $properties, 'watch-of' ) ) {
+			return 'watch';
+		}
+		if ( self::has_property( $properties, 'read-of' ) ) {
+			return 'read';
+		}
+		if ( self::has_property( $properties, 'play-of' ) ) {
+			return 'play';
+		}
+		if ( self::has_property( $properties, 'rsvp' ) ) {
+			return 'rsvp';
+		}
+		if ( self::has_property( $properties, 'mood' ) ) {
+			return 'mood';
+		}
+		// Checkin = location property without one of the food/drink/media of-kinds.
+		if ( self::has_property( $properties, 'location' ) ) {
+			return 'checkin';
+		}
+		return null;
+	}
+
+	/**
+	 * Build the card block for a given post kind. Returns null if the
+	 * kind doesn't have a corresponding card block.
+	 */
+	private static function card_for_kind( string $kind, array $properties ): ?string {
+		switch ( $kind ) {
+			case 'checkin':
+				return self::checkin_card( $properties );
+			case 'eat':
+				return self::eat_card( $properties );
+			case 'drink':
+				return self::drink_card( $properties );
+			case 'listen':
+				return self::listen_card( $properties );
+			case 'watch':
+				return self::watch_card( $properties );
+			case 'read':
+				return self::read_card( $properties );
+			case 'play':
+				return self::play_card( $properties );
+			case 'rsvp':
+				return self::rsvp_card( $properties );
+			case 'mood':
+				return self::mood_card( $properties );
+		}
+		return null;
+	}
+
+	// --- Per-kind block builders -------------------------------------------
+
+	private static function checkin_card( array $properties ): string {
+		$attrs = self::filter_empty(
+			array(
+				'venueName' => self::flatten_scalar( $properties, 'mp-place-name' ),
+				'note'      => self::flatten_scalar( $properties, 'content' ),
+			)
+		);
+		$geo = self::parse_geo_from_location( $properties );
+		if ( null !== $geo ) {
+			$attrs['latitude']  = $geo['lat'];
+			$attrs['longitude'] = $geo['lon'];
+		}
+		return self::self_closing_block( 'post-kinds-indieweb/checkin-card', $attrs );
+	}
+
+	private static function eat_card( array $properties ): string {
+		$attrs = self::filter_empty(
+			array(
+				'name'         => self::flatten_scalar( $properties, 'eat-of' ),
+				'locationName' => self::flatten_scalar( $properties, 'mp-place-name' ),
+				'rating'       => self::flatten_numeric( $properties, 'rating' ),
+				'notes'        => self::flatten_scalar( $properties, 'content' ),
+			)
+		);
+		$geo = self::parse_geo_from_location( $properties );
+		if ( null !== $geo ) {
+			$attrs['geoLatitude']  = $geo['lat'];
+			$attrs['geoLongitude'] = $geo['lon'];
+		}
+		return self::self_closing_block( 'post-kinds-indieweb/eat-card', $attrs );
+	}
+
+	private static function drink_card( array $properties ): string {
+		$attrs = self::filter_empty(
+			array(
+				'name'         => self::flatten_scalar( $properties, 'drink-of' ),
+				'locationName' => self::flatten_scalar( $properties, 'mp-place-name' ),
+				'rating'       => self::flatten_numeric( $properties, 'rating' ),
+				'notes'        => self::flatten_scalar( $properties, 'content' ),
+			)
+		);
+		$geo = self::parse_geo_from_location( $properties );
+		if ( null !== $geo ) {
+			$attrs['geoLatitude']  = $geo['lat'];
+			$attrs['geoLongitude'] = $geo['lon'];
+		}
+		return self::self_closing_block( 'post-kinds-indieweb/drink-card', $attrs );
+	}
+
+	private static function listen_card( array $properties ): string {
+		$attrs = self::filter_empty(
+			array(
+				'listenUrl'  => self::flatten_scalar( $properties, 'listen-of' ),
+				'trackTitle' => self::flatten_scalar( $properties, 'name' ),
+				'artistName' => self::flatten_scalar( $properties, 'author' ),
+				'rating'     => self::flatten_numeric( $properties, 'rating' ),
+			)
+		);
+		return self::self_closing_block( 'post-kinds-indieweb/listen-card', $attrs );
+	}
+
+	private static function watch_card( array $properties ): string {
+		$attrs = self::filter_empty(
+			array(
+				'watchUrl'   => self::flatten_scalar( $properties, 'watch-of' ),
+				'mediaTitle' => self::flatten_scalar( $properties, 'name' ),
+				'director'   => self::flatten_scalar( $properties, 'author' ),
+				'rating'     => self::flatten_numeric( $properties, 'rating' ),
+				'review'     => self::flatten_scalar( $properties, 'content' ),
+			)
+		);
+		return self::self_closing_block( 'post-kinds-indieweb/watch-card', $attrs );
+	}
+
+	private static function read_card( array $properties ): string {
+		$attrs = self::filter_empty(
+			array(
+				'bookUrl'    => self::flatten_scalar( $properties, 'read-of' ),
+				'bookTitle'  => self::flatten_scalar( $properties, 'name' ),
+				'authorName' => self::flatten_scalar( $properties, 'author' ),
+				'readStatus' => self::flatten_scalar( $properties, 'read-status' ),
+				'rating'     => self::flatten_numeric( $properties, 'rating' ),
+				'review'     => self::flatten_scalar( $properties, 'content' ),
+			)
+		);
+		return self::self_closing_block( 'post-kinds-indieweb/read-card', $attrs );
+	}
+
+	private static function play_card( array $properties ): string {
+		// Play-card attributes mirror Listen/Watch's URL+name pattern.
+		$attrs = self::filter_empty(
+			array(
+				'playUrl'   => self::flatten_scalar( $properties, 'play-of' ),
+				'gameTitle' => self::flatten_scalar( $properties, 'name' ),
+				'rating'    => self::flatten_numeric( $properties, 'rating' ),
+			)
+		);
+		return self::self_closing_block( 'post-kinds-indieweb/play-card', $attrs );
+	}
+
+	private static function rsvp_card( array $properties ): string {
+		$attrs = self::filter_empty(
+			array(
+				'eventUrl' => self::flatten_scalar( $properties, 'in-reply-to' ),
+				'response' => self::flatten_scalar( $properties, 'rsvp' ),
+				'note'     => self::flatten_scalar( $properties, 'content' ),
+			)
+		);
+		return self::self_closing_block( 'post-kinds-indieweb/rsvp-card', $attrs );
+	}
+
+	private static function mood_card( array $properties ): string {
+		$attrs = self::filter_empty(
+			array(
+				'mood' => self::flatten_scalar( $properties, 'mood' ),
+				'note' => self::flatten_scalar( $properties, 'content' ),
+			)
+		);
+		return self::self_closing_block( 'post-kinds-indieweb/mood-card', $attrs );
+	}
+
+	// --- Block markup primitives -------------------------------------------
+
+	/**
+	 * Render a self-closing block-comment with JSON attributes.
+	 *
+	 * Output: `<!-- wp:namespace/name {"attr":"value"} /-->` or
+	 * `<!-- wp:namespace/name /-->` when attrs is empty.
+	 */
+	private static function self_closing_block( string $name, array $attrs ): string {
+		if ( empty( $attrs ) ) {
+			return '<!-- wp:' . $name . ' /-->';
+		}
+		$json = wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+		if ( false === $json ) {
+			return '<!-- wp:' . $name . ' /-->';
+		}
+		return '<!-- wp:' . $name . ' ' . $json . ' /-->';
+	}
+
+	/**
+	 * Wrap a card block + optional body content in an h-entry group so
+	 * microformats2 readers see one h-entry root per post and the typed
+	 * body lands inside `e-content`.
+	 */
+	private static function wrap_h_entry( string $card_markup, string $body ): string {
+		$paragraph = '';
+		if ( '' !== trim( $body ) ) {
+			$escaped   = wp_kses_post( $body );
+			$paragraph = "\n\t<!-- wp:group {\"className\":\"e-content\"} -->\n"
+				. "\t<div class=\"wp-block-group e-content\">\n"
+				. "\t\t<!-- wp:paragraph -->\n"
+				. "\t\t<p>" . $escaped . "</p>\n"
+				. "\t\t<!-- /wp:paragraph -->\n"
+				. "\t</div>\n"
+				. "\t<!-- /wp:group -->";
+		}
+
+		return "<!-- wp:group {\"className\":\"h-entry\",\"layout\":{\"type\":\"constrained\"}} -->\n"
+			. "<div class=\"wp-block-group h-entry\">\n"
+			. "\t" . $card_markup
+			. $paragraph
+			. "\n</div>\n"
+			. '<!-- /wp:group -->';
+	}
+
+	// --- Property helpers --------------------------------------------------
+
+	/**
+	 * Form-encoded Micropub repeats single-value properties as
+	 * arrays-of-one (`['content' => ['hello']]`); JSON Micropub uses arrays
+	 * for everything (`'content' => ['hello']`). Flatten to the first
+	 * scalar value, regardless of shape.
+	 */
+	private static function flatten_scalar( array $properties, string $key ): string {
+		if ( ! isset( $properties[ $key ] ) ) {
+			return '';
+		}
+		$value = $properties[ $key ];
+		if ( is_array( $value ) ) {
+			$value = reset( $value );
+		}
+		if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
+			return '';
+		}
+		return (string) $value;
+	}
+
+	/**
+	 * Like `flatten_scalar` but returns an int/float when the value parses
+	 * as numeric, or null. Used for `rating`, `latitude`, `longitude`.
+	 */
+	private static function flatten_numeric( array $properties, string $key ) {
+		$raw = self::flatten_scalar( $properties, $key );
+		if ( '' === $raw ) {
+			return null;
+		}
+		if ( ! is_numeric( $raw ) ) {
+			return null;
+		}
+		return false === strpos( $raw, '.' ) ? (int) $raw : (float) $raw;
+	}
+
+	/**
+	 * Whether the property bag has a non-empty value at $key.
+	 */
+	private static function has_property( array $properties, string $key ): bool {
+		if ( ! isset( $properties[ $key ] ) ) {
+			return false;
+		}
+		$value = $properties[ $key ];
+		if ( is_array( $value ) ) {
+			$value = reset( $value );
+		}
+		return null !== $value && '' !== $value;
+	}
+
+	/**
+	 * Parse `geo:lat,lon[,alt]` per RFC 5870 from the `location` property.
+	 * Returns ['lat' => float, 'lon' => float] or null when not parseable.
+	 */
+	private static function parse_geo_from_location( array $properties ): ?array {
+		$location = self::flatten_scalar( $properties, 'location' );
+		if ( '' === $location ) {
+			return null;
+		}
+		// Match `geo:lat,lon` and `geo:lat,lon,alt`. Reject anything else
+		// (URLs, h-card-shaped object dumps, etc. — not coordinates).
+		if ( 1 !== preg_match( '/^geo:(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)/', $location, $matches ) ) {
+			return null;
+		}
+		return array(
+			'lat' => (float) $matches[1],
+			'lon' => (float) $matches[2],
+		);
+	}
+
+	/**
+	 * Drop empty / null entries from an attributes array. block.json render
+	 * works better when only meaningful attributes are present.
+	 */
+	private static function filter_empty( array $attrs ): array {
+		return array_filter(
+			$attrs,
+			static fn( $value ): bool => null !== $value && '' !== $value && false !== $value
+		);
+	}
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -718,6 +718,13 @@ final class Plugin {
 		// Register block patterns.
 		add_action( 'init', [ $this, 'register_block_patterns' ] );
 
+		// Bridge: rewrite Micropub-created post_content to use card blocks.
+		// Hooks `after_micropub` priority 30 so any client (Outpost,
+		// Quill, etc.) can post a checkin/eat/listen/etc. h-entry and the
+		// front-end will render the corresponding card block instead of
+		// plain text. Idempotent — only writes the first time per post.
+		Micropub_Content_Builder::register();
+
 		// Register block templates for CPT and taxonomy archives.
 		add_filter( 'get_block_templates', [ $this, 'add_plugin_templates' ], 10, 3 );
 		add_filter( 'pre_get_block_file_template', [ $this, 'get_plugin_template' ], 10, 3 );

--- a/tests/phpunit/unit/MicropubContentBuilderTest.php
+++ b/tests/phpunit/unit/MicropubContentBuilderTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Tests for the Micropub_Content_Builder bridge.
+ *
+ * Exercises the per-kind block builders against representative h-entry
+ * property bags and confirms the output is the expected block markup.
+ * The private static methods are reached via Reflection — same pattern
+ * the rest of the plugin's PHPUnit tests use.
+ *
+ * @package PostKindsForIndieWeb
+ */
+
+namespace PostKindsForIndieWeb\Tests\Unit;
+
+use ReflectionMethod;
+use WP_UnitTestCase;
+use PostKindsForIndieWeb\Micropub_Content_Builder;
+
+/**
+ * @covers \PostKindsForIndieWeb\Micropub_Content_Builder
+ */
+class MicropubContentBuilderTest extends WP_UnitTestCase {
+
+	/**
+	 * Invoke a private static method on the builder by name.
+	 *
+	 * @param string                $method
+	 * @param array<int, mixed>     $args
+	 * @return mixed
+	 */
+	private function invoke_private( string $method, array $args = array() ) {
+		$ref = new ReflectionMethod( Micropub_Content_Builder::class, $method );
+		$ref->setAccessible( true );
+		return $ref->invoke( null, ...$args );
+	}
+
+	// --- detect_kind --------------------------------------------------------
+
+	public function test_detect_kind_eat_takes_precedence_over_location(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array(
+				array(
+					'eat-of'   => 'tacos al pastor',
+					'location' => 'geo:29.12,-103.24',
+				),
+			)
+		);
+		$this->assertSame( 'eat', $kind );
+	}
+
+	public function test_detect_kind_checkin_when_only_location(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'location' => 'geo:29.12,-103.24' ) )
+		);
+		$this->assertSame( 'checkin', $kind );
+	}
+
+	public function test_detect_kind_returns_null_for_plain_note(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'content' => 'just a note' ) )
+		);
+		$this->assertNull( $kind );
+	}
+
+	public function test_detect_kind_listen_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'listen-of' => 'https://example.test/track/123' ) )
+		);
+		$this->assertSame( 'listen', $kind );
+	}
+
+	public function test_detect_kind_mood_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'mood' => 'focused' ) )
+		);
+		$this->assertSame( 'mood', $kind );
+	}
+
+	// --- parse_geo_from_location -------------------------------------------
+
+	public function test_parse_geo_extracts_lat_lon(): void {
+		$result = $this->invoke_private(
+			'parse_geo_from_location',
+			array( array( 'location' => 'geo:29.12,-103.24' ) )
+		);
+		$this->assertEqualsWithDelta( 29.12, $result['lat'], 0.001 );
+		$this->assertEqualsWithDelta( -103.24, $result['lon'], 0.001 );
+	}
+
+	public function test_parse_geo_handles_altitude(): void {
+		$result = $this->invoke_private(
+			'parse_geo_from_location',
+			array( array( 'location' => 'geo:29.12,-103.24,1500' ) )
+		);
+		$this->assertEqualsWithDelta( 29.12, $result['lat'], 0.001 );
+	}
+
+	public function test_parse_geo_returns_null_for_url_location(): void {
+		$result = $this->invoke_private(
+			'parse_geo_from_location',
+			array( array( 'location' => 'https://example.test/place/' ) )
+		);
+		$this->assertNull( $result );
+	}
+
+	public function test_parse_geo_returns_null_for_missing_location(): void {
+		$result = $this->invoke_private(
+			'parse_geo_from_location',
+			array( array() )
+		);
+		$this->assertNull( $result );
+	}
+
+	// --- Per-kind card builders --------------------------------------------
+
+	public function test_checkin_card_includes_venue_and_geo(): void {
+		$markup = $this->invoke_private(
+			'checkin_card',
+			array(
+				array(
+					'mp-place-name' => 'St. Johns United Church of Christ',
+					'location'      => 'geo:39.93,-77.66',
+					'content'       => 'beautiful afternoon',
+				),
+			)
+		);
+		$this->assertStringContainsString( 'wp:post-kinds-indieweb/checkin-card', $markup );
+		$this->assertStringContainsString( '"venueName":"St. Johns United Church of Christ"', $markup );
+		$this->assertStringContainsString( '"latitude":39.93', $markup );
+		$this->assertStringContainsString( '"longitude":-77.66', $markup );
+		$this->assertStringContainsString( '"note":"beautiful afternoon"', $markup );
+	}
+
+	public function test_eat_card_routes_eat_of_to_name(): void {
+		$markup = $this->invoke_private(
+			'eat_card',
+			array(
+				array(
+					'eat-of'        => 'tacos al pastor',
+					'mp-place-name' => 'Tacos Don Cuco',
+					'rating'        => '4',
+				),
+			)
+		);
+		$this->assertStringContainsString( 'wp:post-kinds-indieweb/eat-card', $markup );
+		$this->assertStringContainsString( '"name":"tacos al pastor"', $markup );
+		$this->assertStringContainsString( '"locationName":"Tacos Don Cuco"', $markup );
+		$this->assertStringContainsString( '"rating":4', $markup );
+	}
+
+	public function test_read_card_includes_status_and_review(): void {
+		$markup = $this->invoke_private(
+			'read_card',
+			array(
+				array(
+					'read-of'     => 'https://openlibrary.org/works/OL45883W',
+					'name'        => 'The Phoenix Project',
+					'author'      => 'Gene Kim',
+					'read-status' => 'reading',
+					'rating'      => '5',
+					'content'     => 'Halfway through.',
+				),
+			)
+		);
+		$this->assertStringContainsString( '"bookTitle":"The Phoenix Project"', $markup );
+		$this->assertStringContainsString( '"authorName":"Gene Kim"', $markup );
+		$this->assertStringContainsString( '"readStatus":"reading"', $markup );
+		$this->assertStringContainsString( '"review":"Halfway through."', $markup );
+	}
+
+	public function test_self_closing_block_with_no_attrs(): void {
+		$markup = $this->invoke_private(
+			'self_closing_block',
+			array( 'post-kinds-indieweb/checkin-card', array() )
+		);
+		$this->assertSame( '<!-- wp:post-kinds-indieweb/checkin-card /-->', $markup );
+	}
+
+	// --- wrap_h_entry ------------------------------------------------------
+
+	public function test_wrap_h_entry_includes_e_content_when_body_present(): void {
+		$markup = $this->invoke_private(
+			'wrap_h_entry',
+			array( '<!-- wp:post-kinds-indieweb/checkin-card /-->', 'a sunny afternoon' )
+		);
+		$this->assertStringContainsString( 'class="wp-block-group h-entry"', $markup );
+		$this->assertStringContainsString( 'class="wp-block-group e-content"', $markup );
+		$this->assertStringContainsString( '<p>a sunny afternoon</p>', $markup );
+	}
+
+	public function test_wrap_h_entry_omits_paragraph_when_body_empty(): void {
+		$markup = $this->invoke_private(
+			'wrap_h_entry',
+			array( '<!-- wp:post-kinds-indieweb/checkin-card /-->', '' )
+		);
+		$this->assertStringContainsString( 'class="wp-block-group h-entry"', $markup );
+		$this->assertStringNotContainsString( 'e-content', $markup );
+	}
+
+	// --- end-to-end via apply() --------------------------------------------
+
+	public function test_apply_writes_block_content_for_checkin_post(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'plain text typed body',
+			)
+		);
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'             => 'entry',
+				'mp-place-name' => 'St. Johns',
+				'location'      => 'geo:39.93,-77.66',
+				'content'       => 'plain text typed body',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$content = (string) get_post_field( 'post_content', $post_id );
+		$this->assertStringContainsString( 'wp:post-kinds-indieweb/checkin-card', $content );
+		$this->assertStringContainsString( 'plain text typed body', $content );
+		$this->assertSame( '1', (string) get_post_meta( $post_id, '_pkiw_block_content_generated', true ) );
+	}
+
+	public function test_apply_idempotent_on_second_call(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'first body',
+			)
+		);
+
+		// First call writes block markup + sets the marker.
+		Micropub_Content_Builder::apply(
+			array(
+				'h'             => 'entry',
+				'mp-place-name' => 'Original Venue',
+				'location'      => 'geo:1,1',
+			),
+			array( 'ID' => $post_id )
+		);
+		$first = (string) get_post_field( 'post_content', $post_id );
+
+		// User then edits in Gutenberg (simulated by setting different content).
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => '<p>user edited this</p>',
+			)
+		);
+
+		// Second Micropub call (e.g., an update from the same client) must
+		// NOT clobber the user's edits.
+		Micropub_Content_Builder::apply(
+			array(
+				'h'             => 'entry',
+				'mp-place-name' => 'Different Venue',
+				'location'      => 'geo:99,99',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$second = (string) get_post_field( 'post_content', $post_id );
+		$this->assertSame( '<p>user edited this</p>', $second );
+		$this->assertNotSame( $first, $second );
+	}
+
+	public function test_apply_skips_for_plain_note(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'just a note, no card kind',
+			)
+		);
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'       => 'entry',
+				'content' => 'just a note, no card kind',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$content = (string) get_post_field( 'post_content', $post_id );
+		$this->assertSame( 'just a note, no card kind', $content );
+		$this->assertSame( '', (string) get_post_meta( $post_id, '_pkiw_block_content_generated', true ) );
+	}
+}


### PR DESCRIPTION
## What this does

Hooks `after_micropub` priority 30 and rewrites Micropub-created `post_content` from plain text into the registered card blocks when the incoming h-entry shape matches a recognized post kind.

```
Micropub client (Outpost / Quill / Indigenous)
   ↓  form-encoded h-entry
WP Micropub plugin creates wp_posts row, post_content = typed body (or empty)
   ↓                                                    ← THE GAP THIS CLOSES
Micropub_Content_Builder::apply()
   ↓
post_content rewritten to:
  <!-- wp:group {"className":"h-entry"} -->
  <div class="wp-block-group h-entry">
    <!-- wp:post-kinds-indieweb/checkin-card {"venueName":"...","latitude":...} /-->
    <!-- wp:group {"className":"e-content"} -->
      <p>typed body content</p>
    <!-- /wp:group -->
  </div>
  <!-- /wp:group -->
   ↓
Front-end renders the Checkin Card with map + venue + checkins
```

## Recognized post kinds

| h-entry shape | Generated card |
|---|---|
| `eat-of` (food name) | `eat-card` |
| `drink-of` | `drink-card` |
| `listen-of` (URL) | `listen-card` |
| `watch-of` (URL) | `watch-card` |
| `read-of` (URL) | `read-card` |
| `play-of` (URL) | `play-card` |
| `rsvp` (yes/no/maybe) | `rsvp-card` |
| `mood` | `mood-card` |
| `location` (without an of-kind) | `checkin-card` |
| Plain note (just `content`) | _no card — left as-is_ |

## Idempotent

`_pkiw_block_content_generated` post meta marker set on first generation. Subsequent Micropub updates (e.g., a client editing a post) leave (potentially user-edited) content alone. Users can clean up cards manually in Gutenberg without the bridge re-clobbering on the next sync.

## Outpost compatibility

Recognizes Outpost's `mp-place-name` extension property as the venue name attribute on Checkin / Eat / Drink cards. Outpost-made posts that have flowed through this plugin since the day it was installed will now render with cards instead of empty bodies — the most-frequent "missing body content" complaint.

## Tests

17 PHPUnit unit tests in `tests/phpunit/unit/MicropubContentBuilderTest.php`:

- `detect_kind` precedence (eat-of beats location, listen-of recognized, plain note returns null)
- `parse_geo_from_location` (basic / with altitude / non-geo URL / missing → null)
- Per-kind card builders verify the right attributes land in the right field names (e.g., Read's `read-status` → `readStatus`)
- `self_closing_block` no-attrs format
- `wrap_h_entry` includes/omits the e-content paragraph correctly
- End-to-end `apply()` writes block markup for a checkin and sets the marker meta
- `apply()` is idempotent on second call (user edits in between are preserved)
- `apply()` skips plain notes (post_content unchanged, no marker set)

## Test plan

- [ ] CI passes (PHPCS / PHPStan / PHPUnit / E2E).
- [ ] Merge → release a new plugin version → deploy to staging.
- [ ] From Outpost on phone, post a Checkin (Doing tab → Checkin → fill venue + body → Post).
- [ ] Visit the resulting post URL on the front-end. Should render the Checkin Card (map + venue + recent checkins) with body text below as `e-content`.
- [ ] Repeat for Eat, Drink, Listen, Watch, Read, Play, Mood, RSVP.
- [ ] Edit the post in Gutenberg. Click "Update". Run the same Micropub call again (e.g., re-sync). Confirm content is NOT re-overwritten.

## Out of scope

- The wider `post-kinds-indieweb/` vs `post-kinds-for-indieweb/` namespace inconsistency (the plugin slug is `post-kinds-for-indieweb` but blocks register under `post-kinds-indieweb`). This PR uses the existing `post-kinds-indieweb/` block names. A separate PR can standardize on the slug-matching namespace + provide a `block_type_metadata_settings` aliasing filter for legacy content. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)