### PR TITLE
ci: fix intermittent wp-env activation race (micropub/indieauth)

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,9 +3,7 @@
 	"core": "WordPress/WordPress#7.0",
 	"phpVersion": "8.2",
 	"plugins": [
-		".",
-		"https://downloads.wordpress.org/plugin/indieauth.latest-stable.zip",
-		"https://downloads.wordpress.org/plugin/micropub.latest-stable.zip"
+		"."
 	],
 	"themes": [],
 	"config": {
@@ -19,6 +17,6 @@
 		"wp-content/mu-plugins": "./tests/env"
 	},
 	"lifecycleScripts": {
-		"afterStart": "wp-env run cli wp rewrite structure '/%postname%/' --hard"
+		"afterStart": "wp-env run cli wp rewrite structure '/%postname%/' --hard && (wp-env run cli wp plugin install indieauth micropub || true) && wp-env run cli wp plugin activate indieauth micropub"
 	}
 }


### PR DESCRIPTION
wp-env activates the plugins array in parallel — dependency order in the array is an illusion. Micropub's Requires Plugins check fails whenever it beats IndieAuth, killing wp-env start in CI (intermittent: #56 passed, #57 and the main push run failed). Move the pair to sequential install+activate in afterStart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)