### PR TITLE
🐛 FIX: stream fallback renders a linked title again

### DIFF
--- a/includes/functions-stream-card.php
+++ b/includes/functions-stream-card.php
@@ -79,11 +79,19 @@ function render_stream_card( array $attributes = [], string $content = '', ?\WP_
 		);
 	}
 
-	// Any other long-form post: render nothing. The Post Template's linked
-	// post-title and post-date already stand in for the item; adding a
-	// second title link would duplicate them, and the full body must never
-	// reach the feed.
-	return '';
+	// Any other long-form post: a linked post title stands in for the item.
+	// The Stream template no longer renders its own post-title block (the
+	// title now lives inside each card), so this keeps non-card posts from
+	// losing their heading. The full body never reaches the feed.
+	$title = get_the_title( $post );
+	if ( '' === trim( $title ) ) {
+		return '';
+	}
+	return sprintf(
+		'<p class="pk-stream-fallback"><a href="%s">%s</a></p>',
+		esc_url( (string) get_permalink( $post ) ),
+		esc_html( $title )
+	);
 }
 
 /**

--- a/tests/phpunit/integration/StreamCardTest.php
+++ b/tests/phpunit/integration/StreamCardTest.php
@@ -127,14 +127,32 @@ final class StreamCardTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A long-form post with no kind renders nothing — the Post Template's
-	 * own title and date stand in, and the body never reaches the feed.
+	 * A long-form post with no kind renders a linked title (never the body).
 	 */
-	public function test_long_form_non_watch_renders_nothing(): void {
+	public function test_long_form_non_watch_renders_linked_title(): void {
 		$post_id = self::factory()->post->create(
 			[
 				'post_title'   => 'Just an essay',
 				'post_content' => "<!-- wp:paragraph -->\n<p>Body text.</p>\n<!-- /wp:paragraph -->",
+			]
+		);
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$html = \PostKindsForIndieWeb\render_stream_card();
+
+		$this->assertStringContainsString( 'pk-stream-fallback', $html );
+		$this->assertStringContainsString( 'Just an essay', $html );
+		$this->assertStringNotContainsString( 'Body text.', $html );
+	}
+
+	/**
+	 * A title-less long-form post renders nothing (no empty link).
+	 */
+	public function test_long_form_without_title_renders_nothing(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_title'   => '',
+				'post_content' => "<!-- wp:paragraph -->\n<p>Body.</p>\n<!-- /wp:paragraph -->",
 			]
 		);
 		$GLOBALS['post'] = get_post( $post_id );


### PR DESCRIPTION
Companion to a Stream restyle (theme side): the Stream Post Template's own `core/post-title` block was removed so the post title now lives **inside** each card. Non-card posts hit `render_stream_card`'s fallback, which previously returned `''` (relying on that template post-title). It now renders the linked post title itself, with the empty-title guard kept so title-less posts still render nothing (no empty link).

Tests updated: `test_long_form_non_watch_renders_linked_title` + `test_long_form_without_title_renders_nothing`. `php -l` + PHPCS clean.

Deployed to live + staging by direct rsync (stream restyle is already visible on courtneyr.dev).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>