### PR TITLE
Fix Micropub posts always landing as kind=note

### DIFF
--- a/includes/class-micropub-content-builder.php
+++ b/includes/class-micropub-content-builder.php
@@ -118,6 +118,11 @@ final class Micropub_Content_Builder {
 			return;
 		}
 
+		// Assign the kind taxonomy term before touching content — some kinds
+		// (like/reply/repost/bookmark) have terms but no card builder, so the
+		// content path below returns early for them.
+		self::assign_kind_term( $post_id, $properties );
+
 		$block_content = self::build_block_content( $properties );
 		if ( null === $block_content ) {
 			// Post kind didn't match any of the recognized shapes — leave the
@@ -137,6 +142,66 @@ final class Micropub_Content_Builder {
 				'post_content' => $block_content,
 			]
 		);
+	}
+
+	/**
+	 * Assign the detected kind's taxonomy term to the post.
+	 *
+	 * The `kind` taxonomy registers `note` as its default_term, so WP core
+	 * gives every Micropub-created post kind=note — the bridge knows the
+	 * real kind but never wrote it, leaving posts with the wrong badge and
+	 * in the wrong kind archives. `wp_set_post_terms` (via set_post_kind)
+	 * replaces the default cleanly.
+	 *
+	 * Kinds without a registered term (follow, weather) are skipped and
+	 * keep the core default; if a site later creates those terms the
+	 * assignment picks them up automatically.
+	 *
+	 * @param int                  $post_id    Post ID created by Micropub.
+	 * @param array<string, mixed> $properties h-entry properties bag.
+	 * @return void
+	 */
+	private static function assign_kind_term( int $post_id, array $properties ): void {
+		$kind = self::detect_kind( $properties ) ?? self::detect_term_only_kind( $properties );
+		if ( null === $kind ) {
+			return;
+		}
+
+		$taxonomy = Plugin::get_instance()->get_taxonomy();
+		if ( null === $taxonomy || ! $taxonomy->is_valid_kind( $kind ) ) {
+			return;
+		}
+
+		$taxonomy->set_post_kind( $post_id, $kind );
+	}
+
+	/**
+	 * Detect kinds that have taxonomy terms but no card builder.
+	 *
+	 * The detect_kind() pass only recognizes shapes the content builder can
+	 * render into card blocks. Like/reply/repost/bookmark posts arrive with
+	 * standard mf2 properties and have real kind terms, but no card —
+	 * without this fallback they'd stay on the `note` default. Inferring
+	 * `reply` from `in-reply-to` is safe here because detect_kind() has
+	 * already returned null, so no `rsvp` property is present.
+	 *
+	 * @param array<string, mixed> $properties h-entry properties bag.
+	 * @return string|null Kind slug or null when nothing matches.
+	 */
+	private static function detect_term_only_kind( array $properties ): ?string {
+		if ( self::has_property( $properties, 'like-of' ) ) {
+			return 'like';
+		}
+		if ( self::has_property( $properties, 'repost-of' ) ) {
+			return 'repost';
+		}
+		if ( self::has_property( $properties, 'bookmark-of' ) ) {
+			return 'bookmark';
+		}
+		if ( self::has_property( $properties, 'in-reply-to' ) ) {
+			return 'reply';
+		}
+		return null;
 	}
 
 	/**

--- a/tests/e2e/micropub-kinds.spec.js
+++ b/tests/e2e/micropub-kinds.spec.js
@@ -11,6 +11,12 @@
  * Also covers issue #38: a checkin carrying a `photo` property must
  * include a core/image block, not just the checkin card.
  *
+ * Also asserts the `kind` taxonomy term on every created post: the
+ * taxonomy registers `note` as its default_term, so before the bridge
+ * assigned terms every Micropub post landed as kind=note regardless of
+ * its actual kind (wrong badge, wrong kind archive). Builder-only kinds
+ * without terms (follow/weather) intentionally keep the note default.
+ *
  * Requires: wp-env with micropub + indieauth active (see .wp-env.json),
  * the tests/env/pkiw-test-auth.php fixture (grants Micropub scope to
  * application-password requests), and WP_APP_PASSWORD in the env.
@@ -57,7 +63,7 @@ test.describe( 'Micropub kind creation', () => {
 	 * POST a form-encoded h-entry and assert a real post was created.
 	 *
 	 * @param {Record<string, string>} form Form fields (h=entry added).
-	 * @return {Promise<{id: number, content: string}>} Created post id + raw content.
+	 * @return {Promise<{id: number, content: string, kinds: string[]}>} Created post id, raw content, and kind term slugs.
 	 */
 	async function createAndFetch( form ) {
 		const res = await api.post( ENDPOINT, {
@@ -110,42 +116,60 @@ test.describe( 'Micropub kind creation', () => {
 		);
 		expect( post.ok(), 'created post must be queryable' ).toBeTruthy();
 		const body = await post.json();
-		return { id, content: body.content.raw };
+
+		const terms = await api.get(
+			`${ BASE }/?rest_route=/wp/v2/kind&post=${ id }`
+		);
+		expect( terms.ok(), 'kind terms must be queryable' ).toBeTruthy();
+		const kinds = ( await terms.json() ).map( ( term ) => term.slug );
+
+		return { id, content: body.content.raw, kinds };
 	}
 
 	test( 'contentless eat-of creates a post with an eat card', async () => {
-		const { content } = await createAndFetch( { 'eat-of': 'Flat white' } );
+		const { content, kinds } = await createAndFetch( {
+			'eat-of': 'Flat white',
+		} );
 		expect( content ).toContain( '<!-- wp:post-kinds-indieweb/eat-card' );
+		expect( kinds ).toEqual( [ 'eat' ] );
 	} );
 
 	test( 'contentless drink-of creates a post with a drink card', async () => {
-		const { content } = await createAndFetch( { 'drink-of': 'Oat latte' } );
+		const { content, kinds } = await createAndFetch( {
+			'drink-of': 'Oat latte',
+		} );
 		expect( content ).toContain( '<!-- wp:post-kinds-indieweb/drink-card' );
+		expect( kinds ).toEqual( [ 'drink' ] );
 	} );
 
 	test( 'contentless follow-of creates a post with a u-follow-of link', async () => {
-		const { content } = await createAndFetch( {
+		const { content, kinds } = await createAndFetch( {
 			'follow-of': 'https://example.com/author',
 		} );
 		expect( content ).toContain( 'u-follow-of' );
 		expect( content ).toContain( 'https://example.com/author' );
+		// No `follow` term exists — builder-only kinds keep the note default.
+		expect( kinds ).toEqual( [ 'note' ] );
 	} );
 
 	test( 'contentless weather creates a post with a p-weather reading', async () => {
-		const { content } = await createAndFetch( {
+		const { content, kinds } = await createAndFetch( {
 			weather: 'Sunny, 28C, light breeze',
 		} );
 		expect( content ).toContain( 'p-weather' );
 		expect( content ).toContain( 'Sunny, 28C, light breeze' );
+		// No `weather` term exists — builder-only kinds keep the note default.
+		expect( kinds ).toEqual( [ 'note' ] );
 	} );
 
 	test( 'eat-of with content still creates and keeps the body', async () => {
-		const { content } = await createAndFetch( {
+		const { content, kinds } = await createAndFetch( {
 			'eat-of': 'Croissant',
 			content: 'Buttery perfection',
 		} );
 		expect( content ).toContain( '<!-- wp:post-kinds-indieweb/eat-card' );
 		expect( content ).toContain( 'Buttery perfection' );
+		expect( kinds ).toEqual( [ 'eat' ] );
 	} );
 
 	test( 'checkin with a photo includes a core/image block (#38)', async () => {
@@ -157,7 +181,7 @@ test.describe( 'Micropub kind creation', () => {
 		const photoHost =
 			process.env.PKIW_TEST_PHOTO_HOST ||
 			'http://host.docker.internal:8890';
-		const { content } = await createAndFetch( {
+		const { content, kinds } = await createAndFetch( {
 			location: 'geo:52.37,4.89',
 			'mp-place-name': 'Cafe Test',
 			photo: `${ photoHost }/wp-content/uploads/pkiw-test-photo.jpg`,
@@ -166,5 +190,81 @@ test.describe( 'Micropub kind creation', () => {
 			'<!-- wp:post-kinds-indieweb/checkin-card'
 		);
 		expect( content ).toContain( '<!-- wp:image' );
+		expect( kinds ).toEqual( [ 'checkin' ] );
 	} );
+
+	// Kind term assignment across the remaining kinds. The first group has
+	// card builders; the second (like/reply/repost/bookmark) has kind terms
+	// but no card — the term must be assigned even though post_content is
+	// left as the Micropub plugin generated it.
+	const kindMatrix = [
+		{
+			kind: 'listen',
+			form: {
+				'listen-of': 'https://example.test/track/123',
+				name: 'Test Track',
+			},
+		},
+		{
+			kind: 'watch',
+			form: {
+				'watch-of': 'https://example.test/film/456',
+				name: 'Test Film',
+			},
+		},
+		{
+			kind: 'read',
+			form: {
+				'read-of': 'https://example.test/book/789',
+				name: 'Test Book',
+			},
+		},
+		{
+			kind: 'play',
+			form: {
+				'play-of': 'https://example.test/game/101',
+				name: 'Test Game',
+			},
+		},
+		{
+			kind: 'rsvp',
+			form: { rsvp: 'yes', 'in-reply-to': 'https://example.test/event' },
+		},
+		{ kind: 'mood', form: { mood: 'joyful' } },
+		{
+			kind: 'like',
+			form: {
+				'like-of': 'https://example.test/great-post',
+				content: 'So good',
+			},
+		},
+		{
+			kind: 'reply',
+			form: {
+				'in-reply-to': 'https://example.test/a-post',
+				content: 'Agreed!',
+			},
+		},
+		{
+			kind: 'repost',
+			form: {
+				'repost-of': 'https://example.test/a-post',
+				content: 'Reposting this',
+			},
+		},
+		{
+			kind: 'bookmark',
+			form: {
+				'bookmark-of': 'https://example.test/a-post',
+				content: 'Saving for later',
+			},
+		},
+	];
+
+	for ( const { kind, form } of kindMatrix ) {
+		test( `${ kind } post gets the kind=${ kind } term`, async () => {
+			const { kinds } = await createAndFetch( form );
+			expect( kinds ).toEqual( [ kind ] );
+		} );
+	}
 } );

--- a/tests/phpunit/unit/MicropubContentBuilderTest.php
+++ b/tests/phpunit/unit/MicropubContentBuilderTest.php
@@ -22,6 +22,26 @@ use PostKindsForIndieWeb\Micropub_Content_Builder;
 class MicropubContentBuilderTest extends WP_UnitTestCase {
 
 	/**
+	 * Recreate the kind terms these tests rely on.
+	 *
+	 * Earlier suite classes can leak committed term deletions (DDL inside
+	 * a test implicitly commits MySQL's rollback transaction), so the
+	 * bootstrap-created default terms aren't guaranteed to still exist.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		foreach ( array( 'note', 'checkin', 'eat', 'drink', 'like', 'rsvp' ) as $slug ) {
+			if ( ! term_exists( $slug, 'kind' ) ) {
+				wp_insert_term( ucfirst( $slug ), 'kind', array( 'slug' => $slug ) );
+			}
+		}
+		$note = get_term_by( 'slug', 'note', 'kind' );
+		if ( $note instanceof \WP_Term ) {
+			update_option( 'default_term_kind', $note->term_id );
+		}
+	}
+
+	/**
 	 * Invoke a private static method on the builder by name.
 	 *
 	 * @param string                $method
@@ -605,5 +625,168 @@ class MicropubContentBuilderTest extends WP_UnitTestCase {
 		$this->assertSame( 1, substr_count( $markup, '<!-- wp:image' ) );
 		$this->assertStringNotContainsString( '<!-- wp:gallery', $markup );
 		$this->assertStringContainsString( 'alt="one"', $markup );
+	}
+
+	// --- kind term assignment ------------------------------------------------
+
+	/**
+	 * Read the post's kind term slugs.
+	 *
+	 * @param int $post_id
+	 * @return string[]
+	 */
+	private function kind_slugs( int $post_id ): array {
+		$slugs = wp_get_post_terms( $post_id, 'kind', array( 'fields' => 'slugs' ) );
+		return is_array( $slugs ) ? $slugs : array();
+	}
+
+	public function test_detect_term_only_kind_maps_mf2_properties(): void {
+		$cases = array(
+			'like'     => array( 'like-of' => 'https://example.test/post' ),
+			'repost'   => array( 'repost-of' => 'https://example.test/post' ),
+			'bookmark' => array( 'bookmark-of' => 'https://example.test/post' ),
+			'reply'    => array( 'in-reply-to' => 'https://example.test/post' ),
+		);
+		foreach ( $cases as $expected => $properties ) {
+			$this->assertSame(
+				$expected,
+				$this->invoke_private( 'detect_term_only_kind', array( $properties ) )
+			);
+		}
+		$this->assertNull(
+			$this->invoke_private( 'detect_term_only_kind', array( array( 'content' => 'plain note' ) ) )
+		);
+	}
+
+	public function test_apply_assigns_detected_kind_term(): void {
+		// Micropub inserts the post with no kind terms, so WP core's
+		// default_term gives it `note` — apply() must overwrite that.
+		// Core only assigns the default when the acting user can assign
+		// terms, so run as an author like a real Micropub request.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'author' ) ) );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'coffee stop',
+			)
+		);
+		$this->assertSame( array( 'note' ), $this->kind_slugs( $post_id ) );
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'             => 'entry',
+				'mp-place-name' => 'Cafe Test',
+				'location'      => 'geo:39.93,-77.66',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'checkin' ), $this->kind_slugs( $post_id ) );
+	}
+
+	public function test_apply_assigns_term_for_cardless_like_post(): void {
+		// like/reply/repost/bookmark have kind terms but no card builder —
+		// content must stay untouched while the term is still assigned.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'Liked this a lot',
+			)
+		);
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'       => 'entry',
+				'like-of' => 'https://example.test/great-post',
+				'content' => 'Liked this a lot',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'like' ), $this->kind_slugs( $post_id ) );
+		$this->assertSame( 'Liked this a lot', (string) get_post_field( 'post_content', $post_id ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, '_pkiw_block_content_generated', true ) );
+	}
+
+	public function test_apply_rsvp_takes_precedence_over_reply(): void {
+		// RSVP posts always carry in-reply-to; the rsvp property wins.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'See you there',
+			)
+		);
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'           => 'entry',
+				'rsvp'        => 'yes',
+				'in-reply-to' => 'https://example.test/event',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'rsvp' ), $this->kind_slugs( $post_id ) );
+	}
+
+	public function test_apply_leaves_default_note_for_termless_follow_kind(): void {
+		// follow/weather are builder-only kinds with no taxonomy term —
+		// they keep core's `note` default (but still get their content).
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'author' ) ) );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'placeholder',
+			)
+		);
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'         => 'entry',
+				'follow-of' => 'https://example.test/author',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'note' ), $this->kind_slugs( $post_id ) );
+		$this->assertStringContainsString( 'u-follow-of', (string) get_post_field( 'post_content', $post_id ) );
+	}
+
+	public function test_apply_does_not_reassign_kind_after_generation(): void {
+		// Once the marker is set, a later Micropub update must not clobber
+		// a manually-corrected kind (same contract as content idempotency).
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'lunch',
+			)
+		);
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'      => 'entry',
+				'eat-of' => 'Tacos',
+			),
+			array( 'ID' => $post_id )
+		);
+		$this->assertSame( array( 'eat' ), $this->kind_slugs( $post_id ) );
+
+		// User corrects the kind by hand.
+		wp_set_post_terms( $post_id, array( 'drink' ), 'kind' );
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'      => 'entry',
+				'eat-of' => 'More tacos',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'drink' ), $this->kind_slugs( $post_id ) );
 	}
 }


