### PR TITLE
Fix: single-post template hijack from taxonomy-venue injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Single posts no longer render the venue archive template.** `add_plugin_templates` was injecting `taxonomy-venue` into every `get_block_templates()` query result, including the hierarchy lookups that WordPress runs while resolving the single-post template (`slug__in => ['single-post', 'single', 'singular', 'index']`). When `singular` reached the resolver with no theme template registered for that slug, the plugin's `taxonomy-venue` template won the match and rendered for ordinary single posts — producing an empty `<main>` plus an unrelated query pagination block instead of the post body. The filter now respects `slug__in` and only injects when the requested slugs actually include `taxonomy-venue`. Adds four regression tests in `PluginTest.php`.
+
 ### Added
 
 - **Micropub-to-block content bridge** (`includes/class-micropub-content-builder.php`). Hooks `after_micropub` priority 30 and rewrites Micropub-created `post_content` from plain text to the registered card blocks (Checkin Card, Eat Card, Drink Card, Listen Card, Watch Card, Read Card, Play Card, RSVP Card, Mood Card) when the incoming h-entry shape matches a recognized post kind. Bridges any Micropub client (Outpost, Quill, Indigenous, etc.) to this plugin's block-editor cards without requiring the client to know about Gutenberg block markup.

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -989,9 +989,23 @@ final class Plugin {
 			return $query_result;
 		}
 
+		// Respect the slug filter when WordPress is resolving the block-template
+		// hierarchy (e.g. resolve_block_template('singular') queries with
+		// slug__in => ['singular']). Without this guard, the plugin's templates
+		// get appended to every hierarchy lookup and can win a match they were
+		// never meant to answer — which is exactly how taxonomy-venue ended up
+		// rendered for single posts.
+		$slug_filter = isset( $query['slug__in'] ) && is_array( $query['slug__in'] )
+			? $query['slug__in']
+			: null;
+
 		$template_definitions = $this->get_plugin_template_definitions();
 
 		foreach ( $template_definitions as $slug => $definition ) {
+			if ( null !== $slug_filter && ! in_array( $slug, $slug_filter, true ) ) {
+				continue;
+			}
+
 			// Check if template already exists in results.
 			$exists = false;
 			foreach ( $query_result as $template ) {

--- a/post-kinds-for-indieweb.php
+++ b/post-kinds-for-indieweb.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Requires at least: 6.9
  * Tested up to:      6.9
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'POST_KINDS_INDIEWEB_VERSION', '1.0.0' );
+define( 'POST_KINDS_INDIEWEB_VERSION', '1.0.1' );
 
 /**
  * Plugin directory path constant.

--- a/tests/phpunit/unit/PluginTest.php
+++ b/tests/phpunit/unit/PluginTest.php
@@ -32,7 +32,7 @@ class PluginTest extends WP_UnitTestCase {
 	 * Test that the plugin version is set.
 	 */
 	public function test_plugin_version() {
-		$this->assertEquals( '1.0.0', POST_KINDS_INDIEWEB_VERSION );
+		$this->assertEquals( '1.0.1', POST_KINDS_INDIEWEB_VERSION );
 	}
 
 	/**
@@ -47,5 +47,93 @@ class PluginTest extends WP_UnitTestCase {
 	 */
 	public function test_plugin_namespace() {
 		$this->assertTrue( class_exists( 'PostKindsForIndieWeb\Plugin' ) );
+	}
+
+	// --- add_plugin_templates: slug filter regression ---------------------
+
+	/**
+	 * Regression: when WP resolves the single-post block-template hierarchy,
+	 * it queries get_block_templates(['slug__in' => ['singular']]). The
+	 * filter MUST NOT inject taxonomy-venue into that result, or
+	 * resolve_block_template will return the venue template for ordinary
+	 * single posts and the post body never renders.
+	 */
+	public function test_add_plugin_templates_respects_slug_in_filter(): void {
+		$plugin = \PostKindsForIndieWeb\Plugin::get_instance();
+
+		$result = $plugin->add_plugin_templates(
+			array(),
+			array( 'slug__in' => array( 'singular' ) ),
+			'wp_template'
+		);
+
+		$slugs = array_map(
+			static fn( $tpl ) => $tpl->slug,
+			$result
+		);
+
+		$this->assertNotContains(
+			'taxonomy-venue',
+			$slugs,
+			'taxonomy-venue must not bleed into a slug__in => [singular] query.'
+		);
+	}
+
+	/**
+	 * Positive: when slug__in DOES contain taxonomy-venue, the template is
+	 * injected as expected.
+	 */
+	public function test_add_plugin_templates_injects_when_slug_requested(): void {
+		$plugin = \PostKindsForIndieWeb\Plugin::get_instance();
+
+		$result = $plugin->add_plugin_templates(
+			array(),
+			array( 'slug__in' => array( 'taxonomy-venue' ) ),
+			'wp_template'
+		);
+
+		$slugs = array_map(
+			static fn( $tpl ) => $tpl->slug,
+			$result
+		);
+
+		$this->assertContains( 'taxonomy-venue', $slugs );
+	}
+
+	/**
+	 * Positive: when no slug filter is provided (Site Editor list view),
+	 * the template is still injected.
+	 */
+	public function test_add_plugin_templates_injects_when_no_slug_filter(): void {
+		$plugin = \PostKindsForIndieWeb\Plugin::get_instance();
+
+		$result = $plugin->add_plugin_templates(
+			array(),
+			array(),
+			'wp_template'
+		);
+
+		$slugs = array_map(
+			static fn( $tpl ) => $tpl->slug,
+			$result
+		);
+
+		$this->assertContains( 'taxonomy-venue', $slugs );
+	}
+
+	/**
+	 * Negative: non-wp_template queries (e.g. wp_template_part) are passed
+	 * through untouched.
+	 */
+	public function test_add_plugin_templates_skips_non_wp_template_type(): void {
+		$plugin = \PostKindsForIndieWeb\Plugin::get_instance();
+
+		$result = $plugin->add_plugin_templates(
+			array(),
+			array(),
+			'wp_template_part'
+		);
+
+		$this->assertSame( array(), $result );
 	}
 }


