### PR TITLE
fix(ci): green up main — version test, Tested up to 7.0, security perms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,9 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: courane01
 Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 6.9
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 8.2
 Stable tag: 1.0.4
 License: GPLv2 or later

--- a/tests/phpunit/unit/PluginTest.php
+++ b/tests/phpunit/unit/PluginTest.php
@@ -29,10 +29,20 @@ class PluginTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the plugin version is set.
+	 * Test that the plugin version constant matches the plugin header.
+	 *
+	 * Reads the Version from the main plugin file rather than hard-coding it,
+	 * so a version bump can never silently drift the constant out of sync.
 	 */
 	public function test_plugin_version() {
-		$this->assertEquals( '1.0.3', POST_KINDS_INDIEWEB_VERSION );
+		$plugin_file = dirname( __DIR__, 3 ) . '/post-kinds-for-indieweb.php';
+		$data        = get_file_data( $plugin_file, array( 'Version' => 'Version' ) );
+		$this->assertNotEmpty( $data['Version'], 'Plugin header is missing a Version.' );
+		$this->assertSame(
+			$data['Version'],
+			POST_KINDS_INDIEWEB_VERSION,
+			'POST_KINDS_INDIEWEB_VERSION must match the Version in the plugin header.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## What this fixes

main CI had **four** independent failures (root-caused via /investigate). This PR fixes three of them; the fourth (E2E/a11y) is tracked separately because it has never passed and needs a running editor to fix+verify.

| # | Job | Root cause | Fix |
|---|---|---|---|
| A | PHP Tests (all 5 legs) | `PluginTest::test_plugin_version` hard-coded `1.0.3`; #39 bumped to `1.0.4` and left the test stale (1026 tests, 1 failure) | Read `Version` from the plugin header via `get_file_data` and compare to `POST_KINDS_INDIEWEB_VERSION` — drift-proof |
| C | WordPress Plugin Check | `readme.txt` said `Tested up to: 6.9`; WordPress 7.0 shipped | Bump to `7.0` |
| D | Security Scan | SARIF upload failed `Resource not accessible by integration` | Add `security-events: write` to the Security Scan job |

## Not in this PR (tracked separately)

- **B — E2E Tests + Accessibility Tests.** Real failures: a genuine axe violation on the settings page, plus block-editor E2E tests timing out at ~30s (iframed editor under WP 7.0). These have **never been green on main**, so this is first-time-green work, not a regression. Needs a local wp-env/Playwright run to reproduce, fix, and verify.

## Context

`main` CI has never had a fully-green run (`gh run list --status success` on main returns empty). This is the long-standing "subset of checks gate merges, the rest stay red" pattern. After this PR, the recommendation is to require only the green-able checks in branch protection and keep E2E/a11y running as informational until B is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)