### PR TITLE
Fix duplicate images in Micropub photo galleries (v1.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Photo gallery posts no longer render the same images twice.** The Micropub-to-block bridge's `photo_card()` now deduplicates the `$input['photo']` array before emitting `core/image` blocks. The upstream Micropub plugin (David Shanske's `wordpress-micropub`) enriches `$input['photo']` post-sideload with a 2× version of the original array — when an Outpost gallery uploads 3 images and posts them as `photo[]=url1&...`, the array arriving at `after_micropub` priority 30 has 6 entries (originals + canonical URLs, both resolving to the same local URL on a single-server install) while `mp-photo-alt[]` still has only 3. Without dedupe, a 3-photo gallery rendered 6 image blocks: the first 3 with matching alts, the last 3 with empty alts. Dedupe is by URL, first occurrence wins (which is also the occurrence with its aligned alt text). 3 new PHPUnit tests in `MicropubContentBuilderTest.php` cover the staging-reproduced symptom (6→3 dedupe), the alt-alignment ("first occurrence keeps alt"), and the single-image collapse (3 identical URLs collapse to 1 image, gallery wrapper drops away).
+
 ### Added
 
 - **Photo / gallery handling in the Micropub-to-block content bridge.** Photo posts (Micropub `photo` property without one of the specific of-kinds like `eat-of`, `watch-of`) now emit a `core/image` block (single photo) or a `core/gallery` wrapper (multi-photo) inside the same `h-entry` envelope as the other card kinds. Each `core/image` block resolves the photo URL back to its attached media ID via `attachment_url_to_postid()` so the block carries the canonical reference + `class="wp-image-{id}"` for srcset rendering. Alt text comes from the parallel `mp-photo-alt[]` array. Single-photo posts skip the gallery wrapper for a cleaner shape; multi-photo posts get `core/gallery` with `linkTo: none`. The user's typed body text still appears as `e-content` alongside the gallery.

--- a/includes/class-micropub-content-builder.php
+++ b/includes/class-micropub-content-builder.php
@@ -427,20 +427,41 @@ final class Micropub_Content_Builder {
 			return '';
 		}
 
-		$image_blocks = [];
+		// Deduplicate photo URLs while preserving alt-text alignment.
+		// The upstream Micropub plugin (David Shanske's `wordpress-micropub`)
+		// enriches `$input['photo']` post-sideload — when an Outpost
+		// gallery uploads 3 images and posts them as `photo[]=url1&...`,
+		// the plugin's processing produces a 6-entry array (the original
+		// URLs alongside the attached / canonical URLs, which on a
+		// single-server install resolve to the SAME local URL). Without
+		// dedupe, a 3-photo gallery rendered 6 image blocks: the first
+		// 3 with matching alts, the last 3 with empty alts because the
+		// `mp-photo-alt[]` array still had only 3 entries.
+		//
+		// Dedupe by URL — first occurrence wins (the occurrence that
+		// also has its aligned alt-text entry).
+		$seen         = [];
+		$unique_urls  = [];
+		$aligned_alts = [];
 		foreach ( $photo_urls as $i => $url ) {
-			if ( '' === $url ) {
+			if ( '' === $url || isset( $seen[ $url ] ) ) {
 				continue;
 			}
+			$seen[ $url ]   = true;
+			$unique_urls[]  = $url;
+			$aligned_alts[] = isset( $alt_texts[ $i ] ) ? $alt_texts[ $i ] : '';
+		}
+		if ( empty( $unique_urls ) ) {
+			return '';
+		}
+
+		$image_blocks = [];
+		foreach ( $unique_urls as $i => $url ) {
 			$attachment_id  = function_exists( 'attachment_url_to_postid' )
 				? (int) attachment_url_to_postid( $url )
 				: 0;
-			$alt            = isset( $alt_texts[ $i ] ) ? $alt_texts[ $i ] : '';
+			$alt            = $aligned_alts[ $i ];
 			$image_blocks[] = self::image_block( $attachment_id, $url, $alt );
-		}
-
-		if ( empty( $image_blocks ) ) {
-			return '';
 		}
 
 		// Single-photo posts skip the gallery wrapper for a cleaner shape.

--- a/post-kinds-for-indieweb.php
+++ b/post-kinds-for-indieweb.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.0.2
+ * Version:           1.0.3
  * Requires at least: 6.9
  * Tested up to:      6.9
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'POST_KINDS_INDIEWEB_VERSION', '1.0.2' );
+define( 'POST_KINDS_INDIEWEB_VERSION', '1.0.3' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/phpunit/unit/MicropubContentBuilderTest.php
+++ b/tests/phpunit/unit/MicropubContentBuilderTest.php
@@ -535,4 +535,75 @@ class MicropubContentBuilderTest extends WP_UnitTestCase {
 		);
 		$this->assertSame( array( 'first', '', 'third' ), $out );
 	}
