### PR TITLE
🐛 FIX: Register blocks from build/blocks so the distributed zip works

### DIFF
--- a/bin/sync-block-assets.mjs
+++ b/bin/sync-block-assets.mjs
@@ -1,0 +1,30 @@
+/**
+ * Copy per-block runtime assets from src/blocks into build/blocks.
+ *
+ * The plugin registers every block from build/blocks/<block>/block.json so
+ * the shipped zip works without src/. wp-scripts compiles the JS but does
+ * not copy these files, so this runs after each build (see package.json).
+ */
+import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const srcRoot = path.resolve( 'src/blocks' );
+const buildRoot = path.resolve( 'build/blocks' );
+const files = [ 'block.json', 'render.php', 'style.css', 'editor.css' ];
+
+let copied = 0;
+for ( const entry of readdirSync( srcRoot, { withFileTypes: true } ) ) {
+	if ( ! entry.isDirectory() ) {
+		continue;
+	}
+	const outDir = path.join( buildRoot, entry.name );
+	mkdirSync( outDir, { recursive: true } );
+	for ( const file of files ) {
+		const from = path.join( srcRoot, entry.name, file );
+		if ( existsSync( from ) ) {
+			cpSync( from, path.join( outDir, file ) );
+			copied++;
+		}
+	}
+}
+console.log( `sync-block-assets: ${ copied } files copied into build/blocks` );

--- a/build/blocks/acquisition-card/block.json
+++ b/build/blocks/acquisition-card/block.json
@@ -1,104 +1,95 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/acquisition-card",
-  "render": "file:./render.php",
-  "version": "1.0.0",
-  "title": "Acquisition Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display something you acquired or purchased with photo and details.",
-  "keywords": [
-    "acquisition",
-    "purchase",
-    "bought",
-    "got",
-    "haul"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "acquisitionType": {
-      "type": "string",
-      "default": "purchase"
-    },
-    "cost": {
-      "type": "string"
-    },
-    "where": {
-      "type": "string"
-    },
-    "whereUrl": {
-      "type": "string"
-    },
-    "photo": {
-      "type": "string"
-    },
-    "photoAlt": {
-      "type": "string"
-    },
-    "notes": {
-      "type": "string"
-    },
-    "acquiredAt": {
-      "type": "string"
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "New Headphones",
-      "acquisitionType": "purchase",
-      "cost": "$150",
-      "where": "Amazon"
-    }
-  }
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/acquisition-card",
+	"render": "file:./render.php",
+	"version": "1.0.0",
+	"title": "Acquisition Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display something you acquired or purchased with photo and details.",
+	"keywords": ["acquisition", "purchase", "bought", "got", "haul"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"acquisitionType": {
+			"type": "string",
+			"default": "purchase"
+		},
+		"cost": {
+			"type": "string"
+		},
+		"where": {
+			"type": "string"
+		},
+		"whereUrl": {
+			"type": "string"
+		},
+		"photo": {
+			"type": "string"
+		},
+		"photoAlt": {
+			"type": "string"
+		},
+		"notes": {
+			"type": "string"
+		},
+		"acquiredAt": {
+			"type": "string"
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "New Headphones",
+			"acquisitionType": "purchase",
+			"cost": "$150",
+			"where": "Amazon"
+		}
+	}
 }

