### PR TITLE
🔒 FIX: Same-class review sweep — per-post caps on remaining routes, retire pk_ prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ if ( version_compare( get_bloginfo( 'version' ), '7.0', '>=' ) ) { /* 7.0 code *
 if ( function_exists( 'wp_register_ability' ) ) { /* abilities code */ }
 
 // AI gate pattern (doubly gated)
-if ( function_exists( 'wp_ai_client_prompt' ) && get_option( 'pk_enable_ai' ) ) { /* AI code */ }
+if ( function_exists( 'wp_ai_client_prompt' ) && get_option( 'pkiw_enable_ai' ) ) { /* AI code */ }
 ```
 
 ## Priority Order

--- a/includes/blocks/class-media-stats.php
+++ b/includes/blocks/class-media-stats.php
@@ -174,7 +174,7 @@ final class Media_Stats {
 	 * @return array<string, int> Counts keyed by kind slug.
 	 */
 	private function get_stats( string $period ): array {
-		$cache_key = 'pk_media_stats_' . $period;
+		$cache_key = 'pkiw_media_stats_' . $period;
 		$cached    = get_transient( $cache_key );
 
 		if ( is_array( $cached ) ) {

--- a/includes/class-ai-enhancements.php
+++ b/includes/class-ai-enhancements.php
@@ -3,7 +3,7 @@
  * AI Enhancements (WordPress 7.0+ WP AI Client)
  *
  * Optional AI-powered features using the WordPress AI Client API.
- * Double-gated: requires both wp_ai_client_prompt() and pk_enable_ai setting.
+ * Double-gated: requires both wp_ai_client_prompt() and pkiw_enable_ai setting.
  *
  * Features:
  * - Auto-Populate from URL: Extract title, summary, author from URLs.
@@ -70,11 +70,11 @@ final class AI_Enhancements {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return bool True if both wp_ai_client_prompt exists and pk_enable_ai is true.
+	 * @return bool True if both wp_ai_client_prompt exists and pkiw_enable_ai is true.
 	 */
 	public static function is_available(): bool {
 		return function_exists( 'wp_ai_client_prompt' )
-			&& (bool) get_option( 'pk_enable_ai', false );
+			&& (bool) get_option( 'pkiw_enable_ai', false );
 	}
 
 	/**
@@ -98,8 +98,8 @@ final class AI_Enhancements {
 	 */
 	public function register_setting(): void {
 		register_setting(
-			'pk_settings',
-			'pk_enable_ai',
+			'pkiw_settings',
+			'pkiw_enable_ai',
 			[
 				'type'              => 'boolean',
 				'default'           => false,
@@ -142,8 +142,8 @@ final class AI_Enhancements {
 			[
 				'methods'             => 'POST',
 				'callback'            => [ $this, 'handle_suggest_tags' ],
-				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+				'permission_callback' => function ( \WP_REST_Request $request ) {
+					return current_user_can( 'edit_post', absint( $request->get_param( 'post_id' ) ) );
 				},
 				'args'                => [
 					'post_id' => [
@@ -215,7 +215,7 @@ final class AI_Enhancements {
 
 		if ( ! is_array( $parsed ) ) {
 			return new \WP_Error(
-				'pk_ai_parse_error',
+				'pkiw_ai_parse_error',
 				__( 'Failed to parse AI response.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 500 ]
 			);
@@ -251,7 +251,7 @@ final class AI_Enhancements {
 
 		if ( ! $post ) {
 			return new \WP_Error(
-				'pk_post_not_found',
+				'pkiw_post_not_found',
 				__( 'Post not found.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 404 ]
 			);
@@ -281,7 +281,7 @@ final class AI_Enhancements {
 
 		if ( ! is_array( $tags ) ) {
 			return new \WP_Error(
-				'pk_ai_parse_error',
+				'pkiw_ai_parse_error',
 				__( 'Failed to parse AI response.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 500 ]
 			);
@@ -314,7 +314,7 @@ final class AI_Enhancements {
 
 		if ( ! $post ) {
 			return new \WP_Error(
-				'pk_post_not_found',
+				'pkiw_post_not_found',
 				__( 'Post not found.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 404 ]
 			);
@@ -325,7 +325,7 @@ final class AI_Enhancements {
 
 		if ( ! in_array( $kind, [ 'read', 'watch', 'listen' ], true ) ) {
 			return new \WP_Error(
-				'pk_invalid_kind',
+				'pkiw_invalid_kind',
 				__( 'Content summaries are only available for read, watch, and listen posts.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 400 ]
 			);
@@ -352,7 +352,7 @@ final class AI_Enhancements {
 
 		if ( ! is_array( $prompts ) ) {
 			return new \WP_Error(
-				'pk_ai_parse_error',
+				'pkiw_ai_parse_error',
 				__( 'Failed to parse AI response.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 500 ]
 			);
@@ -375,7 +375,7 @@ final class AI_Enhancements {
 	private function ai_request( string $prompt ) {
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			return new \WP_Error(
-				'pk_ai_unavailable',
+				'pkiw_ai_unavailable',
 				__( 'WP AI Client is not available.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 503 ]
 			);
@@ -395,7 +395,7 @@ final class AI_Enhancements {
 			$this->log_error( 'AI request exception', $e->getMessage() );
 
 			return new \WP_Error(
-				'pk_ai_exception',
+				'pkiw_ai_exception',
 				__( 'AI request failed.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 500 ]
 			);
@@ -412,11 +412,11 @@ final class AI_Enhancements {
 	 */
 	private function check_rate_limit( string $action ) {
 		$user_id       = get_current_user_id();
-		$transient_key = 'pk_ai_rate_' . $action . '_' . $user_id;
+		$transient_key = 'pkiw_ai_rate_' . $action . '_' . $user_id;
 
 		if ( get_transient( $transient_key ) ) {
 			return new \WP_Error(
-				'pk_rate_limited',
+				'pkiw_rate_limited',
 				__( 'Please wait a few seconds before making another AI request.', 'post-kinds-for-indieweb-in-block-themes' ),
 				[ 'status' => 429 ]
 			);

--- a/includes/integrations/class-wp-recipe-maker.php
+++ b/includes/integrations/class-wp-recipe-maker.php
@@ -474,8 +474,8 @@ class WP_Recipe_Maker {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'rest_check_recipe' ],
-				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+				'permission_callback' => function ( \WP_REST_Request $request ) {
+					return current_user_can( 'edit_post', absint( $request['id'] ) );
 				},
 				'args'                => [
 					'id' => [

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -288,7 +288,7 @@ function init(): void {
  * @return void
  */
 function maybe_migrate_option_prefixes(): void {
-	if ( get_option( 'pkiw_prefix_migrated' ) ) {
+	if ( (int) get_option( 'pkiw_prefix_migrated' ) >= 2 ) {
 		return;
 	}
 
@@ -326,7 +326,14 @@ function maybe_migrate_option_prefixes(): void {
 	wp_clear_scheduled_hook( 'post_kinds_indieweb_process_import' );
 	wp_clear_scheduled_hook( 'post_kinds_indieweb_scheduled_sync' );
 
-	update_option( 'pkiw_prefix_migrated', 1, false );
+	// v2: the AI toggle gained the full prefix too.
+	$legacy_ai = get_option( 'pk_enable_ai', null );
+	if ( null !== $legacy_ai && false === get_option( 'pkiw_enable_ai', false ) ) {
+		add_option( 'pkiw_enable_ai', $legacy_ai );
+	}
+	delete_option( 'pk_enable_ai' );
+
+	update_option( 'pkiw_prefix_migrated', 2, false );
 }
 
 // Load helper functions.


### PR DESCRIPTION
Follow-up to #101. The review team's round-3 email lists examples and warns they "may not share all cases of the same issue" — this sweeps both flagged classes across the whole plugin:

## Per-post capability checks (same class as the flagged abilities)
- `/ai/suggest-tags` takes a required `post_id` and reads that post's content — now `current_user_can( 'edit_post', $post_id )` (matches `/ai/content-summary`, fixed in round 2).
- `/post/<id>/has-recipe` (WP Recipe Maker integration) — now `current_user_can( 'edit_post', $id )`.
- Audited every other `register_rest_route` + `wp_register_ability`: lookups/geocode are `edit_posts` with no target post (correct), settings/import/OAuth admin routes are `manage_options`, webhooks use signature/token verification, OAuth callbacks are intentionally `__return_true` with state verification.

## Prefix sweep (same class as round 2's prefix requirement)
- `pk_enable_ai` option → `pkiw_enable_ai`, with a one-time migration (guard option now versioned; re-run is harmless and idempotent).
- `pk_settings` group → `pkiw_settings`; `pk_ai_rate_*` / `pk_media_stats_*` transients → `pkiw_*` (ephemeral, no migration needed); `pk_*` REST error codes → `pkiw_*`.
- Left alone deliberately: block-binding keys (`pk_title`, …) — stored inside post block markup under the plugin's own registered binding source, so renaming breaks existing content and they aren't in WordPress's global namespace.

Local gates: PHPCS clean on changed files, PHPStan level 5 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)