+
+	// --- photo_card dedupe (issue: Shanske Micropub plugin enriches `$input['photo']` post-sideload) ---
+
+	public function test_photo_card_dedupes_repeated_urls(): void {
+		// Reproduces the staging symptom: 3 unique photos arriving as a
+		// 6-entry photo array (originals + canonical URLs collapsed to
+		// the same local URL) with mp-photo-alt only carrying the first
+		// 3 alts. Bridge must produce 3 image blocks total, NOT 6.
+		$markup = $this->invoke_private(
+			'photo_card',
+			array(
+				array(
+					'photo'        => array(
+						'https://example.test/uploads/cat-1.jpg',
+						'https://example.test/uploads/cat-2.jpg',
+						'https://example.test/uploads/cat-3.jpg',
+						'https://example.test/uploads/cat-1.jpg',
+						'https://example.test/uploads/cat-2.jpg',
+						'https://example.test/uploads/cat-3.jpg',
+					),
+					'mp-photo-alt' => array( 'Fire', 'Tux', 'Rain' ),
+				),
+			)
+		);
+		$this->assertSame( 3, substr_count( $markup, '<!-- wp:image' ) );
+		$this->assertStringContainsString( 'alt="Fire"', $markup );
+		$this->assertStringContainsString( 'alt="Tux"', $markup );
+		$this->assertStringContainsString( 'alt="Rain"', $markup );
+		$this->assertStringNotContainsString( 'alt=""', $markup );
+	}
+
+	public function test_photo_card_first_occurrence_keeps_alt(): void {
+		// When a URL appears twice and only the first occurrence has a
+		// matching alt, the kept-image carries that alt — confirms the
+		// "first occurrence wins" rule applies to the alt alignment too.
+		$markup = $this->invoke_private(
+			'photo_card',
+			array(
+				array(
+					'photo'        => array(
+						'https://example.test/uploads/cat.jpg',
+						'https://example.test/uploads/cat.jpg',
+					),
+					'mp-photo-alt' => array( 'a cat', '' ),
+				),
+			)
+		);
+		$this->assertSame( 1, substr_count( $markup, '<!-- wp:image' ) );
+		$this->assertStringContainsString( 'alt="a cat"', $markup );
+	}
+
+	public function test_photo_card_dedupe_collapses_to_single_image(): void {
+		// Three identical URLs collapse to one image block — and since
+		// the deduped count is 1, the gallery wrapper drops away too.
+		$markup = $this->invoke_private(
+			'photo_card',
+			array(
+				array(
+					'photo'        => array(
+						'https://example.test/uploads/single.jpg',
+						'https://example.test/uploads/single.jpg',
+						'https://example.test/uploads/single.jpg',
+					),
+					'mp-photo-alt' => array( 'one', 'two', 'three' ),
+				),
+			)
+		);
+		$this->assertSame( 1, substr_count( $markup, '<!-- wp:image' ) );
+		$this->assertStringNotContainsString( '<!-- wp:gallery', $markup );
+		$this->assertStringContainsString( 'alt="one"', $markup );
+	}
 }

