### PR TITLE
ci: auto-merge Dependabot patch/minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+# Enables auto-merge on Dependabot PRs for low-risk updates (patch + minor,
+# including GitHub Actions and dev dependencies). Auto-merge only completes
+# once the required status checks on main pass, so nothing red ever lands.
+# Major version bumps are left for manual review.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch and minor updates
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that enables auto-merge on Dependabot PRs for patch + minor updates (including GitHub Actions and dev dependencies). Auto-merge only completes once the required status checks pass (set via branch protection in #43's wake), so a red PR never lands. Major version bumps are left for manual review.

Completes the Dependabot unblock: `allow_auto_merge` is on, branch protection gates on the green checks, and this makes patch/minor flow hands-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)