### PR TITLE
🐛 FIX: card titles render h2, not h3 (heading order, WCAG 1.3.1)

### DIFF
--- a/build/blocks/acquisition-card/render.php
+++ b/build/blocks/acquisition-card/render.php
@@ -55,13 +55,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php echo esc_html( $pkiw_type_label ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_where_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_where_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_cost || $pkiw_where ) : ?>

--- a/build/blocks/bookmark-card/render.php
+++ b/build/blocks/bookmark-card/render.php
@@ -48,13 +48,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Bookmark', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-bookmark-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/build/blocks/checkin-card/render.php
+++ b/build/blocks/checkin-card/render.php
@@ -113,13 +113,13 @@ ob_start();
 			</div>
 		<?php else : ?>
 			<?php if ( $pkiw_venue_name ) : ?>
-				<h3 class="pk-title p-name">
+				<h2 class="pk-title p-name">
 					<?php if ( $pkiw_venue_url ) : ?>
 						<a class="u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_venue_name ); ?></a>
 					<?php else : ?>
 						<?php echo esc_html( $pkiw_venue_name ); ?>
 					<?php endif; ?>
-				</h3>
+				</h2>
 			<?php endif; ?>
 
 			<p class="pk-sub p-location h-card">

--- a/build/blocks/drink-card/render.php
+++ b/build/blocks/drink-card/render.php
@@ -76,7 +76,7 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Drank', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_name ) : ?>
-			<h3 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h3>
+			<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_brand || $pkiw_badge_label ) : ?>

--- a/build/blocks/eat-card/render.php
+++ b/build/blocks/eat-card/render.php
@@ -62,7 +62,7 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Ate', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_name ) : ?>
-			<h3 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h3>
+			<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_restaurant || $pkiw_cuisine ) : ?>

--- a/build/blocks/favorite-card/render.php
+++ b/build/blocks/favorite-card/render.php
@@ -45,13 +45,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Favorite', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-favorite-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/build/blocks/jam-card/render.php
+++ b/build/blocks/jam-card/render.php
@@ -52,13 +52,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Jam', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-jam-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_artist || $pkiw_album ) : ?>

--- a/build/blocks/like-card/render.php
+++ b/build/blocks/like-card/render.php
@@ -48,13 +48,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Like', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-like-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/build/blocks/listen-card/render.php
+++ b/build/blocks/listen-card/render.php
@@ -49,13 +49,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Listen', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_track_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_listen_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_listen_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_track_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_track_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_artist_name || $pkiw_album_title ) : ?>

--- a/build/blocks/play-card/render.php
+++ b/build/blocks/play-card/render.php
@@ -70,13 +70,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Play', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_game_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_game_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_status_label || $pkiw_platform || $pkiw_hours_played > 0 ) : ?>

--- a/build/blocks/read-card/render.php
+++ b/build/blocks/read-card/render.php
@@ -83,13 +83,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Read', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_book_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_book_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_book_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_book_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_book_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author_name ) : ?>

--- a/build/blocks/reply-card/render.php
+++ b/build/blocks/reply-card/render.php
@@ -49,13 +49,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Reply', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-in-reply-to" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/build/blocks/repost-card/render.php
+++ b/build/blocks/repost-card/render.php
@@ -48,13 +48,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Repost', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-repost-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/build/blocks/rsvp-card/render.php
+++ b/build/blocks/rsvp-card/render.php
@@ -101,13 +101,13 @@ ob_start();
 
 		<div class="pk-event p-in-reply-to h-event">
 			<?php if ( $pkiw_event_name ) : ?>
-				<h3 class="pk-title p-name">
+				<h2 class="pk-title p-name">
 					<?php if ( $pkiw_event_url ) : ?>
 						<a class="u-url" href="<?php echo esc_url( $pkiw_event_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_event_name ); ?></a>
 					<?php else : ?>
 						<?php echo esc_html( $pkiw_event_name ); ?>
 					<?php endif; ?>
-				</h3>
+				</h2>
 			<?php endif; ?>
 
 			<?php if ( $pkiw_event_start_iso || $pkiw_event_location ) : ?>

--- a/build/blocks/watch-card/render.php
+++ b/build/blocks/watch-card/render.php
@@ -81,13 +81,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Watch', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_media_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_watch_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_watch_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_media_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_media_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( 'episode' === $pkiw_media_type && $pkiw_show_title ) : ?>

--- a/build/blocks/wish-card/render.php
+++ b/build/blocks/wish-card/render.php
@@ -45,13 +45,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Wish', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-wish-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_price ) : ?>

