### PR TITLE
fix(blocks): accept nullable $position in Format_Badge hooked_blocks filter (v1.0.4)

### DIFF
--- a/includes/blocks/class-format-badge.php
+++ b/includes/blocks/class-format-badge.php
@@ -128,11 +128,11 @@ final class Format_Badge {
 	 *
 	 * @param string[]                      $hooked_blocks List of hooked block types.
 	 * @param string                        $relative_to   Block type being hooked relative to.
-	 * @param string                        $position      Hook position (before/after/first_child/last_child).
+	 * @param string|null                   $position      Hook position (before/after/first_child/last_child). Null when no anchor block context is present (e.g. theme.json + pattern resolution paths) — WordPress core passes null here, so a non-nullable typehint causes a site-wide PHP fatal on every request that registers blocks.
 	 * @param array|\WP_Block_Template|null $context Block template, pattern, or null.
 	 * @return string[] Modified list of hooked block types.
 	 */
-	public function filter_hooked_blocks( array $hooked_blocks, string $relative_to, string $position, $context ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public function filter_hooked_blocks( array $hooked_blocks, string $relative_to, ?string $position, $context ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( 'core/post-title' !== $relative_to || 'before' !== $position ) {
 			return $hooked_blocks;
 		}

--- a/post-kinds-for-indieweb.php
+++ b/post-kinds-for-indieweb.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.0.3
+ * Version:           1.0.4
  * Requires at least: 6.9
  * Tested up to:      6.9
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'POST_KINDS_INDIEWEB_VERSION', '1.0.3' );
+define( 'POST_KINDS_INDIEWEB_VERSION', '1.0.4' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -175,6 +175,9 @@ Visit [pin13.net/mf2](https://pin13.net/mf2/) and enter your post URL. The tool 
 7. Block inserter showing all post kind blocks
 
 == Changelog ==
+
+= 1.0.4 =
+* Fix site-wide PHP fatal when active alongside block themes that resolve hooked blocks during init (e.g. Ollie). `Format_Badge::filter_hooked_blocks()` now accepts a nullable `$position` parameter, matching WordPress core's `hooked_block_types` filter signature.
 
 = 1.0.0 =
 * Initial release


### PR DESCRIPTION
## Summary

- Fixes site-wide WSOD that fires whenever this plugin is active alongside any block theme that resolves hooked blocks during `init` (Ollie is the load-bearing case on courtneyr.dev — Ollie 2.5.x's `unregister_ollie_woocommerce_patterns()` walks `WP_Block_Patterns_Registry::get_all_registered()` on every `init`, surfacing the typehint mismatch on every request including wp-admin).
- One-character signature change in `Format_Badge::filter_hooked_blocks()`: `string $position` → `?string $position`.
- Matches the actual WordPress core filter contract — `hooked_block_types` passes `null` for "anywhere" hooked-block positions, which is valid per the filter spec.
- Bumps version 1.0.3 → 1.0.4 (plugin header, `POST_KINDS_INDIEWEB_VERSION` constant, readme stable tag, changelog entry).

## Root cause

WP core's `hooked_block_types` filter signature is `(array $hooked_block_types, string $relative_position, ?string $anchor_block_name, array|WP_Block_Template|WP_Post $context)` — but in practice the position argument can be `null` when hooked blocks are registered without a positional anchor (insertion happens "anywhere"). Strict typehints on filter callbacks in WP are a well-known PHP 8 footgun. The safe pattern is no typehint, or `?string`.

Surfaced on staging on 2026-05-20 and live on 2026-05-21 — same fatal, same stack trace, identical `Format_Badge` call site. Workaround until merge was `wp plugin deactivate post-kinds-for-indieweb`.

## Test plan

- [ ] Run `composer lint` (PHPCS) — pre-commit hook already ran clean
- [ ] Run `composer analyze` (PHPStan level 6) — should pass; one-character signature change with no semantic impact
- [ ] Run `composer test` (PHPUnit unit tests) — no regressions expected
- [ ] Manual: activate plugin on a staging site running Ollie, navigate to wp-admin/index.php → no WSOD, no PHP fatal in error log
- [ ] Manual: navigate to post editor for an existing post → editor loads, no fatal
- [ ] Follow-up: add a regression test asserting `Format_Badge::filter_hooked_blocks()` accepts `null` for `$position` without raising `TypeError`

## Follow-ups (not blocking this PR)

- Audit all other filter callbacks in the plugin for strict typehints on args that WP core may pass as null. `git grep "add_filter\|apply_filters"` to enumerate.
- Backfill missing changelog entries for 1.0.2 and 1.0.3 — neither version got an entry when shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)