### PR TITLE
👌 IMPROVE: stream cards — date inside + poster via empty-paragraph tolerance

### DIFF
--- a/includes/functions-stream-card.php
+++ b/includes/functions-stream-card.php
@@ -54,7 +54,7 @@ function render_stream_card( array $attributes = [], string $content = '', ?\WP_
 	// Micro-post: the body is nothing but Post Kinds card block(s). Render
 	// it exactly as it renders today — this is the Enola-Holmes shape.
 	if ( content_is_kind_card_only( (string) $post->post_content ) ) {
-		return link_title_to_post( do_blocks( $post->post_content ), $post );
+		return inject_post_date_into_card( link_title_to_post( do_blocks( $post->post_content ), $post ), $post );
 	}
 
 	// Long-form watch post: show a watch card with the video from the body,
@@ -68,15 +68,18 @@ function render_stream_card( array $attributes = [], string $content = '', ?\WP_
 			$attrs['watchUrl'] = $video_url;
 		}
 
-		return link_title_to_post(
-			render_block(
-				[
-					'blockName'    => 'post-kinds-indieweb/watch-card',
-					'attrs'        => $attrs,
-					'innerBlocks'  => [],
-					'innerHTML'    => '',
-					'innerContent' => [],
-				]
+		return inject_post_date_into_card(
+			link_title_to_post(
+				render_block(
+					[
+						'blockName'    => 'post-kinds-indieweb/watch-card',
+						'attrs'        => $attrs,
+						'innerBlocks'  => [],
+						'innerHTML'    => '',
+						'innerContent' => [],
+					]
+				),
+				$post
 			),
 			$post
 		);
@@ -138,6 +141,15 @@ function content_is_kind_card_only( string $content ): bool {
 
 		// Layout wrappers are fine; their children are flattened alongside.
 		if ( in_array( $name, STREAM_CARD_WRAPPERS, true ) ) {
+			continue;
+		}
+
+		// Empty paragraph / spacer blocks are editor cruft — a trailing empty
+		// paragraph shouldn't stop a single-card post from reading as one.
+		if (
+			in_array( $name, [ 'core/paragraph', 'core/spacer' ], true )
+			&& '' === trim( wp_strip_all_tags( (string) ( $block['innerHTML'] ?? '' ) ) )
+		) {
 			continue;
 		}
 
@@ -205,6 +217,38 @@ function link_title_to_post( string $html, \WP_Post $post ): string {
 		1
 	);
 	return null !== $wrapped ? $wrapped : $html;
+}
+
+/**
+ * Insert the post's published date inside the card, under the title.
+ *
+ * On the Stream the date reads inside each card rather than floating above
+ * it, so the Post Template no longer renders its own post-date block.
+ *
+ * @param string   $html Rendered card HTML.
+ * @param \WP_Post $post Post the card represents.
+ * @return string HTML with a dt-published date under the title.
+ */
+function inject_post_date_into_card( string $html, \WP_Post $post ): string {
+	$display = get_the_date( '', $post );
+	if ( '' === $display ) {
+		return $html;
+	}
+
+	$date_html = '<p class="pk-sub pk-stream-date"><time class="dt-published" datetime="'
+		. esc_attr( (string) get_post_time( 'c', true, $post ) ) . '">'
+		. esc_html( $display ) . '</time></p>';
+
+	$out = preg_replace_callback(
+		'#<h3 class="pk-title[^"]*">.*?</h3>#s',
+		static function ( $matches ) use ( $date_html ) {
+			return $matches[0] . $date_html;
+		},
+		$html,
+		1,
+		$count
+	);
+	return ( null !== $out && $count > 0 ) ? $out : $html;
 }
 
 /**

--- a/tests/phpunit/integration/StreamCardTest.php
+++ b/tests/phpunit/integration/StreamCardTest.php
@@ -60,6 +60,46 @@ final class StreamCardTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A trailing empty paragraph doesn't stop a single-card post from
+	 * reading as a micro-post.
+	 */
+	public function test_card_with_trailing_empty_paragraph_is_micro_post(): void {
+		$content = '<!-- wp:group --><div class="wp-block-group">' .
+			'<!-- wp:post-kinds-indieweb/watch-card {"mediaTitle":"Enola"} /-->' .
+			"</div><!-- /wp:group -->\n\n<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->";
+		$this->assertTrue( \PostKindsForIndieWeb\content_is_kind_card_only( $content ) );
+	}
+
+	/**
+	 * A non-empty trailing paragraph makes it long-form again.
+	 */
+	public function test_card_with_real_paragraph_is_not_micro_post(): void {
+		$content = '<!-- wp:post-kinds-indieweb/watch-card {"mediaTitle":"X"} /-->' .
+			"\n\n<!-- wp:paragraph -->\n<p>Real words.</p>\n<!-- /wp:paragraph -->";
+		$this->assertFalse( \PostKindsForIndieWeb\content_is_kind_card_only( $content ) );
+	}
+
+	/**
+	 * The post date is injected under the card title, before the media.
+	 */
+	public function test_inject_post_date_into_card(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_title' => 'Movie',
+				'post_date'  => '2026-07-05 09:00:00',
+			]
+		);
+		$post = get_post( $post_id );
+		$html = '<h3 class="pk-title p-name"><a href="#">Movie</a></h3><div class="pk-embed"></div>';
+
+		$out = \PostKindsForIndieWeb\inject_post_date_into_card( $html, $post );
+
+		$this->assertStringContainsString( 'pk-stream-date', $out );
+		$this->assertStringContainsString( '<time class="dt-published"', $out );
+		$this->assertLessThan( strpos( $out, 'pk-embed' ), strpos( $out, 'pk-stream-date' ) );
+	}
+
+	/**
 	 * A card wrapped in a group is still a micro-post.
 	 */
 	public function test_group_wrapped_card_is_micro_post(): void {


### PR DESCRIPTION
Two Stream refinements (front-end):

1. **Date inside the card** — `inject_post_date_into_card()` puts the post's published date (dt-published) under the card title; the Stream Post Template's `post-date` block is removed on live + staging so the date reads inside each card.
2. **Cover art shows** — `content_is_kind_card_only()` now ignores empty `core/paragraph`/`core/spacer` blocks. A single-card post with a trailing empty paragraph (editor cruft, e.g. Enola Holmes 3) was falling through to the synthetic watch-card, which ignored the block's `posterImage`. It now renders the real card via `do_blocks`, showing the poster.

Verified on live: Enola renders as a micro-post with its TMDB poster + the date under the title; WP374 keeps its video with the date inside. Tests added (empty-paragraph tolerance both ways, date injection). Deployed to live + staging by direct rsync.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>