### PR TITLE
test(e2e): rewrite iframed-editor selectors with frameLocator

### DIFF
--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -18,7 +18,11 @@ test.describe( 'Accessibility', () => {
 	test( 'settings page should have no critical accessibility violations', async ( {
 		page,
 	} ) => {
-		await page.goto( '/wp-admin/admin.php?page=post-kinds-settings' );
+		// Plugin's actual settings slug is `post-kinds-for-indieweb`
+		// (the menu label is "Reactions"). The previous `post-kinds-settings`
+		// slug was a typo — would silently 404 and the a11y scan would run
+		// against a generic admin error page.
+		await page.goto( '/wp-admin/admin.php?page=post-kinds-for-indieweb' );
 
 		const accessibilityScanResults = await new AxeBuilder( { page } )
 			.withTags( [ 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa' ] )
@@ -33,44 +37,37 @@ test.describe( 'Accessibility', () => {
 		expect( criticalViolations ).toEqual( [] );
 	} );
 
-	// TODO: rewrite for iframed block editor.
-	//
-	// WP 6.5+ runs the block editor inside an `iframe[name="editor-canvas"]`.
-	// The locators below (`.block-editor-writing-flow`, `[data-type="..."]`)
-	// resolve inside the iframe and aren't visible to `page.waitForSelector`
-	// on the outer frame. Proper fix: wrap the in-editor selectors in
-	// `page.frameLocator('iframe[name="editor-canvas"]')`. axe-core scans
-	// also need to target the iframe's document. Skipping until that
-	// rework lands.
-	test.skip( 'block editor with blocks should be accessible', async ( {
+	test( 'block editor with blocks should be accessible', async ( {
 		page,
 	} ) => {
 		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForSelector( '.block-editor-writing-flow' );
 
-		// Insert a Listen Card block
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		// WP 6.5+ runs the editor inside `iframe[name="editor-canvas"]`.
+		// The inserter sidebar is on the OUTER frame; the writing flow
+		// and inserted blocks live INSIDE the iframe.
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Listen Card' );
+		// Inserter UI lives outside the iframe.
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Listen Card' );
+		await page.getByRole( 'option', { name: /Listen Card/ } ).click();
 
-		const listenCardBlock = page.getByRole( 'option', {
-			name: /Listen Card/,
-		} );
-		await listenCardBlock.click();
+		// Inserted block lives inside the iframe.
+		await editor
+			.locator( '[data-type="post-kinds-indieweb/listen-card"]' )
+			.waitFor( { timeout: 10000 } );
 
-		// Wait for block to be inserted
-		await page.waitForSelector(
-			'[data-type="post-kinds-indieweb/listen-card"]'
-		);
-
-		// Run accessibility scan on the editor area
+		// axe-core 4.7+ traverses iframes when given the frame selector
+		// in `include()` — the scanner descends into the canvas document
+		// and reports violations from inside.
 		const accessibilityScanResults = await new AxeBuilder( { page } )
 			.withTags( [ 'wcag2a', 'wcag2aa' ] )
-			.include( '.block-editor-writing-flow' )
+			.include( 'iframe[name="editor-canvas"]' )
 			.analyze();
 
 		const criticalViolations = accessibilityScanResults.violations.filter(
@@ -90,44 +87,40 @@ test.describe( 'Keyboard Navigation', () => {
 		await page.waitForURL( '**/wp-admin/**' );
 	} );
 
-	// TODO: rewrite for iframed block editor — see the matching skip on
-	// `block editor with blocks should be accessible` above for context.
-	test.skip( 'star rating is keyboard accessible', async ( { page } ) => {
+	test( 'star rating is keyboard accessible', async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForSelector( '.block-editor-writing-flow' );
 
-		// Insert Star Rating block
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Star Rating' );
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Star Rating' );
+		await page.getByRole( 'option', { name: /Star Rating/ } ).click();
 
-		const starRatingBlock = page.getByRole( 'option', {
-			name: /Star Rating/,
-		} );
-		await starRatingBlock.click();
+		await editor
+			.locator( '[data-type="post-kinds-indieweb/star-rating"]' )
+			.waitFor( { timeout: 10000 } );
 
-		// Wait for block
-		await page.waitForSelector(
-			'[data-type="post-kinds-indieweb/star-rating"]'
-		);
-
-		// Tab to the star rating and verify focus
+		// Tab through the editor to confirm focus reaches a focusable
+		// element. Two tabs is enough to leave the title field and land
+		// on either the inserter affordance or the block toolbar.
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 
-		// Verify focus is visible (basic check). The lint rule
-		// `@wordpress/no-global-active-element` is meant for product code
-		// inside Block Editor iframes; in a Playwright eval the page's
-		// own `document` is exactly what we want.
-		const focusedElement = await page.evaluate( () => {
+		// Active element across the iframe boundary: the outer page
+		// proxies focus into the iframe via `document.activeElement`,
+		// so reading from outer-frame `document` returns the iframe
+		// itself when focus is inside. Confirming it returns SOMETHING
+		// is enough for "keyboard navigation works."
+		const focusedTag = await page.evaluate( () => {
 			// eslint-disable-next-line @wordpress/no-global-active-element
-			return document.activeElement?.tagName;
+			return document.activeElement?.tagName ?? null;
 		} );
 
-		expect( focusedElement ).toBeTruthy();
+		expect( focusedTag ).toBeTruthy();
 	} );
 } );

--- a/tests/e2e/plugin-activation.spec.js
+++ b/tests/e2e/plugin-activation.spec.js
@@ -51,62 +51,43 @@ test.describe( 'Block Editor Integration', () => {
 		await page.waitForURL( '**/wp-admin/**' );
 	} );
 
-	// TODO: rewrite for iframed block editor (WP 6.5+).
-	// `.block-editor-writing-flow` and the inserted-block selectors live
-	// inside `iframe[name="editor-canvas"]` and aren't visible to outer-
-	// frame locators. Wrap in `page.frameLocator('iframe[name="editor-canvas"]')`
-	// when picking this up.
-	test.skip( 'post kind blocks are available in inserter', async ( {
-		page,
-	} ) => {
-		// Create a new post
+	test( 'post kind blocks are available in inserter', async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
 
-		// Wait for editor to load
-		await page.waitForSelector( '.block-editor-writing-flow' );
+		// Editor canvas lives inside `iframe[name="editor-canvas"]` since
+		// WP 6.5; the inserter sidebar stays on the outer frame.
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		// Open block inserter
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Listen Card' );
 
-		// Search for our blocks
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Listen Card' );
-
-		// Verify block appears
-		const listenCardBlock = page.getByRole( 'option', {
-			name: /Listen Card/,
-		} );
-		await expect( listenCardBlock ).toBeVisible();
+		await expect(
+			page.getByRole( 'option', { name: /Listen Card/ } )
+		).toBeVisible();
 	} );
 
-	// TODO: rewrite for iframed block editor — see the matching skip on
-	// `post kind blocks are available in inserter` above.
-	test.skip( 'can insert Listen Card block', async ( { page } ) => {
+	test( 'can insert Listen Card block', async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForSelector( '.block-editor-writing-flow' );
 
-		// Open inserter
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		// Search and insert
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Listen Card' );
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Listen Card' );
+		await page.getByRole( 'option', { name: /Listen Card/ } ).click();
 
-		const listenCardBlock = page.getByRole( 'option', {
-			name: /Listen Card/,
-		} );
-		await listenCardBlock.click();
-
-		// Verify block is inserted
-		const block = page.locator(
-			'[data-type="post-kinds-indieweb/listen-card"]'
-		);
-		await expect( block ).toBeVisible();
+		// Inserted block lives inside the canvas.
+		await expect(
+			editor.locator( '[data-type="post-kinds-indieweb/listen-card"]' )
+		).toBeVisible();
 	} );
 } );

--- a/tests/e2e/visual-regression.spec.js
+++ b/tests/e2e/visual-regression.spec.js
@@ -1,23 +1,26 @@
 /**
- * Visual regression tests for block appearance
+ * Visual regression tests for block appearance.
  *
- * These tests capture screenshots of blocks and compare against baselines.
- * Run `npm run test:visual` to update snapshots.
+ * These tests capture screenshots of blocks and compare against committed
+ * baselines. Run `npm run test:visual` to update snapshots.
  *
- * Skipped in CI for now — two reasons:
+ * **Skipped in CI by default** — visual regression suites need three things
+ * before they're useful as a PR gate, and we don't have all three yet:
  *
- * 1. The block-editor tests use `.block-editor-writing-flow` selectors
- *    that live inside `iframe[name="editor-canvas"]` (WP 6.5+ iframed
- *    the editor). These need a `page.frameLocator()` rewrite to work
- *    against a current WordPress.
- * 2. The settings-page snapshot test has no committed baseline; without
- *    one, the first CI run can't compare anything. Visual regression
- *    suites typically need baselines generated via
- *    `npm run test:visual` and committed before they can gate PRs.
+ * 1. Committed baseline images. Without them, the first CI run can't
+ *    compare anything. Generate via `npm run test:visual` (which uses
+ *    `--update-snapshots`), then commit the `*-snapshots/` directories.
+ * 2. Cross-environment font rendering parity. CI's headless Chromium and a
+ *    local Mac headed Chromium produce slightly different antialiased
+ *    glyphs even at the same resolution. The `maxDiffPixelRatio: 0.05`
+ *    setting absorbs typical drift but won't survive font-stack changes.
+ * 3. A stable theme. The default `wp-env` theme can shift between WP
+ *    versions; visual baselines need to be regenerated whenever the
+ *    underlying theme paint changes.
  *
- * To re-enable: rewrite the selectors with frameLocator, generate
- * baselines with `npm run test:visual`, and commit the
- * `*-snapshots/` directories.
+ * The tests themselves are correctly written for the iframed editor
+ * (WP 6.5+'s `iframe[name="editor-canvas"]`). Drop the `.skip` on the
+ * describe blocks once baselines are committed.
  */
 
 const { test, expect } = require( '@playwright/test' );
@@ -34,29 +37,23 @@ test.describe.skip( 'Visual Regression', () => {
 
 	test( 'Listen Card block appearance', async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForSelector( '.block-editor-writing-flow' );
 
-		// Insert Listen Card
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Listen Card' );
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Listen Card' );
+		await page.getByRole( 'option', { name: /Listen Card/ } ).click();
 
-		const listenCardBlock = page.getByRole( 'option', {
-			name: /Listen Card/,
-		} );
-		await listenCardBlock.click();
-
-		// Wait for block to render
-		const block = page.locator(
+		const block = editor.locator(
 			'[data-type="post-kinds-indieweb/listen-card"]'
 		);
 		await expect( block ).toBeVisible();
 
-		// Take screenshot of the block
 		await expect( block ).toHaveScreenshot( 'listen-card-default.png', {
 			maxDiffPixelRatio: 0.05,
 		} );
@@ -64,22 +61,19 @@ test.describe.skip( 'Visual Regression', () => {
 
 	test( 'Watch Card block appearance', async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForSelector( '.block-editor-writing-flow' );
 
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Watch Card' );
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Watch Card' );
+		await page.getByRole( 'option', { name: /Watch Card/ } ).click();
 
-		const watchCardBlock = page.getByRole( 'option', {
-			name: /Watch Card/,
-		} );
-		await watchCardBlock.click();
-
-		const block = page.locator(
+		const block = editor.locator(
 			'[data-type="post-kinds-indieweb/watch-card"]'
 		);
 		await expect( block ).toBeVisible();
@@ -91,22 +85,19 @@ test.describe.skip( 'Visual Regression', () => {
 
 	test( 'Read Card block appearance', async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForSelector( '.block-editor-writing-flow' );
 
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Read Card' );
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Read Card' );
+		await page.getByRole( 'option', { name: /Read Card/ } ).click();
 
-		const readCardBlock = page.getByRole( 'option', {
-			name: /Read Card/,
-		} );
-		await readCardBlock.click();
-
-		const block = page.locator(
+		const block = editor.locator(
 			'[data-type="post-kinds-indieweb/read-card"]'
 		);
 		await expect( block ).toBeVisible();
@@ -118,22 +109,19 @@ test.describe.skip( 'Visual Regression', () => {
 
 	test( 'Star Rating block appearance', async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForSelector( '.block-editor-writing-flow' );
 
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Star Rating' );
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Star Rating' );
+		await page.getByRole( 'option', { name: /Star Rating/ } ).click();
 
-		const starRatingBlock = page.getByRole( 'option', {
-			name: /Star Rating/,
-		} );
-		await starRatingBlock.click();
-
-		const block = page.locator(
+		const block = editor.locator(
 			'[data-type="post-kinds-indieweb/star-rating"]'
 		);
 		await expect( block ).toBeVisible();
@@ -144,12 +132,11 @@ test.describe.skip( 'Visual Regression', () => {
 	} );
 
 	test( 'Settings page appearance', async ( { page } ) => {
-		await page.goto( '/wp-admin/admin.php?page=post-kinds-settings' );
-
-		// Wait for page to fully load
+		// Plugin's main admin slug is `post-kinds-for-indieweb` (the menu
+		// label is "Reactions"). Settings page chrome is what we snapshot.
+		await page.goto( '/wp-admin/admin.php?page=post-kinds-for-indieweb' );
 		await page.waitForLoadState( 'networkidle' );
 
-		// Take screenshot of main content area (excluding admin bar)
 		const content = page.locator( '#wpcontent' );
 		await expect( content ).toHaveScreenshot( 'settings-page.png', {
 			maxDiffPixelRatio: 0.05,
@@ -171,22 +158,19 @@ test.describe.skip( 'Dark Mode Visual Regression', () => {
 
 	test( 'Listen Card in dark mode', async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForSelector( '.block-editor-writing-flow' );
 
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
-		} );
-		await inserterButton.click();
+		const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		await editor
+			.locator( '.block-editor-writing-flow' )
+			.waitFor( { timeout: 30000 } );
 
-		const searchInput = page.getByPlaceholder( 'Search' );
-		await searchInput.fill( 'Listen Card' );
+		await page
+			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.click();
+		await page.getByPlaceholder( 'Search' ).fill( 'Listen Card' );
+		await page.getByRole( 'option', { name: /Listen Card/ } ).click();
 
-		const listenCardBlock = page.getByRole( 'option', {
-			name: /Listen Card/,
-		} );
-		await listenCardBlock.click();
-
-		const block = page.locator(
+		const block = editor.locator(
 			'[data-type="post-kinds-indieweb/listen-card"]'
 		);
 		await expect( block ).toBeVisible();


### PR DESCRIPTION
## Summary

Closes the iframed-editor E2E debt tracked in PR #31. WP 6.5+ runs the block editor inside `iframe[name="editor-canvas"]`; selectors against `.block-editor-writing-flow` and `[data-type="…"]` need `page.frameLocator()` scoping. The inserter sidebar stays on the outer frame.

## What changes

**Re-enabled (4 tests):**
- `accessibility.spec.js`: `block editor with blocks should be accessible` — axe-core scan via `.include('iframe[name="editor-canvas"]')` traverses into the canvas document.
- `accessibility.spec.js`: `star rating is keyboard accessible`
- `plugin-activation.spec.js`: `post kind blocks are available in inserter`
- `plugin-activation.spec.js`: `can insert Listen Card block`

**Still skipped (6 tests):** the `visual-regression.spec.js` suite. iframe selectors fixed there too, but two blockers remain before it can gate PRs:

1. No committed baseline images. First CI run can't compare. Generate via `npm run test:visual` and commit the `*-snapshots/` dirs.
2. Cross-environment font rendering. CI's headless Chromium ≠ local Mac headed Chromium for antialiased glyphs; `maxDiffPixelRatio: 0.05` absorbs typical drift but not font-stack changes.

The skip is on the `test.describe.skip` blocks; drop them once baselines + rendering parity are sorted.

## Bonus fix

Also fixed an unrelated typo in `accessibility.spec.js` — the settings-page test was navigating to `?page=post-kinds-settings` which silently 404s. Actual slug is `post-kinds-for-indieweb`. The visual-regression settings-page test had the same typo (fixed in this PR). plugin-activation had the right slug from PR #31.

## Recipe (documented in concepts/iframed-editor-tests.md in the wiki)

```javascript
const editor = page.frameLocator( 'iframe[name="editor-canvas"]' );

// Wait for editor (canvas-side):
await editor.locator( '.block-editor-writing-flow' ).waitFor();

// Inserter UI (outer frame):
await page.getByRole( 'button', { name: 'Toggle block inserter' } ).click();
await page.getByPlaceholder( 'Search' ).fill( 'Listen Card' );
await page.getByRole( 'option', { name: /Listen Card/ } ).click();

// Inserted block (inside iframe):
await editor.locator( '[data-type="..."]' ).waitFor();
```

## Test plan

- [ ] CI: Accessibility Tests passes (was passing on the 2 settings-page tests; now also runs the 2 editor tests)
- [ ] CI: E2E Tests passes (was passing on plugin-menu test; now also runs the 2 inserter tests)
- [ ] Visual Regression Tests stay skipped (no baselines yet); the suite is green-by-skip in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)