### PR TITLE
🔒 FIX: WordPress.org review round 3 — Kindle service docs, raw secrets, per-post ability caps

### DIFF
--- a/includes/abilities/class-core-abilities.php
+++ b/includes/abilities/class-core-abilities.php
@@ -302,8 +302,8 @@ final class Core_Abilities {
 					],
 				],
 				'execute_callback'    => [ $this, 'execute_set_kind' ],
-				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+				'permission_callback' => function ( $input ) {
+					return current_user_can( 'edit_post', (int) ( $input['post_id'] ?? 0 ) );
 				},
 				'meta'                => [ 'show_in_rest' => true ],
 			]
@@ -339,8 +339,8 @@ final class Core_Abilities {
 					],
 				],
 				'execute_callback'    => [ $this, 'execute_get_kind' ],
-				'permission_callback' => function () {
-					return current_user_can( 'read' );
+				'permission_callback' => function ( $input ) {
+					return current_user_can( 'read_post', (int) ( $input['post_id'] ?? 0 ) );
 				},
 				'meta'                => [ 'show_in_rest' => true ],
 			]
@@ -383,8 +383,8 @@ final class Core_Abilities {
 					],
 				],
 				'execute_callback'    => [ $this, 'execute_update_post_meta' ],
-				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+				'permission_callback' => function ( $input ) {
+					return current_user_can( 'edit_post', (int) ( $input['post_id'] ?? 0 ) );
 				},
 				'meta'                => [ 'show_in_rest' => true ],
 			]
@@ -424,8 +424,8 @@ final class Core_Abilities {
 					],
 				],
 				'execute_callback'    => [ $this, 'execute_get_post_meta' ],
-				'permission_callback' => function () {
-					return current_user_can( 'read' );
+				'permission_callback' => function ( $input ) {
+					return current_user_can( 'read_post', (int) ( $input['post_id'] ?? 0 ) );
 				},
 				'meta'                => [ 'show_in_rest' => true ],
 			]
