### PR TITLE
fix(ci): initialize wp-env for WordPress Plugin Check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,27 @@ jobs:
           unzip -q post-kinds-for-indieweb.zip -d dist-check
           ls -la dist-check/post-kinds-for-indieweb
 
+      # plugin-check-action generates a .wp-env.json that installs plugin-check
+      # from a URL zip. @wordpress/env <= 11.8.0 extracts URL-downloaded zips
+      # with extract-zip, which silently exits 0 without booting Docker on
+      # Node 24.16+ (runner images since ubuntu24/20260525.161), so the action
+      # later dies with "Environment not initialized. Run 'wp-env start' first."
+      # Pre-download plugin-check with curl/unzip (unaffected by the bug) and
+      # point wp-env at the local copy via .wp-env.override.json, which the
+      # action leaves untouched and wp-env merges over the generated config
+      # (the override's `plugins` array replaces the URL entry).
+      # See https://github.com/WordPress/plugin-check-action/issues/579 and
+      # https://github.com/WordPress/gutenberg/issues/78762 (fix ships in
+      # @wordpress/env 11.9 / Gutenberg 23.4). Remove this step once
+      # plugin-check-action works on current runner images again.
+      - name: Work around wp-env zip-extraction hang (plugin-check-action#579)
+        run: |
+          curl -fsSL https://downloads.wordpress.org/plugin/plugin-check.zip -o "$RUNNER_TEMP/plugin-check.zip"
+          unzip -q "$RUNNER_TEMP/plugin-check.zip" -d "$RUNNER_TEMP/plugin-check-src"
+          test -f "$RUNNER_TEMP/plugin-check-src/plugin-check/cli.php"
+          printf '{ "plugins": [ "%s" ] }\n' "$RUNNER_TEMP/plugin-check-src/plugin-check" > .wp-env.override.json
+          cat .wp-env.override.json
+
       - name: Run Plugin Check against distribution
         uses: wordpress/plugin-check-action@v1
         with:


### PR DESCRIPTION
## Root cause

The "WordPress Plugin Check" job has failed on main for weeks with:

```
✖ Environment not initialized. Run `wp-env start` first.
```

This isn't caused by anything in this repo. The chain:

1. `wordpress/plugin-check-action@v1` generates a `.wp-env.json` whose `plugins` array installs Plugin Check from a URL source: `https://downloads.wordpress.org/plugin/plugin-check.zip`.
2. `@wordpress/env` (≤ 11.8.0, and the action always installs the latest) extracts URL-downloaded zips with `extract-zip@1.x` (`yauzl`/`fd-slicer`). On Node 24.16.0 / libuv 1.52.1 that extraction path makes the wp-env process **silently exit 0 before booting Docker** — WordPress/gutenberg#78762.
3. Node 24.16.0 arrived in the GitHub runner image tool cache with `ubuntu24/20260525.161`; the action's internal `setup-node` (`node-version: '24'`) picks it up. That's why the job broke with no repo changes — confirmed in run 27226563907, where `wp-env start --update` "completed after 1 attempt(s)" in 33s without starting anything, and the very next `wp-env run cli wp cli info` failed.
4. The `WP_ENV_JSON_EXISTS: false` in the step env is a red herring: it only records that the dist build dir contains no `.wp-env.json` (expected — `.distignore` excludes it) and merely controls result filtering.

Upstream status: WordPress/plugin-check-action#579 is open with no fixed release; the wp-env fix (extract-zip → adm-zip, WordPress/gutenberg PR 78828) is milestoned Gutenberg 23.4 / `@wordpress/env` 11.9 and not yet published. Pinning the action can't help because every version installs the latest wp-env at runtime.

## Fix

Add one step before the action: download `plugin-check.zip` with curl, unzip it (both unaffected by the Node bug), and write a `.wp-env.override.json` pointing wp-env's `plugins` at the local copy. The action never touches the override file, and wp-env merges it over the generated config — the override's `plugins` array *replaces* the URL entry (verified in `packages/env/lib/config/merge-configs.js`), while the action's `mappings` for the plugin under test survive. The local dir's basename (`plugin-check`) mounts at `wp-content/plugins/plugin-check`, so the action's `--require=./wp-content/plugins/plugin-check/cli.php` and activation work unchanged.

This keeps the upstream action in place and is removable once plugin-check-action or `@wordpress/env` 11.9 ships a fix (noted in the workflow comment). One future-compat note: if the action later switches to installing plugin-check via `wp plugin install`, the mounted local copy could conflict — remove this step at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)