### PR TITLE
Fix Plugin Check errors: require WP 7.0, sync headers, split CLI guard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,7 +60,7 @@ Fixes #
 
 ### Compatibility
 
-- [ ] Works with WordPress 6.9+
+- [ ] Works with WordPress 7.0+
 - [ ] Works with PHP 8.2+
 - [ ] Works with and without IndieBlocks
 - [ ] Breaking changes documented (if any)

--- a/.github/QA-CHECKLIST.md
+++ b/.github/QA-CHECKLIST.md
@@ -65,7 +65,7 @@ Use this checklist before each release of Post Kinds for IndieWeb.
 
 ### WordPress Versions
 
-- [ ] WordPress 6.9 (minimum supported)
+- [ ] WordPress 7.0 (minimum supported)
 
 ### PHP Versions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ["8.2", "8.3", "8.4"]
-        wp: ["6.9"]
+        wp: ["7.0"]
         include:
           - php: "8.4"
             wp: "trunk"
@@ -140,7 +140,7 @@ jobs:
         run: composer test
 
       - name: Upload coverage to Codecov
-        if: matrix.php == '8.4' && matrix.wp == '6.9'
+        if: matrix.php == '8.4' && matrix.wp == '7.0'
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage/clover.xml

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
-	"core": "WordPress/WordPress#6.9",
+	"core": "WordPress/WordPress#7.0",
 	"phpVersion": "8.2",
 	"plugins": [
 		"."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **WordPress 7.0 is now the minimum supported version** (previously 6.9). The AI enhancement layer calls `wp_ai_client_prompt()`, which only ships in WP 7.0+, and declaring 6.9 support alongside that call tripped Plugin Check's `wp_function_not_compatible_with_requires_wp` error. Rather than suppress the check, the support floor moves to 7.0: `Requires at least` (readme.txt + plugin header), the `POST_KINDS_INDIEWEB_MIN_WP` activation guard, the wp-env core pin, the CI test matrix, and the docs now all say 7.0. The plugin header's `Tested up to` also catches up with readme.txt at 7.0 (bumped there in #43).
+
 ### Fixed
 
+- **Plugin Check compliance.** `includes/class-cli-commands.php` now uses a standalone `ABSPATH` guard (the combined ABSPATH + WP_CLI guard was behavior-identical, but the `missing_direct_file_access_protection` sniff only recognizes a standalone check), and the `uninstall.php` variables use the full `post_kinds_for_indieweb_` prefix so `WordPress.NamingConventions.PrefixAllGlobals` stops warning.
 - **Photo gallery posts no longer render the same images twice.** The Micropub-to-block bridge's `photo_card()` now deduplicates the `$input['photo']` array before emitting `core/image` blocks. The upstream Micropub plugin (David Shanske's `wordpress-micropub`) enriches `$input['photo']` post-sideload with a 2× version of the original array — when an Outpost gallery uploads 3 images and posts them as `photo[]=url1&...`, the array arriving at `after_micropub` priority 30 has 6 entries (originals + canonical URLs, both resolving to the same local URL on a single-server install) while `mp-photo-alt[]` still has only 3. Without dedupe, a 3-photo gallery rendered 6 image blocks: the first 3 with matching alts, the last 3 with empty alts. Dedupe is by URL, first occurrence wins (which is also the occurrence with its aligned alt text). 3 new PHPUnit tests in `MicropubContentBuilderTest.php` cover the staging-reproduced symptom (6→3 dedupe), the alt-alignment ("first occurrence keeps alt"), and the single-image collapse (3 identical URLs collapse to 1 image, gallery wrapper drops away).
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - **Slug:** post-kinds-for-indieweb
 - **Text Domain:** post-kinds-for-indieweb
 - **Prefix:** pk\_
-- **Min WP:** 6.9 | **Min PHP:** 8.2
+- **Min WP:** 7.0 | **Min PHP:** 8.2
 - **Repo:** https://github.com/courtneyr-dev/post-kinds-for-indieweb
 
 ## What It Does

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This project follows the [WordPress Community Code of Conduct](https://make.word
 - PHP 8.2+
 - Node.js 18+
 - Composer 2.x
-- WordPress 6.9+ (local dev environment)
+- WordPress 7.0+ (local dev environment)
 - Git
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Post Kinds for IndieWeb
 
-[![WordPress 6.9+](https://img.shields.io/badge/WordPress-6.9%2B-21759b.svg?logo=wordpress&logoColor=white)](https://wordpress.org/)
+[![WordPress 7.0+](https://img.shields.io/badge/WordPress-7.0%2B-21759b.svg?logo=wordpress&logoColor=white)](https://wordpress.org/)
 [![PHP 8.2+](https://img.shields.io/badge/PHP-8.2%2B-777BB4.svg?logo=php&logoColor=white)](https://php.net/)
 [![License: GPL v2+](https://img.shields.io/badge/License-GPL%20v2%2B-blue.svg)](LICENSE)
 [![IndieWeb](https://img.shields.io/badge/IndieWeb-compatible-FF5C00.svg)](https://indieweb.org/)
@@ -83,7 +83,7 @@ Validate your output at [pin13.net/mf2](https://pin13.net/mf2/).
 
 ## Requirements
 
-- WordPress 6.9 or higher
+- WordPress 7.0 or higher
 - PHP 8.2 or higher
 
 ## Quick Start

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@ Thanks for using Post Kinds for IndieWeb! Here's how to get help.
 
 Try these steps first — they resolve most issues:
 
-1. **Check requirements** — WordPress 6.9+, PHP 8.2+, plugin activated
+1. **Check requirements** — WordPress 7.0+, PHP 8.2+, plugin activated
 2. **Clear caches** — browser cache, caching plugins, server-side caches
 3. **Test for conflicts** — switch to Twenty Twenty-Five, deactivate other plugins, check if the issue persists
 4. **Check error logs** — enable `WP_DEBUG` in wp-config.php, check `debug.log` and browser console

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,7 +28,7 @@ This document provides comprehensive testing directions for the Post Kinds for I
 
 | Component | Minimum | Recommended |
 | --------- | ------- | ----------- |
-| WordPress | 6.9     | 6.9+        |
+| WordPress | 7.0     | 7.0+        |
 | PHP       | 8.2     | 8.4+        |
 | MySQL     | 5.7     | 8.0+        |
 | Node.js   | 18      | 20+         |

--- a/includes/class-cli-commands.php
+++ b/includes/class-cli-commands.php
@@ -12,8 +12,13 @@ declare(strict_types=1);
 
 namespace PostKindsForIndieWeb;
 
-// Prevent direct access and only load if WP-CLI is active.
-if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Only load if WP-CLI is active.
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
 

--- a/post-kinds-for-indieweb.php
+++ b/post-kinds-for-indieweb.php
@@ -15,8 +15,8 @@
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
  * Version:           1.0.4
- * Requires at least: 6.9
- * Tested up to:      6.9
+ * Requires at least: 7.0
+ * Tested up to:      7.0
  * Requires PHP:      8.2
  * Author:            Courtney Robertson
  * Author URI:        https://courtneyr.dev
@@ -89,7 +89,7 @@ define( 'POST_KINDS_INDIEWEB_MIN_PHP', '8.2' );
  *
  * @var string
  */
-define( 'POST_KINDS_INDIEWEB_MIN_WP', '6.9' );
+define( 'POST_KINDS_INDIEWEB_MIN_WP', '7.0' );
 
 /**
  * Check PHP version requirement.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Post Kinds for IndieWeb ===
 Contributors: courane01
 Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
-Requires at least: 6.9
+Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 8.2
 Stable tag: 1.0.4

--- a/stubs/companion-classes.php
+++ b/stubs/companion-classes.php
@@ -92,7 +92,7 @@ namespace {
 		define( 'POST_KINDS_INDIEWEB_MIN_PHP', '8.2' );
 	}
 	if ( ! defined( 'POST_KINDS_INDIEWEB_MIN_WP' ) ) {
-		define( 'POST_KINDS_INDIEWEB_MIN_WP', '6.9' );
+		define( 'POST_KINDS_INDIEWEB_MIN_WP', '7.0' );
 	}
 
 	// 3. WP_CLI static API. Only the methods this plugin actually calls.

--- a/uninstall.php
+++ b/uninstall.php
@@ -29,15 +29,15 @@ delete_option( 'post_kinds_indieweb_pending_scrobbles' );
 delete_option( 'post_kinds_indieweb_owntracks_last_location' );
 
 // OAuth tokens for each service.
-$pkiw_oauth_services = [ 'trakt', 'simkl', 'foursquare', 'untappd' ];
-foreach ( $pkiw_oauth_services as $pkiw_service ) {
-	delete_option( 'post_kinds_indieweb_' . $pkiw_service . '_access_token' );
-	delete_option( 'post_kinds_indieweb_' . $pkiw_service . '_refresh_token' );
-	delete_option( 'post_kinds_indieweb_' . $pkiw_service . '_token_expires' );
+$post_kinds_for_indieweb_oauth_services = [ 'trakt', 'simkl', 'foursquare', 'untappd' ];
+foreach ( $post_kinds_for_indieweb_oauth_services as $post_kinds_for_indieweb_service ) {
+	delete_option( 'post_kinds_indieweb_' . $post_kinds_for_indieweb_service . '_access_token' );
+	delete_option( 'post_kinds_indieweb_' . $post_kinds_for_indieweb_service . '_refresh_token' );
+	delete_option( 'post_kinds_indieweb_' . $post_kinds_for_indieweb_service . '_token_expires' );
 }
 
 // Legacy individual API key options.
-$pkiw_legacy_keys = [
+$post_kinds_for_indieweb_legacy_keys = [
 	'tmdb_api_key',
 	'trakt_client_id',
 	'trakt_client_secret',
@@ -52,8 +52,8 @@ $pkiw_legacy_keys = [
 	'podcastindex_api_secret',
 	'google_books_api_key',
 ];
-foreach ( $pkiw_legacy_keys as $pkiw_key ) {
-	delete_option( 'post_kinds_indieweb_' . $pkiw_key );
+foreach ( $post_kinds_for_indieweb_legacy_keys as $post_kinds_for_indieweb_key ) {
+	delete_option( 'post_kinds_indieweb_' . $post_kinds_for_indieweb_key );
 }
 
 // Clean up transients.


### PR DESCRIPTION
Resolves the 3 Plugin Check errors that accumulated on `main` while the "WordPress Plugin Check" job was broken (job fixed in #46; findings in [this comment](https://github.com/courtneyr-dev/post-kinds-for-indieweb/pull/46#issuecomment-4665270385)).

## The three errors

### 1. `mismatched_tested_up_to_header`
readme.txt said "Tested up to: 7.0" (bumped in #43) while the plugin header still said 6.9. The header now says **7.0** to match.

### 2. `missing_direct_file_access_protection` (includes/class-cli-commands.php)
The combined `if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) { return; }` guard is behavior-identical to what the sniff wants, but the sniff only recognizes a standalone ABSPATH check. Split into a standalone `ABSPATH` guard that exits, followed by the `WP_CLI` guard that returns.

### 3. `wp_function_not_compatible_with_requires_wp` (includes/class-ai-enhancements.php:383)
`wp_ai_client_prompt()` requires WP 7.0 while the plugin declared "Requires at least: 6.9". The call is `function_exists()`-gated so it was runtime-safe, but Plugin Check does no flow analysis. **Per Courtney's decision: the plugin now requires WordPress 7.0** rather than suppressing the check (which would have masked future ungated 7.0+ calls).

## What the 7.0 requirement touched

Raising the floor is more than the two declaration lines, because WordPress core itself enforces the "Requires at least" header at activation (since 5.5) — a 6.9 test environment would refuse to activate the plugin and break the e2e/integration jobs:

- `Requires at least: 7.0` in readme.txt and the plugin header
- `POST_KINDS_INDIEWEB_MIN_WP` activation/init guard → `7.0` (+ its PHPStan stub mirror)
- `.wp-env.json` core pin `WordPress/WordPress#6.9` → `#7.0` (tag verified on the mirror) — used by the e2e and accessibility jobs
- CI PHP-test matrix `wp: ["6.9"]` → `["7.0"]`, and the Codecov upload condition that referenced `6.9` (the PHP 8.4 + trunk job already covered ≥ 7.0)
- Docs: README badge + requirements, CONTRIBUTING, SUPPORT, TESTING, QA checklist, PR template, CLAUDE.md, CHANGELOG

## Also included

The 4 non-fatal `PrefixAllGlobals` warnings in `uninstall.php`: the `$pkiw_*` variables now use the full `post_kinds_for_indieweb_` prefix. Both prefixes are allowed by `.phpcs.xml.dist`, but Plugin Check derives its accepted prefix from the plugin slug, so the long form satisfies both linters (verified with a local PHPCS run).

## Verification

- `php -l`, PHPCS (`WordPress-Extra` ruleset), and PHPStan (level 6) pass locally on the changed files
- Items 1, 2, and the uninstall.php fix land in the dist zip that the Plugin Check job builds via `npm run plugin-zip`; the readme/header changes resolve items 1 and 3
- Watching this PR's CI run to confirm the "WordPress Plugin Check" job goes green

https://claude.ai/code/session_016T2iNrRhiEWKwYvwR92TbP

---
_Generated by [Claude Code](https://claude.ai/code/session_016T2iNrRhiEWKwYvwR92TbP)_