### PR TITLE
Editor saves sync the kind term from the post's first card block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Editor saves now set the kind term from the post's first block.** When a post's first block is one of the kind card blocks (eat, drink, listen, watch, read, play, checkin, RSVP, like, favorite, jam, wish, mood, acquisition), saving assigns the matching `kind` taxonomy term automatically — no separate pick in the taxonomy panel needed. Manual choices always win: only the `note` default (never chosen by a person) or a kind this sync itself assigned earlier (tracked in `_pkiw_kind_auto_assigned` post meta, so a swapped first block re-syncs) is ever replaced. Companion to the Micropub-side kind assignment, which covers posts arriving via the Micropub bridge.
+
 ## [1.1.0] - 2026-07-03
 
 ### Fixed

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -34,6 +34,41 @@ class Taxonomy {
 	public const TAXONOMY = 'kind';
 
 	/**
+	 * Map of kind card block names to their kind term slugs.
+	 *
+	 * Shared contract for every path that infers a kind from block
+	 * content (editor saves here, Micropub bridge output upstream).
+	 *
+	 * @var array<string, string>
+	 */
+	public const KIND_CARD_BLOCKS = [
+		'post-kinds-indieweb/eat-card'         => 'eat',
+		'post-kinds-indieweb/drink-card'       => 'drink',
+		'post-kinds-indieweb/listen-card'      => 'listen',
+		'post-kinds-indieweb/watch-card'       => 'watch',
+		'post-kinds-indieweb/read-card'        => 'read',
+		'post-kinds-indieweb/play-card'        => 'play',
+		'post-kinds-indieweb/checkin-card'     => 'checkin',
+		'post-kinds-indieweb/rsvp-card'        => 'rsvp',
+		'post-kinds-indieweb/like-card'        => 'like',
+		'post-kinds-indieweb/favorite-card'    => 'favorite',
+		'post-kinds-indieweb/jam-card'         => 'jam',
+		'post-kinds-indieweb/wish-card'        => 'wish',
+		'post-kinds-indieweb/mood-card'        => 'mood',
+		'post-kinds-indieweb/acquisition-card' => 'acquisition',
+	];
+
+	/**
+	 * Meta key recording a kind slug this class assigned automatically.
+	 *
+	 * Lets a later save re-sync when the first card block changes, while
+	 * never overriding a kind a person picked themselves.
+	 *
+	 * @var string
+	 */
+	public const AUTO_KIND_META_KEY = '_pkiw_kind_auto_assigned';
+
+	/**
 	 * Default post types to register taxonomy for.
 	 *
 	 * @var array<string>
@@ -163,6 +198,10 @@ class Taxonomy {
 		add_action( 'init', [ $this, 'maybe_create_default_terms' ], 10 );
 		add_action( 'init', [ $this, 'ensure_all_terms_exist' ], 11 );
 		add_filter( 'term_link', [ $this, 'filter_term_link' ], 10, 3 );
+		// wp_after_insert_post (not save_post): the REST posts controller
+		// assigns taxonomy terms after wp_insert_post(), so save_post would
+		// read the pre-save terms during block editor saves.
+		add_action( 'wp_after_insert_post', [ $this, 'sync_kind_from_first_block' ], 10, 2 );
 	}
 
 	/**
@@ -412,6 +451,80 @@ class Taxonomy {
 		$result = wp_set_post_terms( $post_id, [ $kind ], self::TAXONOMY );
 
 		return ! is_wp_error( $result );
+	}
+
+	/**
+	 * Detect the kind implied by the first block of some post content.
+	 *
+	 * Skips the null-blockName freeform blocks parse_blocks() emits for
+	 * whitespace between block comments, so "first block" means the first
+	 * real block a person sees in the editor.
+	 *
+	 * @param string $content Raw post content.
+	 * @return string|null Kind slug, or null when the first block is not a kind card.
+	 */
+	public static function get_first_block_kind( string $content ): ?string {
+		if ( '' === trim( $content ) || ! has_blocks( $content ) ) {
+			return null;
+		}
+
+		foreach ( parse_blocks( $content ) as $block ) {
+			if ( null === $block['blockName'] ) {
+				continue;
+			}
+
+			return self::KIND_CARD_BLOCKS[ $block['blockName'] ] ?? null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Assign the kind term matching the post's first kind card block.
+	 *
+	 * A post whose first block is a kind card (eat-card, listen-card, …)
+	 * should carry the matching kind term without the author also having
+	 * to pick it in the taxonomy panel. Manual choices always win: the
+	 * `note` default_term core stamps on unselected posts is the only
+	 * term treated as "not chosen", plus whatever this method itself set
+	 * earlier (recorded in AUTO_KIND_META_KEY) so a changed first block
+	 * re-syncs. The block editor sends explicit panel picks with the
+	 * REST request, and those are applied before this hook fires.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 * @return void
+	 */
+	public function sync_kind_from_first_block( int $post_id, \WP_Post $post ): void {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( wp_is_post_revision( $post_id ) || ! is_object_in_taxonomy( $post->post_type, self::TAXONOMY ) ) {
+			return;
+		}
+
+		$kind = self::get_first_block_kind( $post->post_content );
+		if ( null === $kind || ! $this->is_valid_kind( $kind ) ) {
+			return;
+		}
+
+		$current = $this->get_post_kind( $post_id );
+		if ( $current instanceof \WP_Term ) {
+			if ( $current->slug === $kind ) {
+				return;
+			}
+
+			$auto_assigned = get_post_meta( $post_id, self::AUTO_KIND_META_KEY, true );
+			if ( 'note' !== $current->slug && $current->slug !== $auto_assigned ) {
+				// A person picked this kind — never override it.
+				return;
+			}
+		}
+
+		if ( $this->set_post_kind( $post_id, $kind ) ) {
+			update_post_meta( $post_id, self::AUTO_KIND_META_KEY, $kind );
+		}
 	}
 
 	/**

--- a/tests/phpunit/unit/TaxonomyTest.php
+++ b/tests/phpunit/unit/TaxonomyTest.php
@@ -150,4 +150,178 @@ class TaxonomyTest extends WP_UnitTestCase {
 		$result    = $this->taxonomy->filter_term_link( 'http://example.com/test', $wp_term, 'category' );
 		$this->assertSame( 'http://example.com/test', $result );
 	}
+
+	// --- first-block kind sync ------------------------------------------------
+
+	private function ensure_kind_terms( string ...$slugs ): void {
+		foreach ( $slugs as $slug ) {
+			if ( ! term_exists( $slug, Taxonomy::TAXONOMY ) ) {
+				wp_insert_term( $slug, Taxonomy::TAXONOMY );
+			}
+		}
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function kind_slugs( int $post_id ): array {
+		$slugs = wp_get_post_terms( $post_id, Taxonomy::TAXONOMY, [ 'fields' => 'slugs' ] );
+		return is_array( $slugs ) ? $slugs : [];
+	}
+
+	public function test_kind_card_blocks_map_only_default_kinds() {
+		$default_kinds = $this->taxonomy->get_default_kinds();
+		foreach ( Taxonomy::KIND_CARD_BLOCKS as $block_name => $kind ) {
+			$this->assertArrayHasKey( $kind, $default_kinds, "$block_name maps to unknown kind $kind" );
+		}
+	}
+
+	public function test_get_first_block_kind_maps_every_card_block() {
+		foreach ( Taxonomy::KIND_CARD_BLOCKS as $block_name => $kind ) {
+			$this->assertSame(
+				$kind,
+				Taxonomy::get_first_block_kind( "<!-- wp:$block_name /-->" )
+			);
+		}
+	}
+
+	public function test_get_first_block_kind_skips_leading_whitespace() {
+		$this->assertSame(
+			'eat',
+			Taxonomy::get_first_block_kind( "\n\n<!-- wp:post-kinds-indieweb/eat-card /-->\n" )
+		);
+	}
+
+	public function test_get_first_block_kind_null_for_plain_text_and_non_card_first_block() {
+		$this->assertNull( Taxonomy::get_first_block_kind( '' ) );
+		$this->assertNull( Taxonomy::get_first_block_kind( 'just a plain note' ) );
+		// Only the FIRST block counts — a card further down doesn't.
+		$this->assertNull(
+			Taxonomy::get_first_block_kind(
+				"<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->\n<!-- wp:post-kinds-indieweb/eat-card /-->"
+			)
+		);
+	}
+
+	public function test_save_assigns_kind_from_first_card_block() {
+		$this->ensure_kind_terms( 'eat' );
+
+		$post_id = self::factory()->post->create(
+			[ 'post_content' => '<!-- wp:post-kinds-indieweb/eat-card {"name":"Pizza"} /-->' ]
+		);
+
+		$this->assertSame( [ 'eat' ], $this->kind_slugs( $post_id ) );
+		$this->assertSame( 'eat', get_post_meta( $post_id, Taxonomy::AUTO_KIND_META_KEY, true ) );
+	}
+
+	public function test_save_overrides_note_default_term() {
+		// The test suite's between-class cleanup deletes the bootstrap-created
+		// `note` term while `default_term_kind` still points at it, silently
+		// breaking core's default stamping. Re-registering recreates the term
+		// and repairs the option — what init does on a real site.
+		$this->taxonomy->register_taxonomy();
+		$this->ensure_kind_terms( 'checkin' );
+		// Core only stamps the `note` default_term when the acting user can
+		// assign terms — create as an author like a real editor session.
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'author' ] ) );
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_content' => 'plain text, no blocks',
+				'post_status'  => 'publish',
+			]
+		);
+		$this->assertSame( [ 'note' ], $this->kind_slugs( $post_id ) );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:post-kinds-indieweb/checkin-card /-->',
+			]
+		);
+
+		$this->assertSame( [ 'checkin' ], $this->kind_slugs( $post_id ) );
+	}
+
+	public function test_save_respects_manually_chosen_kind() {
+		$this->ensure_kind_terms( 'eat', 'photo' );
+
+		$post_id = self::factory()->post->create( [ 'post_content' => 'plain' ] );
+		wp_set_post_terms( $post_id, [ 'photo' ], Taxonomy::TAXONOMY );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:post-kinds-indieweb/eat-card /-->',
+			]
+		);
+
+		$this->assertSame( [ 'photo' ], $this->kind_slugs( $post_id ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, Taxonomy::AUTO_KIND_META_KEY, true ) );
+	}
+
+	public function test_changing_first_block_resyncs_auto_assigned_kind() {
+		$this->ensure_kind_terms( 'eat', 'drink' );
+
+		$post_id = self::factory()->post->create(
+			[ 'post_content' => '<!-- wp:post-kinds-indieweb/eat-card /-->' ]
+		);
+		$this->assertSame( [ 'eat' ], $this->kind_slugs( $post_id ) );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:post-kinds-indieweb/drink-card /-->',
+			]
+		);
+
+		$this->assertSame( [ 'drink' ], $this->kind_slugs( $post_id ) );
+		$this->assertSame( 'drink', get_post_meta( $post_id, Taxonomy::AUTO_KIND_META_KEY, true ) );
+	}
+
+	public function test_manual_change_after_auto_assign_is_never_overridden() {
+		$this->ensure_kind_terms( 'eat', 'watch' );
+
+		$post_id = self::factory()->post->create(
+			[ 'post_content' => '<!-- wp:post-kinds-indieweb/eat-card /-->' ]
+		);
+		$this->assertSame( [ 'eat' ], $this->kind_slugs( $post_id ) );
+
+		// A person re-kinds the post; the stale auto marker still says eat.
+		wp_set_post_terms( $post_id, [ 'watch' ], Taxonomy::TAXONOMY );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:post-kinds-indieweb/eat-card {"name":"edited"} /-->',
+			]
+		);
+
+		$this->assertSame( [ 'watch' ], $this->kind_slugs( $post_id ) );
+	}
+
+	public function test_sync_skips_kind_without_registered_term() {
+		// The sync must not invent a term the site doesn't have.
+		$term = get_term_by( 'slug', 'jam', Taxonomy::TAXONOMY );
+		if ( $term instanceof \WP_Term ) {
+			wp_delete_term( $term->term_id, Taxonomy::TAXONOMY );
+		}
+
+		$post_id = self::factory()->post->create(
+			[ 'post_content' => '<!-- wp:post-kinds-indieweb/jam-card /-->' ]
+		);
+
+		$this->assertSame( [], $this->kind_slugs( $post_id ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, Taxonomy::AUTO_KIND_META_KEY, true ) );
+	}
+
+	public function test_sync_ignores_non_card_content() {
+		$this->ensure_kind_terms( 'eat' );
+
+		$post_id = self::factory()->post->create(
+			[ 'post_content' => '<!-- wp:paragraph --><p>dinner was great</p><!-- /wp:paragraph -->' ]
+		);
+
+		$this->assertSame( [], $this->kind_slugs( $post_id ) );
+	}
 }


### PR DESCRIPTION
## What

When a post's first block is one of the 14 kind card blocks (`eat-card`, `drink-card`, `listen-card`, `watch-card`, `read-card`, `play-card`, `checkin-card`, `rsvp-card`, `like-card`, `favorite-card`, `jam-card`, `wish-card`, `mood-card`, `acquisition-card`), saving the post now assigns the matching `kind` taxonomy term automatically. Previously nothing did this — the only save-time path was the classic-editor meta box, which the block editor never exercises.

## How

- `Taxonomy::KIND_CARD_BLOCKS` — block-name→kind-slug map, the shared contract for any path that infers a kind from block content.
- `Taxonomy::sync_kind_from_first_block()` on `wp_after_insert_post`. Not `save_post`: the REST posts controller assigns taxonomy terms *after* `wp_insert_post()`, so `save_post` reads stale terms during block editor saves. On `wp_after_insert_post`, an explicit kind picked in the editor panel during the same save is already applied and gets respected.
- **Manual choices always win.** Only two states are ever replaced: the `note` default_term core stamps on unselected posts, and a kind this sync itself assigned earlier — recorded in `_pkiw_kind_auto_assigned` post meta, so swapping the first card block re-syncs, but a human's pick is never overridden.
- Guards: autosaves, revisions, post types outside the taxonomy, unregistered kind terms (the sync never invents a term).

## Coordination with the Micropub kind fix

Complements the in-flight `fix/micropub-kind-term-assignment` work (Micropub-created posts stuck on `note`). The two paths compose: the Micropub bridge assigns the term from mf2 properties *before* rewriting content to a card block, so when that rewrite fires this hook, the term already matches and it no-ops. No shared code conflicts — that branch touches `class-micropub-content-builder.php`, this one touches `class-taxonomy.php`.

⚠️ **Heads-up for that branch:** the WP test suite's between-class cleanup (`_delete_all_data()`) deletes the bootstrap-created `note` term while `default_term_kind` still points at it, silently disabling core's default-term stamping for every test class after the first in a run. Any test asserting the `note` default (their `test_apply_assigns_detected_kind_term` does) passes standalone but fails in full-suite order. Fix used here: re-run `register_taxonomy()` in the test, which recreates the term and repairs the option.

## Testing

- 9 new tests in `TaxonomyTest` (map completeness, first-block detection incl. whitespace/non-card cases, auto-assign, note-default override, manual-choice respect, block-swap re-sync, manual-after-auto protection, missing-term guard).
- Full local suite: **1,040 tests, 2,527 assertions, 0 failures.** PHPCS and PHPStan (level 6) clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)