### PR DESCRIPTION
## Summary

- `add_plugin_templates` was injecting `taxonomy-venue` into every `get_block_templates()` query result, ignoring `slug__in`. WordPress's `resolve_block_template()` walks the single-post hierarchy `[single-post, single, singular, index]` in one query, and when `singular` reached the resolver with no theme template for that slug, the plugin's injected `taxonomy-venue` template won the match.
- Front-end symptom: every single post on a site that activated the plugin rendered with an empty `<main>` plus an unrelated query-pagination block instead of the post body.
- Fix: honor `$query['slug__in']` before injecting. Bumps version to 1.0.1.

## Diagnosis

Confirmed live on staging:

```
=== Before fix ===
resolve(single):   courtneyr-child//single (custom)
resolve(singular): post-kinds-for-indieweb//taxonomy-venue (plugin)   ← bug
resolve(index):    courtneyr-child//index (theme)

=== After fix ===
resolve(single):   courtneyr-child//single (custom)
resolve(singular): NULL                                               ← correct
resolve(index):    courtneyr-child//index (theme)
```

## Test plan

- [ ] CI: `composer test` passes (4 new tests in `PluginTest.php`)
- [ ] CI: `composer lint` passes
- [ ] Manual: deploy to staging, hit any single post, confirm post body renders (`entry-content` present, no rogue `wp-block-query-pagination` in `<main>`)
- [ ] Manual: visit a venue taxonomy archive (e.g. `/venue/<slug>/`), confirm `taxonomy-venue` template still renders
- [ ] Manual: open Site Editor, confirm "Venue Archive" template still appears in the template list

## Regression tests added

- `test_add_plugin_templates_respects_slug_in_filter` — the actual bug repro
- `test_add_plugin_templates_injects_when_slug_requested`
- `test_add_plugin_templates_injects_when_no_slug_filter`
- `test_add_plugin_templates_skips_non_wp_template_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)