--- a/build/blocks/bookmark-card/block.json
+++ b/build/blocks/bookmark-card/block.json
@@ -1,100 +1,91 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/bookmark-card",
-  "version": "1.0.0",
-  "title": "Bookmark Card",
-  "category": "post-kinds-indieweb",
-  "description": "Save a link worth returning to, with title, URL, and optional note.",
-  "keywords": [
-    "bookmark",
-    "save",
-    "link",
-    "read later",
-    "favorite"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "url": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
-    "image": {
-      "type": "string"
-    },
-    "imageAlt": {
-      "type": "string"
-    },
-    "author": {
-      "type": "string"
-    },
-    "bookmarkedAt": {
-      "type": "string"
-    },
-    "rel": {
-      "type": "string",
-      "default": ""
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "Great Blog Post",
-      "url": "https://example.com/post",
-      "author": "Jane Doe"
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/bookmark-card",
+	"version": "1.0.0",
+	"title": "Bookmark Card",
+	"category": "post-kinds-indieweb",
+	"description": "Save a link worth returning to, with title, URL, and optional note.",
+	"keywords": ["bookmark", "save", "link", "read later", "favorite"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"url": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"image": {
+			"type": "string"
+		},
+		"imageAlt": {
+			"type": "string"
+		},
+		"author": {
+			"type": "string"
+		},
+		"bookmarkedAt": {
+			"type": "string"
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "Great Blog Post",
+			"url": "https://example.com/post",
+			"author": "Jane Doe"
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/checkin-card/block.json
+++ b/build/blocks/checkin-card/block.json
@@ -1,141 +1,127 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/checkin-card",
-  "version": "1.0.0",
-  "title": "Checkin Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a location checkin with venue details, map, and optional notes.",
-  "keywords": [
-    "checkin",
-    "location",
-    "venue",
-    "place",
-    "map",
-    "travel"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "venueName": {
-      "type": "string"
-    },
-    "venueType": {
-      "type": "string",
-      "default": "place"
-    },
-    "address": {
-      "type": "string"
-    },
-    "locality": {
-      "type": "string"
-    },
-    "region": {
-      "type": "string"
-    },
-    "country": {
-      "type": "string"
-    },
-    "postalCode": {
-      "type": "string"
-    },
-    "latitude": {
-      "type": "number"
-    },
-    "longitude": {
-      "type": "number"
-    },
-    "locationPrivacy": {
-      "type": "string",
-      "default": "approximate",
-      "enum": [
-        "public",
-        "approximate",
-        "private"
-      ]
-    },
-    "osmId": {
-      "type": "string"
-    },
-    "venueUrl": {
-      "type": "string"
-    },
-    "foursquareId": {
-      "type": "string"
-    },
-    "checkinAt": {
-      "type": "string"
-    },
-    "note": {
-      "type": "string"
-    },
-    "photo": {
-      "type": "string"
-    },
-    "photoAlt": {
-      "type": "string"
-    },
-    "showMap": {
-      "type": "boolean",
-      "default": true
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "post-kinds-indieweb/checkin-card",
+    "version": "1.0.0",
+    "title": "Checkin Card",
+    "category": "post-kinds-indieweb",
+    "description": "Display a location checkin with venue details, map, and optional notes.",
+    "keywords": ["checkin", "location", "venue", "place", "map", "travel"],
+    "textdomain": "post-kinds-for-indieweb-in-block-themes",
     "attributes": {
-      "venueName": "Central Park",
-      "venueType": "park",
-      "locality": "New York",
-      "region": "NY",
-      "country": "United States"
-    }
-  },
-  "editorStyle": "file:./editor.css",
-  "render": "file:./render.php"
+        "venueName": {
+            "type": "string"
+        },
+        "venueType": {
+            "type": "string",
+            "default": "place"
+        },
+        "address": {
+            "type": "string"
+        },
+        "locality": {
+            "type": "string"
+        },
+        "region": {
+            "type": "string"
+        },
+        "country": {
+            "type": "string"
+        },
+        "postalCode": {
+            "type": "string"
+        },
+        "latitude": {
+            "type": "number"
+        },
+        "longitude": {
+            "type": "number"
+        },
+        "locationPrivacy": {
+            "type": "string",
+            "default": "approximate",
+            "enum": ["public", "approximate", "private"]
+        },
+        "osmId": {
+            "type": "string"
+        },
+        "venueUrl": {
+            "type": "string"
+        },
+        "foursquareId": {
+            "type": "string"
+        },
+        "checkinAt": {
+            "type": "string"
+        },
+        "note": {
+            "type": "string"
+        },
+        "photo": {
+            "type": "string"
+        },
+        "photoAlt": {
+            "type": "string"
+        },
+        "showMap": {
+            "type": "boolean",
+            "default": true
+        },
+        "layout": {
+            "type": "string",
+            "default": "horizontal"
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"],
+        "color": {
+            "background": true,
+            "text": true,
+            "gradients": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "width": true,
+                "style": true
+            }
+        },
+        "shadow": true,
+        "dimensions": {
+            "minHeight": true
+        }
+    },
+    "example": {
+        "attributes": {
+            "venueName": "Central Park",
+            "venueType": "park",
+            "locality": "New York",
+            "region": "NY",
+            "country": "United States"
+        }
+    },
+    "editorStyle": "file:./editor.css",
+    "render": "file:./render.php"
 }

--- a/build/blocks/checkin-card/editor.css
+++ b/build/blocks/checkin-card/editor.css
@@ -1,0 +1,123 @@
+/**
+ * Checkin Card Block - Editor Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-photo {
+	cursor: pointer;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-photo:hover {
+	opacity: 0.8;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .photo-placeholder {
+	width: 150px;
+	height: 150px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background: var(--pkiw-card-media-button-bg, transparent);
+	border: 2px dashed var(--pkiw-card-media-button-border, transparent);
+	border-radius: 4px;
+	color: var(--pkiw-card-text-secondary, inherit);
+	font-size: 0.75rem;
+	text-align: center;
+	gap: 0.5rem;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .photo-placeholder .venue-icon {
+	font-size: 2rem;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .placeholder-actions {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+
+/* Nearby venues UI */
+.wp-block-post-kinds-indieweb-checkin-card .nearby-venues-label {
+	font-weight: 600;
+	font-size: 0.875rem;
+	color: var(--pkiw-card-fg, inherit);
+	margin: 1rem 0 0.5rem;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-nearby-results {
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .result-distance {
+	font-size: 0.75rem;
+	color: var(--pkiw-card-badge-fg, inherit);
+	background: var(--pkiw-card-badge-bg, transparent);
+	padding: 0.125rem 0.375rem;
+	border-radius: 3px;
+	margin-left: auto;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .result-type {
+	font-size: 0.75rem;
+	color: var(--pkiw-state-info, currentcolor);
+	background: var(--pkiw-card-badge-bg, transparent);
+	padding: 0.125rem 0.375rem;
+	border-radius: 3px;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .loading-nearby {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 1rem;
+	color: var(--pkiw-card-text-secondary, inherit);
+	font-size: 0.875rem;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-result-item {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.25rem;
+	width: 100%;
+	padding: 0.75rem;
+	background: none;
+	border: none;
+	cursor: pointer;
+	text-align: left;
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-result-item:hover {
+	background: var(--pkiw-card-hover-bg, transparent);
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-result-item .result-name {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--pkiw-card-fg, inherit);
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-result-item .result-address {
+	font-size: 0.75rem;
+	color: var(--pkiw-card-text-secondary, inherit);
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-search-results {
+	list-style: none;
+	margin: 0.5rem 0 0;
+	padding: 0;
+	border: 1px solid var(--pkiw-card-border, transparent);
+	border-radius: 4px;
+	background: var(--pkiw-card-bg, transparent);
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-search-results li {
+	border-bottom: 1px solid var(--pkiw-card-border, transparent);
+}
+
+.wp-block-post-kinds-indieweb-checkin-card .checkin-search-results li:last-child {
+	border-bottom: none;
+}

--- a/build/blocks/checkin-dashboard/block.json
+++ b/build/blocks/checkin-dashboard/block.json
@@ -1,53 +1,44 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/checkin-dashboard",
-  "version": "1.0.0",
-  "title": "Check-in Dashboard",
-  "category": "post-kinds-indieweb",
-  "icon": "location",
-  "description": "Display a dashboard of your check-ins with grid, map, and timeline views.",
-  "keywords": [
-    "checkin",
-    "location",
-    "foursquare",
-    "map",
-    "dashboard"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "layout": {
-      "type": "string",
-      "default": "grid"
-    },
-    "showMap": {
-      "type": "boolean",
-      "default": true
-    },
-    "showStats": {
-      "type": "boolean",
-      "default": true
-    },
-    "limit": {
-      "type": "number",
-      "default": 12
-    },
-    "showFilters": {
-      "type": "boolean",
-      "default": false
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "spacing": {
-      "margin": true,
-      "padding": true
-    }
-  },
-  "viewScript": "file:./view.js",
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/checkin-dashboard",
+	"version": "1.0.0",
+	"title": "Check-in Dashboard",
+	"category": "post-kinds-indieweb",
+	"icon": "location",
+	"description": "Display a dashboard of your check-ins with grid, map, and timeline views.",
+	"keywords": [ "checkin", "location", "foursquare", "map", "dashboard" ],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"layout": {
+			"type": "string",
+			"default": "grid"
+		},
+		"showMap": {
+			"type": "boolean",
+			"default": true
+		},
+		"showStats": {
+			"type": "boolean",
+			"default": true
+		},
+		"limit": {
+			"type": "number",
+			"default": 12
+		},
+		"showFilters": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": [ "wide", "full" ],
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"viewScript": "file:./view.js",
+	"render": "file:./render.php"
 }

--- a/build/blocks/checkin-dashboard/style.css
+++ b/build/blocks/checkin-dashboard/style.css
@@ -1,0 +1,358 @@
+/**
+ * Check-in Dashboard Block - Frontend Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+/*
+ * Internal aliases for the public --pkiw-checkin-dashboard-* tokens
+ * (styles/kind-tokens.css). Defaults are neutral; themes paint the
+ * dashboard by setting the --pkiw-* tokens.
+ */
+.checkin-dashboard-frontend {
+	--checkin-primary: var(--pkiw-checkin-dashboard-accent, currentcolor);
+	--checkin-border: var(--pkiw-checkin-dashboard-border, transparent);
+	--checkin-bg: var(--pkiw-checkin-dashboard-bg, transparent);
+	--checkin-surface: var(--pkiw-checkin-dashboard-surface, transparent);
+	--checkin-text: var(--pkiw-checkin-dashboard-fg, inherit);
+	--checkin-text-light: var(--pkiw-checkin-dashboard-fg-muted, inherit);
+}
+
+/* Stats */
+.checkin-dashboard-stats {
+	display: flex;
+	gap: 1rem;
+	margin-bottom: 1.5rem;
+	flex-wrap: wrap;
+}
+
+.checkin-dashboard-stats .stat-item {
+	background: var(--checkin-bg);
+	padding: 1rem 1.5rem;
+	border-radius: 8px;
+	text-align: center;
+}
+
+.checkin-dashboard-stats .stat-value {
+	display: block;
+	font-size: 2rem;
+	font-weight: 700;
+	color: var(--checkin-primary);
+	line-height: 1;
+}
+
+.checkin-dashboard-stats .stat-label {
+	display: block;
+	font-size: 0.75rem;
+	color: var(--checkin-text-light);
+	text-transform: uppercase;
+	margin-top: 0.25rem;
+}
+
+/* Filters */
+.checkin-dashboard-filters {
+	display: flex;
+	gap: 0.5rem;
+	margin-bottom: 1.5rem;
+}
+
+.checkin-dashboard-filters .view-btn {
+	padding: 0.5rem 1rem;
+	border: 1px solid var(--checkin-border);
+	background: var(--checkin-surface);
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 0.875rem;
+	transition: all 0.2s;
+}
+
+.checkin-dashboard-filters .view-btn:hover {
+	background: var(--checkin-bg);
+}
+
+.checkin-dashboard-filters .view-btn.active {
+	background: var(--checkin-primary);
+	border-color: var(--checkin-primary);
+	color: var(--checkin-surface);
+}
+
+/* Views */
+.checkin-dashboard-views [class*="checkin-view-"] {
+	display: none;
+}
+
+.checkin-dashboard-views [class*="checkin-view-"].active {
+	display: block;
+}
+
+/* Grid View */
+.checkin-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: 1.5rem;
+}
+
+.checkin-card {
+	background: var(--checkin-surface);
+	border: 1px solid var(--checkin-border);
+	border-radius: 8px;
+	overflow: hidden;
+	transition: box-shadow 0.2s, transform 0.2s;
+}
+
+.checkin-card:hover {
+	box-shadow: var(--pkiw-checkin-dashboard-hover-shadow, none);
+	transform: translateY(-2px);
+}
+
+.checkin-card-photo {
+	aspect-ratio: 16 / 9;
+	overflow: hidden;
+	background: var(--checkin-bg);
+}
+
+.checkin-card-photo img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.checkin-card-content {
+	padding: 1rem;
+}
+
+.checkin-card-venue {
+	font-size: 1rem;
+	font-weight: 600;
+	margin: 0 0 0.25rem;
+	line-height: 1.3;
+}
+
+.checkin-card-venue a {
+	color: var(--checkin-text);
+	text-decoration: none;
+}
+
+.checkin-card-venue a:hover {
+	color: var(--checkin-primary);
+}
+
+.checkin-card-address {
+	font-size: 0.875rem;
+	color: var(--checkin-text-light);
+	margin: 0 0 0.5rem;
+}
+
+.checkin-card-date {
+	font-size: 0.75rem;
+	color: var(--checkin-text-light);
+}
+
+/* Map View */
+.checkin-map {
+	height: 500px;
+	border-radius: 8px;
+	overflow: hidden;
+}
+
+.checkin-popup strong {
+	display: block;
+	margin-bottom: 0.25rem;
+}
+
+.checkin-popup span {
+	display: block;
+
+	/* Fixed: Leaflet popups are always white, independent of the theme */
+	color: #666;
+	font-size: 0.875rem;
+	margin-bottom: 0.5rem;
+}
+
+/* Timeline View */
+.timeline-group {
+	margin-bottom: 2rem;
+}
+
+.timeline-month {
+	font-size: 1.25rem;
+	font-weight: 600;
+	margin: 0 0 1rem;
+	padding-bottom: 0.5rem;
+	border-bottom: 2px solid var(--checkin-primary);
+}
+
+.timeline-items {
+	position: relative;
+	padding-left: 2rem;
+}
+
+.timeline-items::before {
+	content: "";
+	position: absolute;
+	left: 0.5rem;
+	top: 0;
+	bottom: 0;
+	width: 2px;
+	background: var(--checkin-border);
+}
+
+.timeline-item {
+	position: relative;
+	padding: 0.75rem 0;
+}
+
+.timeline-marker {
+	position: absolute;
+	left: -1.5rem;
+	top: 1rem;
+	width: 10px;
+	height: 10px;
+	background: var(--checkin-primary);
+	border-radius: 50%;
+	border: 2px solid var(--checkin-surface);
+	box-shadow: 0 0 0 2px var(--checkin-primary);
+}
+
+.timeline-content {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+}
+
+.timeline-venue {
+	font-weight: 600;
+	color: var(--checkin-text);
+	text-decoration: none;
+}
+
+.timeline-venue:hover {
+	color: var(--checkin-primary);
+}
+
+.timeline-address {
+	font-size: 0.875rem;
+	color: var(--checkin-text-light);
+}
+
+.timeline-date {
+	font-size: 0.75rem;
+	color: var(--checkin-text-light);
+}
+
+/* Empty State */
+.checkin-empty {
+	text-align: center;
+	padding: 3rem;
+	color: var(--checkin-text-light);
+}
+
+/* Editor Preview Styles */
+.checkin-dashboard-preview {
+	padding: 1rem;
+	background: var(--checkin-bg);
+	border-radius: 8px;
+}
+
+.checkin-stats-preview {
+	display: flex;
+	gap: 1rem;
+	margin-bottom: 1rem;
+}
+
+.checkin-stats-preview .stat-item {
+	background: var(--checkin-surface);
+	padding: 0.75rem 1rem;
+	border-radius: 4px;
+	text-align: center;
+}
+
+.checkin-stats-preview .stat-value {
+	display: block;
+	font-size: 1.5rem;
+	font-weight: 700;
+	color: var(--checkin-primary);
+}
+
+.checkin-stats-preview .stat-label {
+	font-size: 0.625rem;
+	color: var(--checkin-text-light);
+	text-transform: uppercase;
+}
+
+.checkin-grid-preview {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1rem;
+}
+
+.checkin-card-preview {
+	background: var(--checkin-surface);
+	border-radius: 4px;
+	overflow: hidden;
+	border: 1px solid var(--checkin-border);
+}
+
+.checkin-card-preview img {
+	width: 100%;
+	height: 80px;
+	object-fit: cover;
+}
+
+.checkin-card-preview .no-photo {
+	height: 80px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--checkin-bg);
+	color: var(--checkin-text-light);
+}
+
+.checkin-card-info {
+	padding: 0.5rem;
+}
+
+.checkin-card-info strong {
+	display: block;
+	font-size: 0.75rem;
+	line-height: 1.2;
+	margin-bottom: 0.125rem;
+}
+
+.checkin-card-info span {
+	display: block;
+	font-size: 0.625rem;
+	color: var(--checkin-text-light);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.checkin-more {
+	text-align: center;
+	font-size: 0.75rem;
+	color: var(--checkin-text-light);
+	margin: 1rem 0 0;
+}
+
+.checkin-loading {
+	text-align: center;
+	padding: 2rem;
+	color: var(--checkin-text-light);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+
+	.checkin-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.checkin-grid-preview {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	.checkin-dashboard-stats {
+		flex-direction: column;
+	}
+}

--- a/build/blocks/checkins-feed/block.json
+++ b/build/blocks/checkins-feed/block.json
@@ -1,71 +1,62 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/checkins-feed",
-  "version": "1.2.0",
-  "title": "Check-ins Feed",
-  "category": "post-kinds-indieweb",
-  "icon": "location-alt",
-  "description": "Display a feed of recent check-ins with optional map.",
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "keywords": [
-    "checkin",
-    "feed",
-    "location",
-    "map",
-    "venue"
-  ],
-  "attributes": {
-    "count": {
-      "type": "number",
-      "default": 10
-    },
-    "showMap": {
-      "type": "boolean",
-      "default": true
-    },
-    "showVenue": {
-      "type": "boolean",
-      "default": true
-    },
-    "showDate": {
-      "type": "boolean",
-      "default": true
-    },
-    "showExcerpt": {
-      "type": "boolean",
-      "default": false
-    },
-    "venueId": {
-      "type": "number",
-      "default": 0
-    },
-    "layout": {
-      "type": "string",
-      "default": "list"
-    },
-    "columns": {
-      "type": "number",
-      "default": 2
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "spacing": {
-      "margin": true,
-      "padding": true
-    },
-    "color": {
-      "background": true,
-      "text": true
-    },
-    "typography": {
-      "fontSize": true
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/checkins-feed",
+	"version": "1.2.0",
+	"title": "Check-ins Feed",
+	"category": "post-kinds-indieweb",
+	"icon": "location-alt",
+	"description": "Display a feed of recent check-ins with optional map.",
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"keywords": ["checkin", "feed", "location", "map", "venue"],
+	"attributes": {
+		"count": {
+			"type": "number",
+			"default": 10
+		},
+		"showMap": {
+			"type": "boolean",
+			"default": true
+		},
+		"showVenue": {
+			"type": "boolean",
+			"default": true
+		},
+		"showDate": {
+			"type": "boolean",
+			"default": true
+		},
+		"showExcerpt": {
+			"type": "boolean",
+			"default": false
+		},
+		"venueId": {
+			"type": "number",
+			"default": 0
+		},
+		"layout": {
+			"type": "string",
+			"default": "list"
+		},
+		"columns": {
+			"type": "number",
+			"default": 2
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"color": {
+			"background": true,
+			"text": true
+		},
+		"typography": {
+			"fontSize": true
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/checkins-feed/editor.css
+++ b/build/blocks/checkins-feed/editor.css
@@ -1,0 +1,88 @@
+/**
+ * Check-ins Feed Block - Editor Styles
+ */
+
+.checkins-feed {
+	padding: 1rem;
+}
+
+.checkins-feed__map-placeholder {
+	background: var(--pkiw-card-media-button-bg, transparent);
+	border: 2px dashed var(--pkiw-card-media-button-border, transparent);
+	border-radius: 4px;
+	padding: 2rem;
+	margin-bottom: 1rem;
+}
+
+.checkins-feed__map-preview {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
+	color: var(--pkiw-card-text-secondary, inherit);
+}
+
+.checkins-feed__map-preview .dashicons {
+	font-size: 2rem;
+	width: 2rem;
+	height: 2rem;
+}
+
+.checkins-feed__list {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.checkins-feed__list.columns-2,
+.checkins-feed__list.columns-3,
+.checkins-feed__list.columns-4 {
+	display: grid;
+	gap: 1rem;
+}
+
+.checkins-feed__list.columns-2 {
+	grid-template-columns: repeat(2, 1fr);
+}
+
+.checkins-feed__list.columns-3 {
+	grid-template-columns: repeat(3, 1fr);
+}
+
+.checkins-feed__list.columns-4 {
+	grid-template-columns: repeat(4, 1fr);
+}
+
+.checkins-feed__item {
+	background: var(--pkiw-card-bg, transparent);
+	border: 1px solid var(--pkiw-card-border, transparent);
+	border-radius: 4px;
+	padding: 1rem;
+}
+
+.checkins-feed__title {
+	margin: 0 0 0.5rem;
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.checkins-feed__venue {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+	font-size: 0.875rem;
+	color: var(--pkiw-card-text-secondary, inherit);
+	margin-bottom: 0.25rem;
+}
+
+.checkins-feed__date {
+	font-size: 0.75rem;
+	color: var(--pkiw-card-text-secondary, inherit);
+}
+
+.checkins-feed__excerpt {
+	margin-top: 0.5rem;
+	font-size: 0.875rem;
+	color: var(--pkiw-card-fg, inherit);
+}

--- a/build/blocks/checkins-feed/style.css
+++ b/build/blocks/checkins-feed/style.css
@@ -1,0 +1,165 @@
+/**
+ * Check-ins Feed Block - Frontend Styles
+ */
+
+.checkins-feed {
+	--checkins-gap: 1rem;
+}
+
+.checkins-feed__map {
+	width: 100%;
+	height: 300px;
+	background: var(--pkiw-checkin-map-bg, transparent);
+	border-radius: 8px;
+	margin-bottom: var(--checkins-gap);
+	overflow: hidden;
+}
+
+.checkins-feed__map-fallback {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--pkiw-checkins-feed-muted, inherit);
+	margin: 0;
+}
+
+.checkins-feed__list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--checkins-gap);
+}
+
+/* Grid layout */
+.checkins-feed.layout-grid .checkins-feed__list {
+	display: grid;
+	gap: var(--checkins-gap);
+}
+
+.checkins-feed.layout-grid.columns-2 .checkins-feed__list {
+	grid-template-columns: repeat(2, 1fr);
+}
+
+.checkins-feed.layout-grid.columns-3 .checkins-feed__list {
+	grid-template-columns: repeat(3, 1fr);
+}
+
+.checkins-feed.layout-grid.columns-4 .checkins-feed__list {
+	grid-template-columns: repeat(4, 1fr);
+}
+
+@media (max-width: 768px) {
+
+	.checkins-feed.layout-grid .checkins-feed__list {
+		grid-template-columns: 1fr;
+	}
+}
+
+/* List item */
+.checkins-feed__item {
+	display: flex;
+	gap: 1rem;
+	padding: 1rem;
+	background: var(--pkiw-checkins-feed-item-bg, transparent);
+	border: 1px solid var(--pkiw-checkins-feed-border, transparent);
+	border-radius: 8px;
+	transition: box-shadow 0.2s ease;
+}
+
+.checkins-feed__item:hover {
+	box-shadow: var(--pkiw-checkins-feed-hover-shadow, none);
+}
+
+/* Compact layout */
+.checkins-feed.layout-compact .checkins-feed__item {
+	padding: 0.75rem;
+	gap: 0.75rem;
+}
+
+/* Thumbnail */
+.checkins-feed__thumbnail {
+	flex-shrink: 0;
+}
+
+.checkins-feed__thumbnail img {
+	width: 80px;
+	height: 80px;
+	object-fit: cover;
+	border-radius: 4px;
+}
+
+.checkins-feed.layout-compact .checkins-feed__thumbnail img {
+	width: 48px;
+	height: 48px;
+}
+
+.checkins-feed.layout-grid .checkins-feed__thumbnail img {
+	width: 100%;
+	height: 150px;
+}
+
+/* Content */
+.checkins-feed__content {
+	flex: 1;
+	min-width: 0;
+}
+
+.checkins-feed__title {
+	margin: 0 0 0.25rem;
+	font-size: var(--wp--preset--font-size--medium, 1rem);
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.checkins-feed__title a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.checkins-feed__title a:hover {
+	text-decoration: underline;
+}
+
+.checkins-feed__venue {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+	font-size: var(--wp--preset--font-size--small, 0.875rem);
+	color: var(--pkiw-checkins-feed-muted, inherit);
+	margin-bottom: 0.25rem;
+}
+
+.checkins-feed__venue-icon {
+	flex-shrink: 0;
+}
+
+.checkins-feed__date {
+	display: block;
+	font-size: var(--wp--preset--font-size--small, 0.75rem);
+	color: var(--pkiw-checkins-feed-muted, inherit);
+	opacity: 0.8;
+}
+
+.checkins-feed__excerpt {
+	margin-top: 0.5rem;
+	font-size: var(--wp--preset--font-size--small, 0.875rem);
+	color: var(--pkiw-checkins-feed-fg, inherit);
+}
+
+.checkins-feed__excerpt p {
+	margin: 0;
+}
+
+/* Empty state */
+.checkins-feed__empty {
+	text-align: center;
+	padding: 2rem;
+	color: var(--pkiw-checkins-feed-muted, inherit);
+	background: var(--pkiw-checkins-feed-empty-bg, transparent);
+	border-radius: 8px;
+}
+
+/* Hidden microformat data */
+[hidden] {
+	display: none !important;
+}

--- a/build/blocks/drink-card/block.json
+++ b/build/blocks/drink-card/block.json
@@ -1,129 +1,119 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/drink-card",
-  "version": "1.0.0",
-  "title": "Drink Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a drink you had with photo, type, brand, and rating.",
-  "keywords": [
-    "drink",
-    "beverage",
-    "coffee",
-    "beer",
-    "wine",
-    "cocktail"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "name": {
-      "type": "string"
-    },
-    "drinkType": {
-      "type": "string",
-      "default": "coffee"
-    },
-    "brand": {
-      "type": "string"
-    },
-    "photo": {
-      "type": "string"
-    },
-    "photoAlt": {
-      "type": "string"
-    },
-    "rating": {
-      "type": "number",
-      "default": 0
-    },
-    "drankAt": {
-      "type": "string"
-    },
-    "notes": {
-      "type": "string"
-    },
-    "venueUrl": {
-      "type": "string"
-    },
-    "locationName": {
-      "type": "string"
-    },
-    "locationAddress": {
-      "type": "string"
-    },
-    "locationLocality": {
-      "type": "string"
-    },
-    "locationRegion": {
-      "type": "string"
-    },
-    "locationCountry": {
-      "type": "string"
-    },
-    "geoLatitude": {
-      "type": "number",
-      "default": 0
-    },
-    "geoLongitude": {
-      "type": "number",
-      "default": 0
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "name": "Flat White",
-      "drinkType": "coffee",
-      "brand": "Blue Bottle",
-      "rating": 4
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/drink-card",
+	"version": "1.0.0",
+	"title": "Drink Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display a drink you had with photo, type, brand, and rating.",
+	"keywords": ["drink", "beverage", "coffee", "beer", "wine", "cocktail"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"name": {
+			"type": "string"
+		},
+		"drinkType": {
+			"type": "string",
+			"default": "coffee"
+		},
+		"brand": {
+			"type": "string"
+		},
+		"photo": {
+			"type": "string"
+		},
+		"photoAlt": {
+			"type": "string"
+		},
+		"rating": {
+			"type": "number",
+			"default": 0
+		},
+		"drankAt": {
+			"type": "string"
+		},
+		"notes": {
+			"type": "string"
+		},
+		"venueUrl": {
+			"type": "string"
+		},
+		"locationName": {
+			"type": "string"
+		},
+		"locationAddress": {
+			"type": "string"
+		},
+		"locationLocality": {
+			"type": "string"
+		},
+		"locationRegion": {
+			"type": "string"
+		},
+		"locationCountry": {
+			"type": "string"
+		},
+		"geoLatitude": {
+			"type": "number",
+			"default": 0
+		},
+		"geoLongitude": {
+			"type": "number",
+			"default": 0
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"name": "Flat White",
+			"drinkType": "coffee",
+			"brand": "Blue Bottle",
+			"rating": 4
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/eat-card/block.json
+++ b/build/blocks/eat-card/block.json
@@ -1,127 +1,118 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/eat-card",
-  "version": "1.0.0",
-  "title": "Eat Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a meal or food you ate with photo, restaurant, cuisine, and rating.",
-  "keywords": [
-    "eat",
-    "food",
-    "meal",
-    "restaurant",
-    "dining"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "name": {
-      "type": "string"
-    },
-    "restaurant": {
-      "type": "string"
-    },
-    "cuisine": {
-      "type": "string"
-    },
-    "photo": {
-      "type": "string"
-    },
-    "photoAlt": {
-      "type": "string"
-    },
-    "rating": {
-      "type": "number",
-      "default": 0
-    },
-    "ateAt": {
-      "type": "string"
-    },
-    "notes": {
-      "type": "string"
-    },
-    "restaurantUrl": {
-      "type": "string"
-    },
-    "locationName": {
-      "type": "string"
-    },
-    "locationAddress": {
-      "type": "string"
-    },
-    "locationLocality": {
-      "type": "string"
-    },
-    "locationRegion": {
-      "type": "string"
-    },
-    "locationCountry": {
-      "type": "string"
-    },
-    "geoLatitude": {
-      "type": "number",
-      "default": 0
-    },
-    "geoLongitude": {
-      "type": "number",
-      "default": 0
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "name": "Margherita Pizza",
-      "restaurant": "Pizzeria Napoletana",
-      "cuisine": "Italian",
-      "rating": 5
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/eat-card",
+	"version": "1.0.0",
+	"title": "Eat Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display a meal or food you ate with photo, restaurant, cuisine, and rating.",
+	"keywords": ["eat", "food", "meal", "restaurant", "dining"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"name": {
+			"type": "string"
+		},
+		"restaurant": {
+			"type": "string"
+		},
+		"cuisine": {
+			"type": "string"
+		},
+		"photo": {
+			"type": "string"
+		},
+		"photoAlt": {
+			"type": "string"
+		},
+		"rating": {
+			"type": "number",
+			"default": 0
+		},
+		"ateAt": {
+			"type": "string"
+		},
+		"notes": {
+			"type": "string"
+		},
+		"restaurantUrl": {
+			"type": "string"
+		},
+		"locationName": {
+			"type": "string"
+		},
+		"locationAddress": {
+			"type": "string"
+		},
+		"locationLocality": {
+			"type": "string"
+		},
+		"locationRegion": {
+			"type": "string"
+		},
+		"locationCountry": {
+			"type": "string"
+		},
+		"geoLatitude": {
+			"type": "number",
+			"default": 0
+		},
+		"geoLongitude": {
+			"type": "number",
+			"default": 0
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"name": "Margherita Pizza",
+			"restaurant": "Pizzeria Napoletana",
+			"cuisine": "Italian",
+			"rating": 5
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/favorite-card/block.json
+++ b/build/blocks/favorite-card/block.json
@@ -1,99 +1,91 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/favorite-card",
-  "render": "file:./render.php",
-  "version": "1.0.0",
-  "title": "Favorite Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display something you favorited with title, URL, and description.",
-  "keywords": [
-    "favorite",
-    "star",
-    "like",
-    "bookmark"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "url": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
-    "image": {
-      "type": "string"
-    },
-    "imageAlt": {
-      "type": "string"
-    },
-    "author": {
-      "type": "string"
-    },
-    "favoritedAt": {
-      "type": "string"
-    },
-    "rel": {
-      "type": "string",
-      "default": ""
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "Amazing Blog Post",
-      "url": "https://example.com/post",
-      "author": "Jane Doe"
-    }
-  }
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/favorite-card",
+	"render": "file:./render.php",
+	"version": "1.0.0",
+	"title": "Favorite Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display something you favorited with title, URL, and description.",
+	"keywords": ["favorite", "star", "like", "bookmark"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"url": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"image": {
+			"type": "string"
+		},
+		"imageAlt": {
+			"type": "string"
+		},
+		"author": {
+			"type": "string"
+		},
+		"favoritedAt": {
+			"type": "string"
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "Amazing Blog Post",
+			"url": "https://example.com/post",
+			"author": "Jane Doe"
+		}
+	}
 }

--- a/build/blocks/jam-card/block.json
+++ b/build/blocks/jam-card/block.json
@@ -1,102 +1,94 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/jam-card",
-  "version": "1.0.0",
-  "title": "Jam Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a song you're jamming to with cover art and artist.",
-  "keywords": [
-    "jam",
-    "music",
-    "song",
-    "currently playing"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "artist": {
-      "type": "string"
-    },
-    "album": {
-      "type": "string"
-    },
-    "cover": {
-      "type": "string"
-    },
-    "coverAlt": {
-      "type": "string"
-    },
-    "url": {
-      "type": "string"
-    },
-    "note": {
-      "type": "string"
-    },
-    "jammedAt": {
-      "type": "string"
-    },
-    "rel": {
-      "type": "string",
-      "default": ""
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "Bohemian Rhapsody",
-      "artist": "Queen",
-      "album": "A Night at the Opera"
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/jam-card",
+	"version": "1.0.0",
+	"title": "Jam Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display a song you're jamming to with cover art and artist.",
+	"keywords": ["jam", "music", "song", "currently playing"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"artist": {
+			"type": "string"
+		},
+		"album": {
+			"type": "string"
+		},
+		"cover": {
+			"type": "string"
+		},
+		"coverAlt": {
+			"type": "string"
+		},
+		"url": {
+			"type": "string"
+		},
+		"note": {
+			"type": "string"
+		},
+		"jammedAt": {
+			"type": "string"
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "Bohemian Rhapsody",
+			"artist": "Queen",
+			"album": "A Night at the Opera"
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/like-card/block.json
+++ b/build/blocks/like-card/block.json
@@ -1,100 +1,91 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/like-card",
-  "version": "1.0.0",
-  "title": "Like Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a like reaction to content you appreciated, with title, URL, and optional note.",
-  "keywords": [
-    "like",
-    "heart",
-    "appreciate",
-    "love",
-    "reaction"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "url": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
-    "image": {
-      "type": "string"
-    },
-    "imageAlt": {
-      "type": "string"
-    },
-    "author": {
-      "type": "string"
-    },
-    "likedAt": {
-      "type": "string"
-    },
-    "rel": {
-      "type": "string",
-      "default": ""
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "Great Blog Post",
-      "url": "https://example.com/post",
-      "author": "Jane Doe"
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/like-card",
+	"version": "1.0.0",
+	"title": "Like Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display a like reaction to content you appreciated, with title, URL, and optional note.",
+	"keywords": ["like", "heart", "appreciate", "love", "reaction"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"url": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"image": {
+			"type": "string"
+		},
+		"imageAlt": {
+			"type": "string"
+		},
+		"author": {
+			"type": "string"
+		},
+		"likedAt": {
+			"type": "string"
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "Great Blog Post",
+			"url": "https://example.com/post",
+			"author": "Jane Doe"
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/listen-card/block.json
+++ b/build/blocks/listen-card/block.json
@@ -1,111 +1,100 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/listen-card",
-  "version": "1.0.0",
-  "title": "Listen Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a listen/scrobble with track, artist, and album information.",
-  "keywords": [
-    "listen",
-    "music",
-    "scrobble",
-    "track",
-    "song",
-    "album",
-    "artist"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "trackTitle": {
-      "type": "string"
-    },
-    "artistName": {
-      "type": "string"
-    },
-    "albumTitle": {
-      "type": "string"
-    },
-    "releaseDate": {
-      "type": "string"
-    },
-    "coverImage": {
-      "type": "string"
-    },
-    "coverImageAlt": {
-      "type": "string"
-    },
-    "listenUrl": {
-      "type": "string"
-    },
-    "musicbrainzId": {
-      "type": "string"
-    },
-    "rating": {
-      "type": "number",
-      "default": 0
-    },
-    "listenedAt": {
-      "type": "string"
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "post-kinds-indieweb/listen-card",
+    "version": "1.0.0",
+    "title": "Listen Card",
+    "category": "post-kinds-indieweb",
+    "description": "Display a listen/scrobble with track, artist, and album information.",
+    "keywords": ["listen", "music", "scrobble", "track", "song", "album", "artist"],
+    "textdomain": "post-kinds-for-indieweb-in-block-themes",
     "attributes": {
-      "trackTitle": "Bohemian Rhapsody",
-      "artistName": "Queen",
-      "albumTitle": "A Night at the Opera",
-      "releaseDate": "1975-10-31",
-      "rating": 5
-    }
-  },
-  "editorStyle": "file:./editor.css",
-  "render": "file:./render.php"
+        "trackTitle": {
+            "type": "string"
+        },
+        "artistName": {
+            "type": "string"
+        },
+        "albumTitle": {
+            "type": "string"
+        },
+        "releaseDate": {
+            "type": "string"
+        },
+        "coverImage": {
+            "type": "string"
+        },
+        "coverImageAlt": {
+            "type": "string"
+        },
+        "listenUrl": {
+            "type": "string"
+        },
+        "musicbrainzId": {
+            "type": "string"
+        },
+        "rating": {
+            "type": "number",
+            "default": 0
+        },
+        "listenedAt": {
+            "type": "string"
+        },
+        "layout": {
+            "type": "string",
+            "default": "horizontal"
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"],
+        "color": {
+            "background": true,
+            "text": true,
+            "gradients": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "width": true,
+                "style": true
+            }
+        },
+        "shadow": true,
+        "dimensions": {
+            "minHeight": true
+        }
+    },
+    "example": {
+        "attributes": {
+            "trackTitle": "Bohemian Rhapsody",
+            "artistName": "Queen",
+            "albumTitle": "A Night at the Opera",
+            "releaseDate": "1975-10-31",
+            "rating": 5
+        }
+    },
+    "editorStyle": "file:./editor.css",
+    "render": "file:./render.php"
 }

--- a/build/blocks/listen-card/editor.css
+++ b/build/blocks/listen-card/editor.css
@@ -1,0 +1,53 @@
+/**
+ * Listen Card Block - Editor Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+.wp-block-post-kinds-indieweb-listen-card {
+
+	/* Editor-specific overrides */
+}
+
+.wp-block-post-kinds-indieweb-listen-card .post-kinds-card__media {
+	cursor: pointer;
+}
+
+.wp-block-post-kinds-indieweb-listen-card .post-kinds-card__media:hover {
+	opacity: 0.8;
+}
+
+.wp-block-post-kinds-indieweb-listen-card .cover-placeholder {
+	width: 120px;
+	height: 120px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background: var(--pkiw-card-media-button-bg, transparent);
+	border: 2px dashed var(--pkiw-card-media-button-border, transparent);
+	border-radius: 4px;
+	color: var(--pkiw-card-text-secondary, inherit);
+	font-size: 0.8rem;
+	text-align: center;
+	gap: 0.5rem;
+}
+
+.wp-block-post-kinds-indieweb-listen-card .cover-placeholder .cover-icon {
+	font-size: 2rem;
+}
+
+/* Search mode styling */
+.wp-block-post-kinds-indieweb-listen-card .search-mode {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: 100%;
+	max-width: 400px;
+}
+
+.wp-block-post-kinds-indieweb-listen-card .placeholder-actions {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}

--- a/build/blocks/media-lookup/block.json
+++ b/build/blocks/media-lookup/block.json
@@ -1,82 +1,71 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/media-lookup",
-  "version": "1.0.0",
-  "title": "Media Lookup",
-  "category": "post-kinds-indieweb",
-  "description": "Search and embed media info from external APIs (books, movies, music).",
-  "keywords": [
-    "lookup",
-    "search",
-    "media",
-    "book",
-    "movie",
-    "music",
-    "api"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "mediaType": {
-      "type": "string",
-      "default": "book"
-    },
-    "searchQuery": {
-      "type": "string"
-    },
-    "selectedItem": {
-      "type": "object"
-    },
-    "displayStyle": {
-      "type": "string",
-      "default": "card"
-    },
-    "showImage": {
-      "type": "boolean",
-      "default": true
-    },
-    "showDescription": {
-      "type": "boolean",
-      "default": true
-    },
-    "linkToSource": {
-      "type": "boolean",
-      "default": true
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true
-    },
-    "typography": {
-      "fontSize": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true
-    }
-  },
-  "example": {
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "post-kinds-indieweb/media-lookup",
+    "version": "1.0.0",
+    "title": "Media Lookup",
+    "category": "post-kinds-indieweb",
+    "description": "Search and embed media info from external APIs (books, movies, music).",
+    "keywords": ["lookup", "search", "media", "book", "movie", "music", "api"],
+    "textdomain": "post-kinds-for-indieweb-in-block-themes",
     "attributes": {
-      "mediaType": "book",
-      "selectedItem": {
-        "title": "The Great Gatsby",
-        "author": "F. Scott Fitzgerald",
-        "year": "1925"
-      }
-    }
-  },
-  "editorStyle": "file:./editor.css",
-  "style": "file:./style.css"
+        "mediaType": {
+            "type": "string",
+            "default": "book"
+        },
+        "searchQuery": {
+            "type": "string"
+        },
+        "selectedItem": {
+            "type": "object"
+        },
+        "displayStyle": {
+            "type": "string",
+            "default": "card"
+        },
+        "showImage": {
+            "type": "boolean",
+            "default": true
+        },
+        "showDescription": {
+            "type": "boolean",
+            "default": true
+        },
+        "linkToSource": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"],
+        "color": {
+            "background": true,
+            "text": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "width": true
+        }
+    },
+    "example": {
+        "attributes": {
+            "mediaType": "book",
+            "selectedItem": {
+                "title": "The Great Gatsby",
+                "author": "F. Scott Fitzgerald",
+                "year": "1925"
+            }
+        }
+    },
+    "editorStyle": "file:./editor.css",
+    "style": "file:./style.css"
 }

--- a/build/blocks/media-lookup/editor.css
+++ b/build/blocks/media-lookup/editor.css
@@ -1,0 +1,50 @@
+/**
+ * Media Lookup Block - Editor Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+.wp-block-post-kinds-indieweb-media-lookup .media-lookup-search {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: 100%;
+	max-width: 400px;
+}
+
+.wp-block-post-kinds-indieweb-media-lookup .media-type-selector {
+	display: flex;
+	gap: 0.5rem;
+	margin-bottom: 0.5rem;
+}
+
+.wp-block-post-kinds-indieweb-media-lookup .media-item-preview {
+	display: flex;
+	gap: 1rem;
+	position: relative;
+}
+
+.wp-block-post-kinds-indieweb-media-lookup .media-item-preview .clear-selection {
+	position: absolute;
+	top: 0;
+	right: 0;
+}
+
+.wp-block-post-kinds-indieweb-media-lookup .media-source {
+	margin-top: 0.5rem;
+}
+
+.wp-block-post-kinds-indieweb-media-lookup .source-label {
+	font-size: 0.75rem;
+	color: var(--pkiw-card-text-secondary, inherit);
+	font-style: italic;
+}
+
+.wp-block-post-kinds-indieweb-media-lookup .selected-item-details {
+	font-size: 0.85rem;
+	margin: 0.5rem 0;
+}
+
+.wp-block-post-kinds-indieweb-media-lookup .selected-item-details p {
+	margin: 0.25rem 0;
+}

--- a/build/blocks/media-lookup/style.css
+++ b/build/blocks/media-lookup/style.css
@@ -1,0 +1,140 @@
+/**
+ * Media Lookup Block - Frontend Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+.wp-block-post-kinds-indieweb-media-lookup {
+	--media-lookup-gap: 1rem;
+	--media-lookup-radius: 8px;
+}
+
+.media-lookup-inner {
+	display: flex;
+	gap: var(--media-lookup-gap);
+	background: var(--pkiw-media-lookup-bg, transparent);
+	border: 1px solid var(--pkiw-media-lookup-border, transparent);
+	border-radius: var(--media-lookup-radius);
+	padding: 1rem;
+}
+
+/* Style variations */
+.media-lookup-block.style-card .media-lookup-inner {
+	flex-direction: row;
+}
+
+.media-lookup-block.style-inline .media-lookup-inner {
+	flex-direction: row;
+	padding: 0.5rem 0.75rem;
+	border: none;
+	background: transparent;
+}
+
+.media-lookup-block.style-compact .media-lookup-inner {
+	flex-direction: row;
+	padding: 0.5rem;
+	align-items: center;
+}
+
+/* Media image */
+.media-lookup-block .media-image {
+	flex-shrink: 0;
+}
+
+.media-lookup-block .media-image img {
+	width: 80px;
+	height: auto;
+	object-fit: cover;
+	border-radius: calc(var(--media-lookup-radius) / 2);
+}
+
+.media-lookup-block.type-book .media-image img {
+	aspect-ratio: 2/3;
+}
+
+.media-lookup-block.type-movie .media-image img {
+	aspect-ratio: 2/3;
+}
+
+.media-lookup-block.type-music .media-image img {
+	aspect-ratio: 1;
+}
+
+.media-lookup-block.style-inline .media-image img {
+	width: 40px;
+}
+
+.media-lookup-block.style-compact .media-image img {
+	width: 50px;
+}
+
+/* Media info */
+.media-lookup-block .media-info {
+	flex: 1;
+	min-width: 0;
+}
+
+/* Media title */
+.media-lookup-block .media-title {
+	margin: 0 0 0.25rem;
+	font-size: 1rem;
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.media-lookup-block.style-inline .media-title {
+	display: inline;
+	font-size: inherit;
+	font-weight: 600;
+}
+
+.media-lookup-block .media-title a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.media-lookup-block .media-title a:hover {
+	text-decoration: underline;
+}
+
+/* Media subtitle (author/artist/director) */
+.media-lookup-block .media-subtitle {
+	margin: 0 0 0.25rem;
+	font-size: 0.9rem;
+	color: var(--pkiw-media-lookup-muted, inherit);
+}
+
+.media-lookup-block.style-inline .media-subtitle {
+	display: inline;
+	font-size: inherit;
+}
+
+.media-lookup-block.style-inline .media-subtitle::before {
+	content: " by ";
+	font-weight: 400;
+}
+
+/* Year */
+.media-lookup-block .media-year {
+	font-size: 0.85rem;
+	color: var(--pkiw-media-lookup-muted, inherit);
+}
+
+/* Description */
+.media-lookup-block .media-description {
+	font-size: 0.85rem;
+	color: var(--pkiw-media-lookup-muted, inherit);
+	line-height: 1.5;
+	margin: 0.5rem 0;
+}
+
+/* Additional meta */
+.media-lookup-block .media-meta {
+	font-size: 0.8rem;
+	color: var(--pkiw-media-lookup-muted, inherit);
+	margin-top: 0.5rem;
+}
+
+.media-lookup-block .media-meta span {
+	margin-right: 0.75rem;
+}

--- a/build/blocks/mood-card/block.json
+++ b/build/blocks/mood-card/block.json
@@ -1,91 +1,83 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/mood-card",
-  "version": "1.0.0",
-  "title": "Mood Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display your current mood with emoji and note.",
-  "keywords": [
-    "mood",
-    "feeling",
-    "emotion",
-    "status"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "mood": {
-      "type": "string"
-    },
-    "emoji": {
-      "type": "string",
-      "default": ""
-    },
-    "note": {
-      "type": "string"
-    },
-    "intensity": {
-      "type": "number",
-      "default": 3
-    },
-    "moodAt": {
-      "type": "string"
-    },
-    "layout": {
-      "type": "string",
-      "default": "compact"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "mood": "Happy",
-      "emoji": "😊",
-      "intensity": 4
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/mood-card",
+	"version": "1.0.0",
+	"title": "Mood Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display your current mood with emoji and note.",
+	"keywords": ["mood", "feeling", "emotion", "status"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"mood": {
+			"type": "string"
+		},
+		"emoji": {
+			"type": "string",
+			"default": ""
+		},
+		"note": {
+			"type": "string"
+		},
+		"intensity": {
+			"type": "number",
+			"default": 3
+		},
+		"moodAt": {
+			"type": "string"
+		},
+		"layout": {
+			"type": "string",
+			"default": "compact"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"mood": "Happy",
+			"emoji": "😊",
+			"intensity": 4
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/play-card/block.json
+++ b/build/blocks/play-card/block.json
@@ -1,132 +1,117 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/play-card",
-  "version": "1.0.0",
-  "title": "Play Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a game you played with cover art, platform, status, and rating.",
-  "keywords": [
-    "play",
-    "game",
-    "gaming",
-    "video game",
-    "board game"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "platform": {
-      "type": "string"
-    },
-    "cover": {
-      "type": "string"
-    },
-    "coverAlt": {
-      "type": "string"
-    },
-    "status": {
-      "type": "string",
-      "default": "playing",
-      "enum": [
-        "playing",
-        "completed",
-        "abandoned",
-        "backlog",
-        "wishlist"
-      ]
-    },
-    "hoursPlayed": {
-      "type": "number",
-      "default": 0
-    },
-    "rating": {
-      "type": "number",
-      "default": 0
-    },
-    "playedAt": {
-      "type": "string"
-    },
-    "review": {
-      "type": "string"
-    },
-    "gameUrl": {
-      "type": "string"
-    },
-    "bggId": {
-      "type": "string"
-    },
-    "rawgId": {
-      "type": "string"
-    },
-    "steamId": {
-      "type": "string"
-    },
-    "officialUrl": {
-      "type": "string"
-    },
-    "purchaseUrl": {
-      "type": "string"
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "The Legend of Zelda: Breath of the Wild",
-      "platform": "Nintendo Switch",
-      "status": "completed",
-      "rating": 5,
-      "hoursPlayed": 120
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/play-card",
+	"version": "1.0.0",
+	"title": "Play Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display a game you played with cover art, platform, status, and rating.",
+	"keywords": ["play", "game", "gaming", "video game", "board game"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"platform": {
+			"type": "string"
+		},
+		"cover": {
+			"type": "string"
+		},
+		"coverAlt": {
+			"type": "string"
+		},
+		"status": {
+			"type": "string",
+			"default": "playing",
+			"enum": ["playing", "completed", "abandoned", "backlog", "wishlist"]
+		},
+		"hoursPlayed": {
+			"type": "number",
+			"default": 0
+		},
+		"rating": {
+			"type": "number",
+			"default": 0
+		},
+		"playedAt": {
+			"type": "string"
+		},
+		"review": {
+			"type": "string"
+		},
+		"gameUrl": {
+			"type": "string"
+		},
+		"bggId": {
+			"type": "string"
+		},
+		"rawgId": {
+			"type": "string"
+		},
+		"steamId": {
+			"type": "string"
+		},
+		"officialUrl": {
+			"type": "string"
+		},
+		"purchaseUrl": {
+			"type": "string"
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "The Legend of Zelda: Breath of the Wild",
+			"platform": "Nintendo Switch",
+			"status": "completed",
+			"rating": 5,
+			"hoursPlayed": 120
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/read-card/block.json
+++ b/build/blocks/read-card/block.json
@@ -1,128 +1,118 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/read-card",
-  "version": "1.0.0",
-  "title": "Read Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a book you're reading or have read with cover, author, and progress.",
-  "keywords": [
-    "read",
-    "book",
-    "reading",
-    "author",
-    "isbn",
-    "library"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "bookTitle": {
-      "type": "string"
-    },
-    "authorName": {
-      "type": "string"
-    },
-    "isbn": {
-      "type": "string"
-    },
-    "publisher": {
-      "type": "string"
-    },
-    "publishDate": {
-      "type": "string"
-    },
-    "pageCount": {
-      "type": "number"
-    },
-    "currentPage": {
-      "type": "number"
-    },
-    "coverImage": {
-      "type": "string"
-    },
-    "coverImageAlt": {
-      "type": "string"
-    },
-    "bookUrl": {
-      "type": "string"
-    },
-    "openlibraryId": {
-      "type": "string"
-    },
-    "readStatus": {
-      "type": "string",
-      "default": "reading"
-    },
-    "rating": {
-      "type": "number",
-      "default": 0
-    },
-    "startedAt": {
-      "type": "string"
-    },
-    "finishedAt": {
-      "type": "string"
-    },
-    "review": {
-      "type": "string"
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "post-kinds-indieweb/read-card",
+    "version": "1.0.0",
+    "title": "Read Card",
+    "category": "post-kinds-indieweb",
+    "description": "Display a book you're reading or have read with cover, author, and progress.",
+    "keywords": ["read", "book", "reading", "author", "isbn", "library"],
+    "textdomain": "post-kinds-for-indieweb-in-block-themes",
     "attributes": {
-      "bookTitle": "The Hitchhiker's Guide to the Galaxy",
-      "authorName": "Douglas Adams",
-      "readStatus": "finished",
-      "rating": 5
-    }
-  },
-  "editorStyle": "file:./editor.css",
-  "render": "file:./render.php"
+        "bookTitle": {
+            "type": "string"
+        },
+        "authorName": {
+            "type": "string"
+        },
+        "isbn": {
+            "type": "string"
+        },
+        "publisher": {
+            "type": "string"
+        },
+        "publishDate": {
+            "type": "string"
+        },
+        "pageCount": {
+            "type": "number"
+        },
+        "currentPage": {
+            "type": "number"
+        },
+        "coverImage": {
+            "type": "string"
+        },
+        "coverImageAlt": {
+            "type": "string"
+        },
+        "bookUrl": {
+            "type": "string"
+        },
+        "openlibraryId": {
+            "type": "string"
+        },
+        "readStatus": {
+            "type": "string",
+            "default": "reading"
+        },
+        "rating": {
+            "type": "number",
+            "default": 0
+        },
+        "startedAt": {
+            "type": "string"
+        },
+        "finishedAt": {
+            "type": "string"
+        },
+        "review": {
+            "type": "string"
+        },
+        "layout": {
+            "type": "string",
+            "default": "horizontal"
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"],
+        "color": {
+            "background": true,
+            "text": true,
+            "gradients": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "width": true,
+                "style": true
+            }
+        },
+        "shadow": true,
+        "dimensions": {
+            "minHeight": true
+        }
+    },
+    "example": {
+        "attributes": {
+            "bookTitle": "The Hitchhiker's Guide to the Galaxy",
+            "authorName": "Douglas Adams",
+            "readStatus": "finished",
+            "rating": 5
+        }
+    },
+    "editorStyle": "file:./editor.css",
+    "render": "file:./render.php"
 }

--- a/build/blocks/read-card/editor.css
+++ b/build/blocks/read-card/editor.css
@@ -1,0 +1,27 @@
+/**
+ * Read Card Block - Editor Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+.wp-block-post-kinds-indieweb-read-card .post-kinds-card__media {
+	cursor: pointer;
+}
+
+.wp-block-post-kinds-indieweb-read-card .post-kinds-card__media:hover {
+	opacity: 0.8;
+}
+
+.wp-block-post-kinds-indieweb-read-card .search-mode {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: 100%;
+	max-width: 400px;
+}
+
+.wp-block-post-kinds-indieweb-read-card .placeholder-actions {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}

--- a/build/blocks/reply-card/block.json
+++ b/build/blocks/reply-card/block.json
@@ -1,100 +1,91 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/reply-card",
-  "version": "1.0.0",
-  "title": "Reply Card",
-  "category": "post-kinds-indieweb",
-  "description": "Show the post you are replying to, with title, URL, and optional context.",
-  "keywords": [
-    "reply",
-    "response",
-    "comment",
-    "conversation",
-    "in reply to"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "url": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
-    "image": {
-      "type": "string"
-    },
-    "imageAlt": {
-      "type": "string"
-    },
-    "author": {
-      "type": "string"
-    },
-    "repliedAt": {
-      "type": "string"
-    },
-    "rel": {
-      "type": "string",
-      "default": ""
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "Great Blog Post",
-      "url": "https://example.com/post",
-      "author": "Jane Doe"
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/reply-card",
+	"version": "1.0.0",
+	"title": "Reply Card",
+	"category": "post-kinds-indieweb",
+	"description": "Show the post you are replying to, with title, URL, and optional context.",
+	"keywords": ["reply", "response", "comment", "conversation", "in reply to"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"url": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"image": {
+			"type": "string"
+		},
+		"imageAlt": {
+			"type": "string"
+		},
+		"author": {
+			"type": "string"
+		},
+		"repliedAt": {
+			"type": "string"
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "Great Blog Post",
+			"url": "https://example.com/post",
+			"author": "Jane Doe"
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/repost-card/block.json
+++ b/build/blocks/repost-card/block.json
@@ -1,100 +1,91 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/repost-card",
-  "version": "1.0.0",
-  "title": "Repost Card",
-  "category": "post-kinds-indieweb",
-  "description": "Share someone else's post on your own site, with title, URL, and optional note.",
-  "keywords": [
-    "repost",
-    "reshare",
-    "retweet",
-    "boost",
-    "share"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "url": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
-    "image": {
-      "type": "string"
-    },
-    "imageAlt": {
-      "type": "string"
-    },
-    "author": {
-      "type": "string"
-    },
-    "repostedAt": {
-      "type": "string"
-    },
-    "rel": {
-      "type": "string",
-      "default": ""
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "Great Blog Post",
-      "url": "https://example.com/post",
-      "author": "Jane Doe"
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/repost-card",
+	"version": "1.0.0",
+	"title": "Repost Card",
+	"category": "post-kinds-indieweb",
+	"description": "Share someone else's post on your own site, with title, URL, and optional note.",
+	"keywords": ["repost", "reshare", "retweet", "boost", "share"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"url": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"image": {
+			"type": "string"
+		},
+		"imageAlt": {
+			"type": "string"
+		},
+		"author": {
+			"type": "string"
+		},
+		"repostedAt": {
+			"type": "string"
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "Great Blog Post",
+			"url": "https://example.com/post",
+			"author": "Jane Doe"
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/rsvp-card/block.json
+++ b/build/blocks/rsvp-card/block.json
@@ -1,115 +1,105 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/rsvp-card",
-  "version": "1.0.0",
-  "title": "RSVP Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display an RSVP response to an event with status, event details, and optional note.",
-  "keywords": [
-    "rsvp",
-    "event",
-    "attend",
-    "interested",
-    "maybe",
-    "response"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "eventName": {
-      "type": "string"
-    },
-    "eventUrl": {
-      "type": "string"
-    },
-    "eventStart": {
-      "type": "string"
-    },
-    "eventEnd": {
-      "type": "string"
-    },
-    "eventLocation": {
-      "type": "string"
-    },
-    "eventDescription": {
-      "type": "string"
-    },
-    "rsvpStatus": {
-      "type": "string",
-      "default": "yes"
-    },
-    "rsvpNote": {
-      "type": "string"
-    },
-    "rsvpAt": {
-      "type": "string"
-    },
-    "eventImage": {
-      "type": "string"
-    },
-    "eventImageAlt": {
-      "type": "string"
-    },
-    "rel": {
-      "type": "string",
-      "default": ""
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "post-kinds-indieweb/rsvp-card",
+    "version": "1.0.0",
+    "title": "RSVP Card",
+    "category": "post-kinds-indieweb",
+    "description": "Display an RSVP response to an event with status, event details, and optional note.",
+    "keywords": ["rsvp", "event", "attend", "interested", "maybe", "response"],
+    "textdomain": "post-kinds-for-indieweb-in-block-themes",
     "attributes": {
-      "eventName": "IndieWebCamp 2025",
-      "rsvpStatus": "yes",
-      "eventLocation": "Portland, OR"
-    }
-  },
-  "editorStyle": "file:./editor.css",
-  "render": "file:./render.php"
+        "eventName": {
+            "type": "string"
+        },
+        "eventUrl": {
+            "type": "string"
+        },
+        "eventStart": {
+            "type": "string"
+        },
+        "eventEnd": {
+            "type": "string"
+        },
+        "eventLocation": {
+            "type": "string"
+        },
+        "eventDescription": {
+            "type": "string"
+        },
+        "rsvpStatus": {
+            "type": "string",
+            "default": "yes"
+        },
+        "rsvpNote": {
+            "type": "string"
+        },
+        "rsvpAt": {
+            "type": "string"
+        },
+        "eventImage": {
+            "type": "string"
+        },
+        "eventImageAlt": {
+            "type": "string"
+        },
+        "rel": {
+            "type": "string",
+            "default": ""
+        },
+        "layout": {
+            "type": "string",
+            "default": "horizontal"
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"],
+        "color": {
+            "background": true,
+            "text": true,
+            "gradients": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "width": true,
+                "style": true
+            }
+        },
+        "shadow": true,
+        "dimensions": {
+            "minHeight": true
+        }
+    },
+    "example": {
+        "attributes": {
+            "eventName": "IndieWebCamp 2025",
+            "rsvpStatus": "yes",
+            "eventLocation": "Portland, OR"
+        }
+    },
+    "editorStyle": "file:./editor.css",
+    "render": "file:./render.php"
 }

--- a/build/blocks/rsvp-card/editor.css
+++ b/build/blocks/rsvp-card/editor.css
@@ -1,0 +1,45 @@
+/**
+ * RSVP Card Block - Editor Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+.wp-block-post-kinds-indieweb-rsvp-card .event-image {
+	cursor: pointer;
+}
+
+.wp-block-post-kinds-indieweb-rsvp-card .event-image:hover {
+	opacity: 0.8;
+}
+
+.wp-block-post-kinds-indieweb-rsvp-card .image-placeholder {
+	width: 150px;
+	height: 100px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background: var(--pkiw-card-media-button-bg, transparent);
+	border: 2px dashed var(--pkiw-card-media-button-border, transparent);
+	border-radius: 4px;
+	color: var(--pkiw-card-text-secondary, inherit);
+	font-size: 0.75rem;
+	text-align: center;
+	gap: 0.5rem;
+}
+
+.wp-block-post-kinds-indieweb-rsvp-card .image-placeholder .rsvp-icon {
+	font-size: 2rem;
+}
+
+.wp-block-post-kinds-indieweb-rsvp-card .rsvp-quick-buttons {
+	margin: 0.5rem 0;
+}
+
+.wp-block-post-kinds-indieweb-rsvp-card .placeholder-actions {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	width: 100%;
+	max-width: 400px;
+}

--- a/build/blocks/star-rating/block.json
+++ b/build/blocks/star-rating/block.json
@@ -1,84 +1,74 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/star-rating",
-  "version": "1.0.0",
-  "title": "Star Rating",
-  "category": "post-kinds-indieweb",
-  "description": "Add an interactive star rating to any content with customizable scale and style.",
-  "keywords": [
-    "rating",
-    "stars",
-    "review",
-    "score",
-    "feedback"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "rating": {
-      "type": "number",
-      "default": 0
-    },
-    "maxRating": {
-      "type": "number",
-      "default": 5
-    },
-    "showLabel": {
-      "type": "boolean",
-      "default": true
-    },
-    "label": {
-      "type": "string",
-      "default": "Rating"
-    },
-    "showValue": {
-      "type": "boolean",
-      "default": true
-    },
-    "size": {
-      "type": "string",
-      "default": "medium"
-    },
-    "style": {
-      "type": "string",
-      "default": "stars"
-    },
-    "allowHalf": {
-      "type": "boolean",
-      "default": false
-    },
-    "itemUrl": {
-      "type": "string"
-    },
-    "itemName": {
-      "type": "string"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "left",
-      "center",
-      "right"
-    ],
-    "color": {
-      "text": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true
-    },
-    "typography": {
-      "fontSize": true
-    }
-  },
-  "example": {
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "post-kinds-indieweb/star-rating",
+    "version": "1.0.0",
+    "title": "Star Rating",
+    "category": "post-kinds-indieweb",
+    "description": "Add an interactive star rating to any content with customizable scale and style.",
+    "keywords": ["rating", "stars", "review", "score", "feedback"],
+    "textdomain": "post-kinds-for-indieweb-in-block-themes",
     "attributes": {
-      "rating": 4,
-      "maxRating": 5,
-      "label": "My Rating"
-    }
-  },
-  "editorStyle": "file:./editor.css",
-  "style": "file:./style.css"
+        "rating": {
+            "type": "number",
+            "default": 0
+        },
+        "maxRating": {
+            "type": "number",
+            "default": 5
+        },
+        "showLabel": {
+            "type": "boolean",
+            "default": true
+        },
+        "label": {
+            "type": "string",
+            "default": "Rating"
+        },
+        "showValue": {
+            "type": "boolean",
+            "default": true
+        },
+        "size": {
+            "type": "string",
+            "default": "medium"
+        },
+        "style": {
+            "type": "string",
+            "default": "stars"
+        },
+        "allowHalf": {
+            "type": "boolean",
+            "default": false
+        },
+        "itemUrl": {
+            "type": "string"
+        },
+        "itemName": {
+            "type": "string"
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": ["left", "center", "right"],
+        "color": {
+            "text": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true
+        }
+    },
+    "example": {
+        "attributes": {
+            "rating": 4,
+            "maxRating": 5,
+            "label": "My Rating"
+        }
+    },
+    "editorStyle": "file:./editor.css",
+    "style": "file:./style.css"
 }

--- a/build/blocks/star-rating/editor.css
+++ b/build/blocks/star-rating/editor.css
@@ -1,0 +1,38 @@
+/**
+ * Star Rating Block - Editor Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+.wp-block-post-kinds-indieweb-star-rating .rating-icons {
+	display: inline-flex;
+}
+
+.wp-block-post-kinds-indieweb-star-rating .rating-icon {
+	background: none;
+	border: none;
+	padding: 0.125rem;
+	cursor: pointer;
+	transition: transform 0.1s ease;
+	appearance: none;
+	-webkit-appearance: none;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI Symbol", system-ui, sans-serif;
+	font-size: 1.25rem;
+	line-height: 1;
+}
+
+.wp-block-post-kinds-indieweb-star-rating .rating-icon:hover {
+	transform: scale(1.1);
+}
+
+.wp-block-post-kinds-indieweb-star-rating .rating-icon:focus {
+	outline: 2px solid var(--pkiw-focus-indicator, currentcolor);
+	outline-offset: 2px;
+	border-radius: 2px;
+}
+
+.wp-block-post-kinds-indieweb-star-rating .rating-numeric {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+}

--- a/build/blocks/star-rating/style.css
+++ b/build/blocks/star-rating/style.css
@@ -1,0 +1,94 @@
+/**
+ * Star Rating Block - Frontend Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+/*
+ * Rating colors come from the --pkiw-star-rating-* token catalog
+ * (styles/kind-tokens.css). Defaults are neutral: filled icons inherit
+ * the surrounding text color; empty icons render as a muted mix of it.
+ * Themes opt into gold stars, pink hearts, etc. by setting the tokens.
+ */
+
+.star-rating-inner {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+
+/* Label */
+.star-rating-block .rating-label {
+	font-weight: 500;
+	margin-right: 0.25rem;
+}
+
+/* Rating display */
+.star-rating-block .rating-display {
+	display: inline-flex;
+	align-items: center;
+}
+
+.star-rating-block .rating-icon {
+	color: var(--pkiw-star-rating-empty, color-mix(in srgb, currentcolor 35%, transparent));
+	transition: color 0.15s ease;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI Symbol", system-ui, sans-serif;
+	line-height: 1;
+}
+
+.star-rating-block .rating-icon.filled {
+	color: var(--pkiw-star-rating-fill, currentcolor);
+}
+
+/* Size variations */
+.star-rating-block.size-small .rating-icon {
+	font-size: 1rem;
+}
+
+.star-rating-block.size-medium .rating-icon {
+	font-size: 1.25rem;
+}
+
+.star-rating-block.size-large .rating-icon {
+	font-size: 1.75rem;
+}
+
+/* Half stars */
+.star-rating-block .half-star {
+	position: relative;
+	display: inline-block;
+}
+
+.star-rating-block .half-filled-part {
+	position: absolute;
+	width: 50%;
+	overflow: hidden;
+	color: var(--pkiw-star-rating-fill, currentcolor);
+}
+
+.star-rating-block .half-empty-part {
+	color: var(--pkiw-star-rating-empty, color-mix(in srgb, currentcolor 35%, transparent));
+}
+
+/* Style variations */
+.star-rating-block.style-hearts .rating-icon.filled {
+	color: var(--pkiw-star-rating-variant-1, currentcolor);
+}
+
+.star-rating-block.style-circles .rating-icon.filled {
+	color: var(--pkiw-star-rating-variant-2, currentcolor);
+}
+
+/* Rating value */
+.star-rating-block .rating-value {
+	font-size: 0.85em;
+	color: var(--pkiw-star-rating-caption, inherit);
+	margin-left: 0.25rem;
+}
+
+/* Numeric style */
+.star-rating-block .rating-numeric-display {
+	font-size: 1.1em;
+	font-weight: 600;
+}

--- a/build/blocks/venue-detail/block.json
+++ b/build/blocks/venue-detail/block.json
@@ -1,59 +1,50 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/venue-detail",
-  "version": "1.2.0",
-  "title": "Venue Detail",
-  "category": "post-kinds-indieweb",
-  "icon": "store",
-  "description": "Display venue information with map and recent check-ins.",
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "keywords": [
-    "venue",
-    "location",
-    "map",
-    "checkin",
-    "place"
-  ],
-  "attributes": {
-    "venueId": {
-      "type": "number",
-      "default": 0
-    },
-    "showMap": {
-      "type": "boolean",
-      "default": true
-    },
-    "showAddress": {
-      "type": "boolean",
-      "default": true
-    },
-    "showCheckins": {
-      "type": "boolean",
-      "default": true
-    },
-    "checkinCount": {
-      "type": "number",
-      "default": 5
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "spacing": {
-      "margin": true,
-      "padding": true
-    },
-    "color": {
-      "background": true,
-      "text": true
-    },
-    "typography": {
-      "fontSize": true
-    }
-  },
-  "render": "file:./render.php"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/venue-detail",
+	"version": "1.2.0",
+	"title": "Venue Detail",
+	"category": "post-kinds-indieweb",
+	"icon": "store",
+	"description": "Display venue information with map and recent check-ins.",
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"keywords": ["venue", "location", "map", "checkin", "place"],
+	"attributes": {
+		"venueId": {
+			"type": "number",
+			"default": 0
+		},
+		"showMap": {
+			"type": "boolean",
+			"default": true
+		},
+		"showAddress": {
+			"type": "boolean",
+			"default": true
+		},
+		"showCheckins": {
+			"type": "boolean",
+			"default": true
+		},
+		"checkinCount": {
+			"type": "number",
+			"default": 5
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"color": {
+			"background": true,
+			"text": true
+		},
+		"typography": {
+			"fontSize": true
+		}
+	},
+	"render": "file:./render.php"
 }

--- a/build/blocks/venue-detail/editor.css
+++ b/build/blocks/venue-detail/editor.css
@@ -1,0 +1,67 @@
+/**
+ * Venue Detail Block - Editor Styles
+ */
+
+.venue-detail {
+	padding: 1rem;
+}
+
+.venue-detail__preview {
+	border: 1px solid var(--pkiw-card-border, transparent);
+	border-radius: 8px;
+	overflow: hidden;
+}
+
+.venue-detail__map-placeholder {
+	background: var(--pkiw-checkin-map-bg, transparent);
+	border-bottom: 1px solid var(--pkiw-card-border, transparent);
+	padding: 2rem;
+}
+
+.venue-detail__map-preview {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
+	color: var(--pkiw-card-text-secondary, inherit);
+}
+
+.venue-detail__map-preview .dashicons {
+	font-size: 2rem;
+	width: 2rem;
+	height: 2rem;
+}
+
+.venue-detail__info {
+	padding: 1rem;
+}
+
+.venue-detail__name {
+	margin: 0 0 0.5rem;
+	font-size: 1.25rem;
+	font-weight: 600;
+}
+
+.venue-detail__address {
+	color: var(--pkiw-card-text-secondary, inherit);
+	font-size: 0.875rem;
+	margin-bottom: 0.5rem;
+}
+
+.venue-detail__checkins-preview {
+	margin-top: 1rem;
+	padding-top: 1rem;
+	border-top: 1px solid var(--pkiw-card-border, transparent);
+}
+
+.venue-detail__checkins-preview h3 {
+	margin: 0 0 0.5rem;
+	font-size: 1rem;
+}
+
+.venue-detail__checkins-preview .description {
+	color: var(--pkiw-card-text-secondary, inherit);
+	font-size: 0.875rem;
+	font-style: italic;
+}

--- a/build/blocks/venue-detail/style.css
+++ b/build/blocks/venue-detail/style.css
@@ -1,0 +1,140 @@
+/**
+ * Venue Detail Block - Frontend Styles
+ */
+
+.venue-detail {
+	--venue-spacing: 1rem;
+}
+
+.venue-detail__card {
+	background: var(--pkiw-venue-detail-bg, transparent);
+	border: 1px solid var(--pkiw-venue-detail-border, transparent);
+	border-radius: 8px;
+	overflow: hidden;
+}
+
+.venue-detail__map {
+	width: 100%;
+	height: 250px;
+	background: var(--pkiw-checkin-map-bg, transparent);
+}
+
+.venue-detail__map-fallback {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--pkiw-venue-detail-muted, inherit);
+	margin: 0;
+}
+
+.venue-detail__info {
+	padding: var(--venue-spacing);
+}
+
+.venue-detail__name {
+	margin: 0 0 0.5rem;
+	font-size: var(--wp--preset--font-size--large, 1.5rem);
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.venue-detail__address {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+	margin-bottom: 0.5rem;
+	font-size: var(--wp--preset--font-size--small, 0.9375rem);
+	color: var(--pkiw-venue-detail-muted, inherit);
+}
+
+.venue-detail__address-icon {
+	flex-shrink: 0;
+	line-height: 1.4;
+}
+
+.venue-detail__address-text span {
+	display: inline;
+}
+
+.venue-detail__address-text span:not(:last-child)::after {
+	content: ", ";
+}
+
+.venue-detail__website,
+.venue-detail__phone {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-bottom: 0.25rem;
+	font-size: var(--wp--preset--font-size--small, 0.875rem);
+}
+
+.venue-detail__website a,
+.venue-detail__phone a,
+.venue-detail__checkins-more a {
+	color: var(--pkiw-venue-detail-accent, currentcolor);
+	text-decoration: none;
+}
+
+.venue-detail__website a:hover,
+.venue-detail__phone a:hover,
+.venue-detail__checkins-more a:hover {
+	text-decoration: underline;
+}
+
+/* Check-ins section */
+.venue-detail__checkins {
+	margin-top: var(--venue-spacing);
+}
+
+.venue-detail__checkins-title {
+	margin: 0 0 0.75rem;
+	font-size: var(--wp--preset--font-size--medium, 1.125rem);
+	font-weight: 600;
+}
+
+.venue-detail__checkins-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.venue-detail__checkin-item {
+	background: var(--pkiw-venue-detail-item-bg, transparent);
+	border-radius: 4px;
+	transition: background-color 0.2s ease;
+}
+
+.venue-detail__checkin-item:hover {
+	background: var(--pkiw-venue-detail-item-hover-bg, transparent);
+}
+
+.venue-detail__checkin-link {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0.75rem 1rem;
+	color: inherit;
+	text-decoration: none;
+}
+
+.venue-detail__checkin-title {
+	font-weight: 500;
+}
+
+.venue-detail__checkin-date {
+	font-size: var(--wp--preset--font-size--small, 0.75rem);
+	color: var(--pkiw-venue-detail-muted, inherit);
+	opacity: 0.8;
+}
+
+.venue-detail__checkins-more {
+	margin-top: 0.75rem;
+	font-size: var(--wp--preset--font-size--small, 0.875rem);
+}
+
+/* Hidden microformat data */
+[hidden] {
+	display: none !important;
+}

--- a/build/blocks/watch-card/block.json
+++ b/build/blocks/watch-card/block.json
@@ -1,137 +1,126 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/watch-card",
-  "version": "1.0.0",
-  "title": "Watch Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display a movie or TV show you watched with poster, rating, and details.",
-  "keywords": [
-    "watch",
-    "movie",
-    "tv",
-    "film",
-    "show",
-    "episode",
-    "video"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "mediaTitle": {
-      "type": "string"
-    },
-    "mediaType": {
-      "type": "string",
-      "default": "movie"
-    },
-    "showTitle": {
-      "type": "string"
-    },
-    "seasonNumber": {
-      "type": "number"
-    },
-    "episodeNumber": {
-      "type": "number"
-    },
-    "episodeTitle": {
-      "type": "string"
-    },
-    "releaseYear": {
-      "type": "number"
-    },
-    "director": {
-      "type": "string"
-    },
-    "posterImage": {
-      "type": "string"
-    },
-    "posterImageAlt": {
-      "type": "string"
-    },
-    "watchUrl": {
-      "type": "string"
-    },
-    "captionsUrl": {
-      "type": "string"
-    },
-    "tmdbId": {
-      "type": "string"
-    },
-    "imdbId": {
-      "type": "string"
-    },
-    "rating": {
-      "type": "number",
-      "default": 0
-    },
-    "isRewatch": {
-      "type": "boolean",
-      "default": false
-    },
-    "watchedAt": {
-      "type": "string"
-    },
-    "review": {
-      "type": "string"
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "post-kinds-indieweb/watch-card",
+    "version": "1.0.0",
+    "title": "Watch Card",
+    "category": "post-kinds-indieweb",
+    "description": "Display a movie or TV show you watched with poster, rating, and details.",
+    "keywords": ["watch", "movie", "tv", "film", "show", "episode", "video"],
+    "textdomain": "post-kinds-for-indieweb-in-block-themes",
     "attributes": {
-      "mediaTitle": "The Shawshank Redemption",
-      "mediaType": "movie",
-      "releaseYear": 1994,
-      "director": "Frank Darabont",
-      "rating": 5
-    }
-  },
-  "editorStyle": "file:./editor.css",
-  "render": "file:./render.php"
+        "mediaTitle": {
+            "type": "string"
+        },
+        "mediaType": {
+            "type": "string",
+            "default": "movie"
+        },
+        "showTitle": {
+            "type": "string"
+        },
+        "seasonNumber": {
+            "type": "number"
+        },
+        "episodeNumber": {
+            "type": "number"
+        },
+        "episodeTitle": {
+            "type": "string"
+        },
+        "releaseYear": {
+            "type": "number"
+        },
+        "director": {
+            "type": "string"
+        },
+        "posterImage": {
+            "type": "string"
+        },
+        "posterImageAlt": {
+            "type": "string"
+        },
+        "watchUrl": {
+            "type": "string"
+        },
+        "captionsUrl": {
+            "type": "string"
+        },
+        "tmdbId": {
+            "type": "string"
+        },
+        "imdbId": {
+            "type": "string"
+        },
+        "rating": {
+            "type": "number",
+            "default": 0
+        },
+        "isRewatch": {
+            "type": "boolean",
+            "default": false
+        },
+        "watchedAt": {
+            "type": "string"
+        },
+        "review": {
+            "type": "string"
+        },
+        "layout": {
+            "type": "string",
+            "default": "horizontal"
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"],
+        "color": {
+            "background": true,
+            "text": true,
+            "gradients": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "width": true,
+                "style": true
+            }
+        },
+        "shadow": true,
+        "dimensions": {
+            "minHeight": true
+        }
+    },
+    "example": {
+        "attributes": {
+            "mediaTitle": "The Shawshank Redemption",
+            "mediaType": "movie",
+            "releaseYear": 1994,
+            "director": "Frank Darabont",
+            "rating": 5
+        }
+    },
+    "editorStyle": "file:./editor.css",
+    "render": "file:./render.php"
 }

--- a/build/blocks/watch-card/editor.css
+++ b/build/blocks/watch-card/editor.css
@@ -1,0 +1,47 @@
+/**
+ * Watch Card Block - Editor Styles
+ *
+ * @package Reactions_For_IndieWeb
+ */
+
+.wp-block-post-kinds-indieweb-watch-card .poster-image {
+	cursor: pointer;
+}
+
+.wp-block-post-kinds-indieweb-watch-card .poster-image:hover {
+	opacity: 0.8;
+}
+
+.wp-block-post-kinds-indieweb-watch-card .poster-placeholder {
+	width: 100px;
+	height: 150px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background: var(--pkiw-card-media-button-bg, transparent);
+	border: 2px dashed var(--pkiw-card-media-button-border, transparent);
+	border-radius: 4px;
+	color: var(--pkiw-card-text-secondary, inherit);
+	font-size: 0.75rem;
+	text-align: center;
+	gap: 0.5rem;
+}
+
+.wp-block-post-kinds-indieweb-watch-card .poster-placeholder .poster-icon {
+	font-size: 2rem;
+}
+
+.wp-block-post-kinds-indieweb-watch-card .search-mode {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: 100%;
+	max-width: 400px;
+}
+
+.wp-block-post-kinds-indieweb-watch-card .placeholder-actions {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}

--- a/build/blocks/wish-card/block.json
+++ b/build/blocks/wish-card/block.json
@@ -1,107 +1,99 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 3,
-  "name": "post-kinds-indieweb/wish-card",
-  "render": "file:./render.php",
-  "version": "1.0.0",
-  "title": "Wish Card",
-  "category": "post-kinds-indieweb",
-  "description": "Display something you wish for or want with image and reason.",
-  "keywords": [
-    "wish",
-    "want",
-    "wishlist",
-    "gift"
-  ],
-  "textdomain": "post-kinds-for-indieweb-in-block-themes",
-  "attributes": {
-    "title": {
-      "type": "string"
-    },
-    "wishType": {
-      "type": "string",
-      "default": "item"
-    },
-    "url": {
-      "type": "string"
-    },
-    "image": {
-      "type": "string"
-    },
-    "imageAlt": {
-      "type": "string"
-    },
-    "price": {
-      "type": "string"
-    },
-    "reason": {
-      "type": "string"
-    },
-    "priority": {
-      "type": "string",
-      "default": "medium"
-    },
-    "wishedAt": {
-      "type": "string"
-    },
-    "rel": {
-      "type": "string",
-      "default": ""
-    },
-    "layout": {
-      "type": "string",
-      "default": "horizontal"
-    }
-  },
-  "supports": {
-    "html": false,
-    "align": [
-      "wide",
-      "full"
-    ],
-    "color": {
-      "background": true,
-      "text": true,
-      "gradients": true,
-      "link": true
-    },
-    "spacing": {
-      "margin": true,
-      "padding": true,
-      "blockGap": true
-    },
-    "typography": {
-      "fontSize": true,
-      "lineHeight": true,
-      "__experimentalFontFamily": true,
-      "__experimentalFontWeight": true,
-      "__experimentalFontStyle": true,
-      "__experimentalTextTransform": true,
-      "__experimentalTextDecoration": true,
-      "__experimentalLetterSpacing": true
-    },
-    "__experimentalBorder": {
-      "color": true,
-      "radius": true,
-      "width": true,
-      "style": true,
-      "__experimentalDefaultControls": {
-        "color": true,
-        "radius": true,
-        "width": true,
-        "style": true
-      }
-    },
-    "shadow": true,
-    "dimensions": {
-      "minHeight": true
-    }
-  },
-  "example": {
-    "attributes": {
-      "title": "Mechanical Keyboard",
-      "wishType": "item",
-      "priority": "high"
-    }
-  }
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "post-kinds-indieweb/wish-card",
+	"render": "file:./render.php",
+	"version": "1.0.0",
+	"title": "Wish Card",
+	"category": "post-kinds-indieweb",
+	"description": "Display something you wish for or want with image and reason.",
+	"keywords": ["wish", "want", "wishlist", "gift"],
+	"textdomain": "post-kinds-for-indieweb-in-block-themes",
+	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"wishType": {
+			"type": "string",
+			"default": "item"
+		},
+		"url": {
+			"type": "string"
+		},
+		"image": {
+			"type": "string"
+		},
+		"imageAlt": {
+			"type": "string"
+		},
+		"price": {
+			"type": "string"
+		},
+		"reason": {
+			"type": "string"
+		},
+		"priority": {
+			"type": "string",
+			"default": "medium"
+		},
+		"wishedAt": {
+			"type": "string"
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		},
+		"layout": {
+			"type": "string",
+			"default": "horizontal"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true,
+				"style": true
+			}
+		},
+		"shadow": true,
+		"dimensions": {
+			"minHeight": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "Mechanical Keyboard",
+			"wishType": "item",
+			"priority": "high"
+		}
+	}
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -867,8 +867,17 @@ final class Plugin {
 		}
 
 		// Register each block with the shared editor script and styles.
+		// Blocks register from build/blocks (kept in sync by
+		// bin/sync-block-assets.mjs after each build) so the distributed
+		// plugin works without src/; src is the dev-only fallback.
 		foreach ( $blocks as $block ) {
-			$block_dir = \PKIW_PATH . 'src/blocks/' . $block;
+			$block_dir     = \PKIW_PATH . 'build/blocks/' . $block;
+			$block_dir_url = \PKIW_URL . 'build/blocks/' . $block;
+
+			if ( ! file_exists( $block_dir . '/block.json' ) ) {
+				$block_dir     = \PKIW_PATH . 'src/blocks/' . $block;
+				$block_dir_url = \PKIW_URL . 'src/blocks/' . $block;
+			}
 
 			if ( ! file_exists( $block_dir . '/block.json' ) ) {
 				continue;
@@ -888,7 +897,7 @@ final class Plugin {
 			if ( file_exists( $style_file ) ) {
 				wp_register_style(
 					'pkiw-block-' . $block,
-					\PKIW_URL . 'src/blocks/' . $block . '/style.css',
+					$block_dir_url . '/style.css',
 					$style_deps,
 					filemtime( $style_file )
 				);
@@ -903,7 +912,7 @@ final class Plugin {
 			if ( file_exists( $editor_style_file ) ) {
 				wp_register_style(
 					'pkiw-block-' . $block . '-editor',
-					\PKIW_URL . 'src/blocks/' . $block . '/editor.css',
+					$block_dir_url . '/editor.css',
 					$style_deps,
 					filemtime( $editor_style_file )
 				);

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
 		"lint-staged": "^17.0.8"
 	},
 	"scripts": {
-		"build": "wp-scripts build",
-		"build:prod": "wp-scripts build --mode=production",
+		"build": "wp-scripts build && node bin/sync-block-assets.mjs",
+		"build:prod": "wp-scripts build --mode=production && node bin/sync-block-assets.mjs",
 		"start": "wp-scripts start",
 		"lint": "npm run lint:js && npm run lint:css && npm run lint:pkg-json",
 		"lint:js": "wp-scripts lint-js src/",


### PR DESCRIPTION
**Shipping blocker caught during screenshot recapture.** The wp.org submission zip contains `build/` but not `src/`, while `Plugin::register_blocks()` read every `block.json` from `src/blocks/` — so in the zip-shaped install, none of the 22 card blocks registered. The plugin's core feature was absent from the build under review. Plugin Check can't catch this (it doesn't execute registration), and all local/CI testing runs from the full repo where `src/` exists.

## Fix
- `register_blocks()` loads each block and its per-block stylesheets from `build/blocks/<block>/`, with `src/blocks/` as the dev fallback.
- New `bin/sync-block-assets.mjs` copies `block.json`, `render.php`, `style.css`, `editor.css` into `build/blocks/` — wired into `npm run build`/`build:prod`, refreshed copies committed. The previously committed `build/blocks/*/block.json` files were stale truncated versions missing full attribute schemas, and `checkins-feed`/`venue-detail` front-end styles weren't shipped at all.

## Verification
Deployed the zip-faithful layout (no `src/`) to a clean local WordPress: 23 `post-kinds-indieweb/*` blocks register, card posts render with styles. PHPCS + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)