### PR TITLE
PHPCS: align prefix config with in-code 'post_kinds_indieweb' convention

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -135,12 +135,19 @@
 		</properties>
 	</rule>
 
-	<!-- Register allowed prefixes for globals, hooks, and options -->
+	<!-- Register allowed prefixes for globals, hooks, and options.
+		 The plugin uses two parallel snake_case conventions:
+		 - "post_kinds_for_indieweb" matches the slug + text domain.
+		 - "post_kinds_indieweb"     is the established convention for hooks
+		   and runtime constants (POST_KINDS_INDIEWEB_*, post_kinds_indieweb_*).
+		 Both are recognized to avoid forcing a breaking rename of hooks that
+		 may already have third-party listeners. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
 				<element value="pkiw"/>
 				<element value="post_kinds_for_indieweb"/>
+				<element value="post_kinds_indieweb"/>
 				<element value="PostKindsForIndieWeb"/>
 			</property>
 		</properties>


### PR DESCRIPTION
## Summary

The `.phpcs.xml.dist` allowed-prefix list was missing `post_kinds_indieweb`, which is the prefix the codebase actually uses for hooks (`apply_filters('post_kinds_indieweb_*', …)`) and runtime constants (`POST_KINDS_INDIEWEB_*`). Adding it eliminates the 5 `NonPrefixedHooknameFound` errors that have been failing CI since before #28.

## What changed

- One file: `.phpcs.xml.dist`. Adds `<element value="post_kinds_indieweb"/>` alongside the existing `pkiw`, `post_kinds_for_indieweb`, and `PostKindsForIndieWeb`.
- No code changes. Renaming the hooks would be a breaking change for any third-party listener; expanding the config is non-breaking.

## Errors removed

| line | hook |
|---|---|
| 540 | `post_kinds_indieweb_integrations_init` |
| 580 | `post_kinds_indieweb_checkin_sync_services` |
| 627 | `post_kinds_indieweb_listen_sync_services` |
| 674 | `post_kinds_indieweb_watch_sync_services` |
| 1421 | `post_kinds_indieweb_syndication_services` |

Local `vendor/bin/phpcs includes/class-plugin.php` now exits clean on this branch.

## Out of scope

`uninstall.php` has 4 `NonPrefixedVariableFound` errors (`$post_kinds_oauth_services`, `$post_kinds_service`, `$post_kinds_legacy_keys`, `$post_kinds_key`) that use an even shorter `post_kinds_` prefix. Those are real code issues — the variables should be renamed to `$pkiw_*` rather than further relaxing the config. Tracked for a follow-up PR; this one stays surgical.

## Test plan

- [ ] CI: PHP Coding Standards job passes (down from 5 errors → 0 errors in `class-plugin.php`)
- [ ] Spot-check: `vendor/bin/phpcs includes/class-plugin.php` exits 0 locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)