### PR DESCRIPTION
## Root cause

The `kind` taxonomy registers `note` as its `default_term` (includes/class-taxonomy.php). WordPress core assigns that default to any post inserted with no kind terms — which is how every Micropub post arrives. The `after_micropub` bridge built the correct card content but never wrote the matching term, so eat/drink/listen/watch/read/play/rsvp/checkin/mood/photo/like/reply/repost/bookmark posts all wore the note badge and landed in the note archive (observed on staging courtneyr.dev 2026-07-03; affects all Outpost-created posts in production).

## Fix

- `Micropub_Content_Builder::apply()` now assigns the detected kind's term via `Taxonomy::set_post_kind()` when the term exists. `wp_set_post_terms` replaces core's note default cleanly, and doesn't depend on the request user's `assign_terms` cap.
- like/reply/repost/bookmark have kind terms but no card builder, so `detect_kind()` never returns them — a new `detect_term_only_kind()` fallback maps `like-of`/`repost-of`/`bookmark-of`/`in-reply-to`. Reply-vs-RSVP precedence is preserved (rsvp detected first).
- Term assignment happens after the idempotency marker check, so a later Micropub update never clobbers a manually corrected kind.

## follow/weather decision

They're builder-only kinds with no taxonomy term, so they intentionally keep the note default. The term-exists guard means that if a site creates `follow`/`weather` terms later, assignment picks them up with no code change.

## Tests

- PHPUnit: `detect_term_only_kind` mapping, term assignment for card and cardless kinds, rsvp-over-reply precedence, follow keeps note, no reassignment after the generated marker is set (red before fix, green after). Test class now recreates its kind terms in `set_up` — an earlier suite class leaks committed term deletions (DDL implicitly commits the rollback transaction), which made these fail in full-suite order only.
- e2e (`tests/e2e/micropub-kinds.spec.js`): `createAndFetch` returns kind slugs; every existing test asserts its kind, plus a 10-kind matrix. Verified locally against wp-env: 16/16 pass with the fix, kind tests fail without it.

Full PHPUnit suite: 1035 tests green. PHPCS + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)