### PR TITLE
📦 NEW: default category applies only to stream-shaped posts (1.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-07-07
+
+### Changed
+
+- Default category (stream): the category is now applied only to "stream-shaped" posts -- those created through a Micropub client (the composer), or with a Status/Aside post format, or carrying a genuine activity kind (listen, watch, checkin, …). It is no longer applied to article/review/recipe kinds or plain admin-written posts, so long-form content stays out of the stream. The bare `note` kind alone no longer qualifies (it is auto-assigned to plain posts); a note needs a Status/Aside format or a Micropub origin to count. New `pkiw_default_category_stream_kinds` filter.
+
 ## [1.4.1] - 2026-07-07
 
 ### Fixed

--- a/includes/class-default-category.php
+++ b/includes/class-default-category.php
@@ -16,16 +16,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Applies a site-configured default category to any post that carries a post
- * kind. The setting (Post Kinds → General → Default category) is empty by
- * default, so the behaviour is opt-in.
+ * Applies a site-configured default category to "stream-shaped" posts — the
+ * short-form activity content that belongs in a stream, as opposed to
+ * long-form articles. The setting (Post Kinds → General → Default category)
+ * is empty by default, so the behaviour is opt-in.
+ *
+ * A post is stream-shaped when it was created through a Micropub client (the
+ * composer), OR has a Status/Aside post format, OR carries a genuine activity
+ * kind (listen, watch, checkin, …) — but not article/review/recipe kinds or a
+ * bare `note`. A plain admin-written article matches none of these and never
+ * receives the category. See {@see self::is_stream_shaped()}.
  *
  * The category is applied once, on `wp_after_insert_post` — the same hook the
- * kind taxonomy is synced on, so the kind is guaranteed to be present, and it
- * fires for the editor, the REST API, and Micropub (so Outpost's kind content
- * inherits the default without Outpost needing its own setting). A per-post
- * marker means it applies as a default, not a lock: remove it from a post and
- * it stays removed.
+ * kind taxonomy is synced on, so the kind is present when this runs, and it
+ * fires for the editor, the REST API, and Micropub. A per-post marker means it
+ * applies as a default, not a lock: remove it from a post and it stays removed.
  *
  * @since 1.3.0
  */
@@ -81,8 +86,12 @@ class Default_Category {
 			return false;
 		}
 
-		$kinds = get_the_terms( $post_id, 'kind' );
-		if ( empty( $kinds ) || is_wp_error( $kinds ) ) {
+		// get_the_terms() returns an array of terms, false, or WP_Error;
+		// is_array() accepts only the first (WP_Error is an object).
+		$kind_terms = get_the_terms( $post_id, 'kind' );
+		$kind_slugs = is_array( $kind_terms ) ? wp_list_pluck( $kind_terms, 'slug' ) : [];
+
+		if ( ! self::is_stream_shaped( $post_id, $kind_slugs ) ) {
 			return false;
 		}
 
@@ -91,7 +100,7 @@ class Default_Category {
 		}
 
 		/**
-		 * Filter the default category term id applied to a kind post.
+		 * Filter the default category term id applied to a stream post.
 		 *
 		 * Return 0 (or a non-positive value) to skip this post entirely, or a
 		 * different term id to override the configured default per post.
@@ -112,6 +121,70 @@ class Default_Category {
 
 		update_post_meta( $post_id, self::APPLIED_META, 1 );
 		return true;
+	}
+
+	/**
+	 * Post kinds that read as ephemeral "stream" content (as opposed to
+	 * long-form article/review/recipe kinds, which belong in a main archive).
+	 * The catch-all `note` kind is intentionally excluded: it is auto-assigned
+	 * to plain posts, so a note only counts as stream content when it also
+	 * carries a stream signal (a Status/Aside format or a Micropub origin).
+	 */
+	private const STREAM_KINDS = [
+		'listen',
+		'watch',
+		'read',
+		'checkin',
+		'jam',
+		'play',
+		'eat',
+		'drink',
+		'mood',
+		'photo',
+		'rsvp',
+		'like',
+		'reply',
+		'repost',
+		'bookmark',
+		'favorite',
+		'wish',
+		'acquisition',
+	];
+
+	/**
+	 * Whether a post is "stream-shaped" — the kind of short-form activity that
+	 * belongs in the stream rather than the blog. True when any one holds:
+	 *
+	 *   1. It was created through a Micropub client (the composer) — the
+	 *      `micropub_auth_response` meta the Micropub plugin stamps.
+	 *   2. Its post format is Status or Aside.
+	 *   3. It carries a genuine activity kind (see STREAM_KINDS) — not
+	 *      article/review/recipe, and not a bare `note`.
+	 *
+	 * A plain standard-format post written in the admin (an article) matches
+	 * none of these, so it never receives the default category.
+	 *
+	 * @param int           $post_id    Post being evaluated.
+	 * @param array<string> $kind_slugs Slugs of the post's kind terms.
+	 */
+	private static function is_stream_shaped( int $post_id, array $kind_slugs ): bool {
+		if ( get_post_meta( $post_id, 'micropub_auth_response', true ) ) {
+			return true;
+		}
+
+		if ( in_array( get_post_format( $post_id ), [ 'status', 'aside' ], true ) ) {
+			return true;
+		}
+
+		/**
+		 * Filter the kinds treated as stream content for the default category.
+		 *
+		 * @param array<string> $stream_kinds Kind slugs.
+		 * @param int           $post_id      Post being evaluated.
+		 */
+		$stream_kinds = (array) apply_filters( 'pkiw_default_category_stream_kinds', self::STREAM_KINDS, $post_id );
+
+		return [] !== array_intersect( $kind_slugs, $stream_kinds );
 	}
 
 	/**

--- a/post-kinds-for-indieweb.php
+++ b/post-kinds-for-indieweb.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.4.1
+ * Version:           1.4.2
  * Requires at least: 7.0
  * Tested up to:      7.0
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'POST_KINDS_INDIEWEB_VERSION', '1.4.1' );
+define( 'POST_KINDS_INDIEWEB_VERSION', '1.4.2' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -181,6 +181,9 @@ Add the kind slugs to the `pkiw_stream_kinds` filter. Those kinds get a cached `
 7. Block inserter showing all post kind blocks
 
 == Changelog ==
+
+= 1.4.2 =
+* Default category (stream) now applies only to stream-shaped posts — those posted via the composer (Micropub), with a Status/Aside format, or carrying a real activity kind (listen/watch/checkin/…). Articles, reviews, recipes, and plain admin posts no longer get it, so long-form content stays out of the stream. New pkiw_default_category_stream_kinds filter.
 
 = 1.4.1 =
 * Editor card parity fix: the 1.4.0 pass imposed a grid layout that scattered the editor card's contents. Reverted to paint-only so the existing layout stands and the theme tokens recolor the badge, title, artist, and rating.

--- a/tests/phpunit/integration/DefaultCategoryTest.php
+++ b/tests/phpunit/integration/DefaultCategoryTest.php
@@ -61,6 +61,59 @@ class DefaultCategoryTest extends WP_UnitTestCase {
 		$this->assertNotContains( $this->activity_id, $this->category_ids( $post_id ) );
 	}
 
+	public function test_does_not_apply_to_article_kind(): void {
+		$post_id = $this->make_kind_post( 'article' );
+		$this->assertNotContains(
+			$this->activity_id,
+			$this->category_ids( $post_id ),
+			'articles belong in the blog, not the stream'
+		);
+	}
+
+	public function test_does_not_apply_to_bare_note_kind(): void {
+		// A plain note (no Status/Aside format, not composer-created) reads as
+		// long-form and must not get the stream category.
+		$post_id = $this->make_kind_post( 'note' );
+		$this->assertNotContains( $this->activity_id, $this->category_ids( $post_id ) );
+	}
+
+	public function test_applies_to_status_format_post_without_a_kind(): void {
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		wp_set_object_terms( $post_id, 'post-format-status', 'post_format' );
+		do_action( 'wp_after_insert_post', $post_id, get_post( $post_id ), false, null );
+		$this->assertContains( $this->activity_id, $this->category_ids( $post_id ) );
+	}
+
+	public function test_applies_to_aside_format_post(): void {
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		wp_set_object_terms( $post_id, 'post-format-aside', 'post_format' );
+		do_action( 'wp_after_insert_post', $post_id, get_post( $post_id ), false, null );
+		$this->assertContains( $this->activity_id, $this->category_ids( $post_id ) );
+	}
+
+	public function test_applies_to_composer_created_post(): void {
+		// A Micropub-created post (the composer) is stream content even when its
+		// only kind is the bare `note`.
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		update_post_meta( $post_id, 'micropub_auth_response', [ 'client_id' => 'https://example.com/post/' ] );
+		wp_set_object_terms( $post_id, 'note', 'kind' );
+		do_action( 'wp_after_insert_post', $post_id, get_post( $post_id ), false, null );
+		$this->assertContains( $this->activity_id, $this->category_ids( $post_id ) );
+	}
+
+	public function test_stream_kinds_filter_can_extend_the_set(): void {
+		add_filter(
+			'pkiw_default_category_stream_kinds',
+			static function ( array $kinds ): array {
+				$kinds[] = 'note';
+				return $kinds;
+			}
+		);
+		$post_id = $this->make_kind_post( 'note' );
+		remove_all_filters( 'pkiw_default_category_stream_kinds' );
+		$this->assertContains( $this->activity_id, $this->category_ids( $post_id ) );
+	}
+
 	public function test_does_nothing_when_no_default_configured(): void {
 		update_option( 'post_kinds_indieweb_settings', [ 'default_category' => 0 ] );
 		$post_id = $this->make_kind_post( 'listen' );


### PR DESCRIPTION
## What

The default-category feature (1.3.0) applied the configured category to **any** post carrying a kind. Because the catch-all `note` kind gets auto-assigned to plain posts, this swept whole back catalogs of articles into the stream category.

## Change

`apply_to_post()` now gates on `is_stream_shaped()` — a post gets the category only when it:
1. was created through a Micropub client (the composer) — `micropub_auth_response` meta, **or**
2. has a **Status** or **Aside** post format, **or**
3. carries a genuine activity kind (`listen`, `watch`, `read`, `checkin`, … — see `STREAM_KINDS`).

Article/review/recipe kinds and plain standard-format posts match none of these and never receive the category. A bare `note` no longer qualifies on its own. New `pkiw_default_category_stream_kinds` filter.

## Tests

Existing `DefaultCategoryTest` cases (watch/read/listen) still pass. Added: article-kind excluded, bare-note excluded, Status/Aside applied, composer-created (`micropub_auth_response`) applied, and the stream-kinds filter extends the set. Version 1.4.1 → 1.4.2 (header, constant, readme Stable tag, CHANGELOG).