--- a/includes/functions-stream-card.php
+++ b/includes/functions-stream-card.php
@@ -195,7 +195,7 @@ function link_title_to_post( string $html, \WP_Post $post ): string {
 
 	// Title already linked → repoint the anchor at the post.
 	$relinked = preg_replace_callback(
-		'#(<h3 class="pk-title[^"]*">\s*)<a\b[^>]*>#s',
+		'#(<h[1-6] class="pk-title[^"]*">\s*)<a\b[^>]*>#s',
 		static function ( $matches ) use ( $permalink ) {
 			return $matches[1] . '<a href="' . $permalink . '">';
 		},
@@ -209,7 +209,7 @@ function link_title_to_post( string $html, \WP_Post $post ): string {
 
 	// Plain-text title → wrap it in a link to the post.
 	$wrapped = preg_replace_callback(
-		'#(<h3 class="pk-title[^"]*">)(\s*)([^<]+?)(\s*)(</h3>)#s',
+		'#(<h[1-6] class="pk-title[^"]*">)(\s*)([^<]+?)(\s*)(</h[1-6]>)#s',
 		static function ( $matches ) use ( $permalink ) {
 			return $matches[1] . $matches[2] . '<a href="' . $permalink . '">' . $matches[3] . '</a>' . $matches[4] . $matches[5];
 		},
@@ -240,7 +240,7 @@ function inject_post_date_into_card( string $html, \WP_Post $post ): string {
 		. esc_html( $display ) . '</time></p>';
 
 	$out = preg_replace_callback(
-		'#<h3 class="pk-title[^"]*">.*?</h3>#s',
+		'#<h[1-6] class="pk-title[^"]*">.*?</h[1-6]>#s',
 		static function ( $matches ) use ( $date_html ) {
 			return $matches[0] . $date_html;
 		},

--- a/src/blocks/acquisition-card/render.php
+++ b/src/blocks/acquisition-card/render.php
@@ -55,13 +55,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php echo esc_html( $pkiw_type_label ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_where_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_where_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_cost || $pkiw_where ) : ?>

--- a/src/blocks/bookmark-card/render.php
+++ b/src/blocks/bookmark-card/render.php
@@ -48,13 +48,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Bookmark', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-bookmark-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/src/blocks/checkin-card/render.php
+++ b/src/blocks/checkin-card/render.php
@@ -113,13 +113,13 @@ ob_start();
 			</div>
 		<?php else : ?>
 			<?php if ( $pkiw_venue_name ) : ?>
-				<h3 class="pk-title p-name">
+				<h2 class="pk-title p-name">
 					<?php if ( $pkiw_venue_url ) : ?>
 						<a class="u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_venue_name ); ?></a>
 					<?php else : ?>
 						<?php echo esc_html( $pkiw_venue_name ); ?>
 					<?php endif; ?>
-				</h3>
+				</h2>
 			<?php endif; ?>
 
 			<p class="pk-sub p-location h-card">

--- a/src/blocks/drink-card/render.php
+++ b/src/blocks/drink-card/render.php
@@ -76,7 +76,7 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Drank', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_name ) : ?>
-			<h3 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h3>
+			<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_brand || $pkiw_badge_label ) : ?>

--- a/src/blocks/eat-card/render.php
+++ b/src/blocks/eat-card/render.php
@@ -62,7 +62,7 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Ate', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_name ) : ?>
-			<h3 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h3>
+			<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_restaurant || $pkiw_cuisine ) : ?>

--- a/src/blocks/favorite-card/render.php
+++ b/src/blocks/favorite-card/render.php
@@ -45,13 +45,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Favorite', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-favorite-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/src/blocks/jam-card/render.php
+++ b/src/blocks/jam-card/render.php
@@ -52,13 +52,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Jam', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-jam-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_artist || $pkiw_album ) : ?>

--- a/src/blocks/like-card/render.php
+++ b/src/blocks/like-card/render.php
@@ -48,13 +48,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Like', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-like-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/src/blocks/listen-card/render.php
+++ b/src/blocks/listen-card/render.php
@@ -49,13 +49,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Listen', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_track_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_listen_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_listen_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_track_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_track_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_artist_name || $pkiw_album_title ) : ?>

--- a/src/blocks/play-card/render.php
+++ b/src/blocks/play-card/render.php
@@ -70,13 +70,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Play', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_game_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_game_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_status_label || $pkiw_platform || $pkiw_hours_played > 0 ) : ?>

--- a/src/blocks/read-card/render.php
+++ b/src/blocks/read-card/render.php
@@ -83,13 +83,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Read', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_book_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_book_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_book_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_book_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_book_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author_name ) : ?>

--- a/src/blocks/reply-card/render.php
+++ b/src/blocks/reply-card/render.php
@@ -49,13 +49,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Reply', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-in-reply-to" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/src/blocks/repost-card/render.php
+++ b/src/blocks/repost-card/render.php
@@ -48,13 +48,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Repost', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-repost-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_author ) : ?>

--- a/src/blocks/rsvp-card/render.php
+++ b/src/blocks/rsvp-card/render.php
@@ -101,13 +101,13 @@ ob_start();
 
 		<div class="pk-event p-in-reply-to h-event">
 			<?php if ( $pkiw_event_name ) : ?>
-				<h3 class="pk-title p-name">
+				<h2 class="pk-title p-name">
 					<?php if ( $pkiw_event_url ) : ?>
 						<a class="u-url" href="<?php echo esc_url( $pkiw_event_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_event_name ); ?></a>
 					<?php else : ?>
 						<?php echo esc_html( $pkiw_event_name ); ?>
 					<?php endif; ?>
-				</h3>
+				</h2>
 			<?php endif; ?>
 
 			<?php if ( $pkiw_event_start_iso || $pkiw_event_location ) : ?>

--- a/src/blocks/watch-card/render.php
+++ b/src/blocks/watch-card/render.php
@@ -81,13 +81,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Watch', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_media_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_watch_url ) : ?>
 					<a class="u-url" href="<?php echo esc_url( $pkiw_watch_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_media_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_media_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( 'episode' === $pkiw_media_type && $pkiw_show_title ) : ?>

--- a/src/blocks/wish-card/render.php
+++ b/src/blocks/wish-card/render.php
@@ -45,13 +45,13 @@ ob_start();
 		<p class="pk-kindlabel"><?php esc_html_e( 'Wish', 'post-kinds-for-indieweb' ); ?></p>
 
 		<?php if ( $pkiw_title ) : ?>
-			<h3 class="pk-title p-name">
+			<h2 class="pk-title p-name">
 				<?php if ( $pkiw_url ) : ?>
 					<a class="u-url u-wish-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
 				<?php else : ?>
 					<?php echo esc_html( $pkiw_title ); ?>
 				<?php endif; ?>
-			</h3>
+			</h2>
 		<?php endif; ?>
 
 		<?php if ( $pkiw_price ) : ?>

--- a/tests/phpunit/integration/BlockFieldRenderTest.php
+++ b/tests/phpunit/integration/BlockFieldRenderTest.php
@@ -178,6 +178,41 @@ final class BlockFieldRenderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Card titles must render as <h2>, not <h3>. A card sits directly under the
+	 * page <h1> (single post) or the archive <h1> (stream), so an <h3> skips a
+	 * heading level — WCAG 1.3.1 (Info and Relationships). Regression guard for
+	 * the 2026-07 heading-order fix. Blocks that render no pk-title heading
+	 * (e.g. mood-card) simply assert no stray <h3> title is present.
+	 *
+	 * @dataProvider dynamic_blocks
+	 *
+	 * @param string $block_name Block name.
+	 * @param array  $attributes Attribute definitions from the fixture.
+	 */
+	public function test_card_title_uses_h2_not_h3( string $block_name, array $attributes ): void {
+		$post_id = self::factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$attrs   = array_map( static fn( $a ) => $a['sample'], $attributes );
+		$comment = sprintf( '<!-- wp:%s %s /-->', $block_name, wp_json_encode( $attrs ) );
+		$html    = do_blocks( $comment );
+
+		$this->assertStringNotContainsString(
+			'<h3 class="pk-title',
+			$html,
+			"$block_name: card title must not be <h3> — it skips a level under the page <h1> (WCAG 1.3.1)"
+		);
+
+		if ( false !== strpos( $html, 'class="pk-title' ) ) {
+			$this->assertStringContainsString(
+				'<h2 class="pk-title',
+				$html,
+				"$block_name: card title should render as <h2>"
+			);
+		}
+	}
+
+	/**
 	 * Rendering with no attributes must not leak placeholders or PHP noise.
 	 *
 	 * @dataProvider dynamic_blocks


### PR DESCRIPTION
Every dynamic card rendered its title as `<h3>`. On a single post the page `<h1>` is the post title, so the card's `<h3>` skips a heading level — Accessibility Checker flags "Incorrect Heading Order" (WCAG 1.3.1). Same skip under the archive `<h1>` on the stream.

**All 16 dynamic cards that render a title** go `h3` → `h2` (render.php + editor `tagName`): checkin, drink, eat, jam, listen, play, read, rsvp, watch, wish, reply, bookmark, favorite, acquisition, repost, like. `mood-card` renders no title and is untouched. Dynamic blocks, so it takes effect on all existing posts with **no saved-content migration**.

Also widens the **stream card renderer** (`functions-stream-card.php`): its three title regexes were pinned to `<h3 class="pk-title">` (link repointing, date injection). Now `<h[1-6]>` so the stream keeps working with h2 titles and survives any future level change.

**Test:** `BlockFieldRenderTest::test_card_title_uses_h2_not_h3` renders every dynamic block and asserts no `<h3 class="pk-title">` reaches the markup — it caught seven cards missed on the first pass and the stream-renderer coupling. Local: PHPCS, PHPStan, jest, lint-js clean; integration assertion runs in CI.