--- a/tests/phpunit/unit/PluginTest.php
+++ b/tests/phpunit/unit/PluginTest.php
@@ -32,7 +32,7 @@ class PluginTest extends WP_UnitTestCase {
 	 * Test that the plugin version is set.
 	 */
 	public function test_plugin_version() {
-		$this->assertEquals( '1.0.2', POST_KINDS_INDIEWEB_VERSION );
+		$this->assertEquals( '1.0.3', POST_KINDS_INDIEWEB_VERSION );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

PR #36's `photo_card` iterates `\$input['photo']` without dedup. The upstream Micropub plugin (David Shanske's `wordpress-micropub`) enriches `\$input['photo']` post-sideload — a 3-photo gallery posted by Outpost arrives at \`after_micropub\` priority 30 with a 6-entry array (originals + canonical URLs, both resolving to the same local URL), while \`mp-photo-alt[]\` still has 3 entries. Result: 6 image blocks rendered, first 3 with matching alts, last 3 with empty alts.

**Reproduced on staging today** with two test posts:
- \`/2026/05/05/gallery/\` — 3 photos uploaded, 6 image blocks in post_content (Fire/Tux/Rain alt-text + 3 alt="" duplicates)
- \`/2026/05/05/night/\` — 2 photos uploaded, 4 image blocks in post_content (Fire/Rain + 2 alt="" duplicates)

## Fix

Dedupe \`\$photo_urls\` by URL before emitting blocks. First occurrence wins (which is also the occurrence with its aligned alt-text entry). Single-photo posts where the doubled array collapses to 1 unique URL drop the gallery wrapper too — a single \`core/image\` block results, consistent with the existing single-photo path.

3 new PHPUnit tests:
- \`test_photo_card_dedupes_repeated_urls\`: 6 doubled URLs + 3 alts → 3 image blocks, all alts preserved, no \`alt=""\`
- \`test_photo_card_first_occurrence_keeps_alt\`: 2 URLs where only first has alt → 1 image block carries that alt
- \`test_photo_card_dedupe_collapses_to_single_image\`: 3 identical URLs → 1 image block, no gallery wrapper

## Why the upstream plugin doubles the array

The Shanske Micropub plugin processes \`photo[]\` URLs by calling \`media_handle_sideload\`/\`media_sideload_url\` per URL and then setting the resulting attachment's URL on \`\$input['photo']\` for downstream hooks. On a single-server install, the original URL Outpost sent and the post-sideload URL collapse to the same local URL — but the array has both entries side by side, producing the doubling. PR #36 didn't anticipate this because the staging post that exposed the photo-bridge gap had been observed BEFORE the bridge ran with photo content; the doubling only appeared in posts created AFTER the bridge was active.

## Companion fix

[outpost @ next commit](https://github.com/courtneyr-dev/outpost) — same dedupe applied to \`Outpost_Micropub_Bridges::infer_post_format()\` so a single-photo post with doubled \`\$input['photo']\` doesn't misclassify as \`post_format=gallery\`.

## Bumps

- \`Version: 1.0.2\` → \`1.0.3\` (plugin header)
- \`POST_KINDS_INDIEWEB_VERSION = '1.0.2'\` → \`'1.0.3'\` (constant)
- \`readme.txt\` Stable tag → \`1.0.3\`
- \`PluginTest::test_plugin_version\` → \`1.0.3\`

## Test plan

- [ ] CI passes (PHPUnit + PHPCS + PHPStan)
- [ ] Merge → bump staging-courtneyr-dev submodule pin → deploy
- [ ] Publish a fresh 3-photo gallery via Outpost → confirm 3 images render (not 6)
- [ ] Publish a fresh single-photo post → confirm 1 image, no gallery wrapper
- [ ] Existing posts with the doubled gallery (cats, gallery, night) need manual edit in WP admin Block Editor to remove the duplicate blocks (idempotency marker prevents auto-regenerate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)