@@ -516,6 +516,11 @@ final class Core_Abilities {
 		}
 
 		if ( ! in_array( $status, [ 'draft', 'publish', 'private' ], true ) ) {
+			$status = 'draft';
+		}
+
+		// Publishing (or creating private posts) requires more than edit_posts.
+		if ( 'draft' !== $status && ! current_user_can( 'publish_posts' ) ) {
 			$status = 'draft';
 		}
 

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -703,6 +703,11 @@ class Admin {
 	public function sanitize_api_credentials( array $input ): array {
 		$sanitized = [];
 
+		// Secret material (keys, tokens, shared secrets) may legitimately contain
+		// characters that sanitize_text_field() would strip or alter, so those
+		// fields are only minimally validated via sanitize_secret_value().
+		$secret_fields = [ 'token', 'api_key', 'api_secret', 'session_key', 'access_token', 'refresh_token', 'client_id', 'client_secret', 'api_token' ];
+
 		$api_configs = [
 			'musicbrainz'  => [ 'app_name', 'app_version', 'contact' ],
 			'listenbrainz' => [ 'token', 'username' ],
@@ -738,6 +743,10 @@ class Admin {
 					} elseif ( 'email' === $field || 'contact' === $field ) {
 						// Email-type fields use the email sanitizer.
 						$sanitized[ $api ][ $field ] = sanitize_email( $input[ $api ][ $field ] );
+					} elseif ( 'token_expires' === $field ) {
+						$sanitized[ $api ][ $field ] = absint( $input[ $api ][ $field ] );
+					} elseif ( in_array( $field, $secret_fields, true ) ) {
+						$sanitized[ $api ][ $field ] = $this->sanitize_secret_value( $input[ $api ][ $field ] );
 					} else {
 						$sanitized[ $api ][ $field ] = sanitize_text_field( $input[ $api ][ $field ] );
 					}
@@ -746,6 +755,23 @@ class Admin {
 		}
 
 		return $sanitized;
+	}
+
+	/**
+	 * Minimally validate a secret value (API key, token, shared secret).
+	 *
+	 * Secrets are stored as entered so they keep working with the remote
+	 * service; only surrounding whitespace and control characters are removed.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string Validated secret.
+	 */
+	private function sanitize_secret_value( mixed $value ): string {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		return (string) preg_replace( '/[\x00-\x1F\x7F]/', '', trim( (string) $value ) );
 	}
 
 	/**
@@ -778,7 +804,7 @@ class Admin {
 					$existing                     = get_option( 'pkiw_webhook_settings', [] );
 					$sanitized[ $type ]['secret'] = $existing[ $type ]['secret'] ?? '';
 				} else {
-					$sanitized[ $type ]['secret'] = sanitize_text_field( $input[ $type ]['secret'] );
+					$sanitized[ $type ]['secret'] = $this->sanitize_secret_value( $input[ $type ]['secret'] );
 				}
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,10 @@ When you connect an account, the plugin stores your token and, on import, schedu
 
 * **Letterboxd** — when you paste a Letterboxd link into a watch post, the plugin fetches that page once to identify the film. Only the URL you pasted is requested. [Terms](https://letterboxd.com/legal/terms-of-use/), [Privacy](https://letterboxd.com/legal/privacy-policy/).
 
+= Book previews =
+
+* **Amazon Kindle previews** — when you paste an Amazon or Kindle book link into a read post (or a bulk import creates one), the post can embed that book's preview from read.amazon.com. The preview frame is loaded by the editor's and site visitors' browsers directly from Amazon, with only the book's ID in the URL; the plugin itself sends nothing to Amazon. [Conditions of Use](https://www.amazon.com/gp/help/customer/display.html?nodeId=GLSBYFE9MGKKQXXM), [Privacy Notice](https://www.amazon.com/gp/help/customer/display.html?nodeId=GX7NJQ4ZB8MHFRNJ).
+
 = Inbound webhooks (no data sent) =
 
 Plex, Jellyfin, Trakt, ListenBrainz, and OwnTracks scrobbling works through webhooks: those services send data *to* your site at the secret URL you configure. The plugin makes no outbound request to them for this feature.
@@ -209,6 +213,7 @@ External services contacted (when you use the matching feature):
 * Foursquare — venue information
 * OpenStreetMap / Nominatim — geocoding and map data
 * Letterboxd — fetched when you paste a Letterboxd URL into a Watch Card, to find the matching movie
+* Amazon (read.amazon.com) — Kindle book previews embedded in read posts load in the browser directly from Amazon
 
 Each external service has its own privacy policy. API calls retrieve public metadata for the items you look up.
 

--- a/tests/phpunit/unit/AdminTest.php
+++ b/tests/phpunit/unit/AdminTest.php
@@ -369,18 +369,26 @@ class AdminTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test sanitize_api_credentials strips HTML.
+	 * Test sanitize_api_credentials stores secrets as entered.
+	 *
+	 * Secret fields must not be altered by sanitization (only trimmed and
+	 * stripped of control characters), while non-secret text fields still
+	 * go through sanitize_text_field().
 	 */
-	public function test_sanitize_api_credentials_strips_html(): void {
+	public function test_sanitize_api_credentials_preserves_secrets(): void {
 		$input = [
-			'tmdb' => [
-				'api_key' => '<b>key</b>',
+			'tmdb'   => [
+				'api_key' => " <b>key</b>+/=~\x01 ",
+			],
+			'lastfm' => [
+				'username' => '<b>user</b>',
 			],
 		];
 
 		$result = $this->admin->sanitize_api_credentials( $input );
 
-		$this->assertSame( 'key', $result['tmdb']['api_key'] );
+		$this->assertSame( '<b>key</b>+/=~', $result['tmdb']['api_key'] );
+		$this->assertSame( 'user', $result['lastfm']['username'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes the three issue groups from the wp.org Plugin Review Team round-3 email (Review ID P0TDX289240HGN):

## External services
- **Amazon Kindle previews** (`read.amazon.com`) are now documented in `readme.txt` under **External services** with verified Conditions of Use / Privacy Notice links, and listed in the privacy section. The embed loads in the browser (editor preview + visitor-facing embeds from the read-card block, ISBN helper, and bulk import).
- ListenBrainz was also listed in the email but is already documented (readme line 166) — noted for the reply, no change needed.

## register_setting() sanitization
- New `sanitize_secret_value()`: secrets (API keys, tokens, shared secrets) are stored as entered — trim + control-character strip only — instead of `sanitize_text_field()`, which could alter them.
- Applied to the secret fields in `pkiw_api_credentials` and the webhook `secret` in `pkiw_webhook_settings`; `token_expires` now uses `absint()`; usernames/app fields keep `sanitize_text_field()`, emails keep `sanitize_email()`. Asterisk-placeholder preservation unchanged.

## Ability permission callbacks (per-post capabilities)
The Abilities API passes validated input to `permission_callback`, so:
- `post_kinds/set_kind` and `post_kinds/update_post_meta` → `current_user_can( 'edit_post', $post_id )`
- `post_kinds/get_kind` and `post_kinds/get_post_meta` → `current_user_can( 'read_post', $post_id )` (get_post_meta wasn't flagged but is the same class of issue)
- `post_kinds/create_post` → falls back to draft when the caller lacks `publish_posts`

Local gates: PHPCS 0 errors, PHPStan clean. PHPUnit + e2e run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)