### PR TITLE
🐛 Fix IDOR in syndication handlers: require per-post edit_post capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The public OAuth callback now rejects requests with a missing or malformed `code`/`state` as a clean 400 instead of hitting `hash_equals()` with a non-string (a PHP 8 fatal → 500). State validation itself was already sound: single-use transient, constant-time comparison.
+- The syndication admin handlers (`ajax_syndicate_now`, `handle_actions`) now require the per-post `edit_post` capability before syndicating, closing an IDOR where any user with the generic `edit_posts` capability could syndicate another user's post.
 
 ## [1.4.3] - 2026-07-07
 

--- a/includes/admin/class-syndication-page.php
+++ b/includes/admin/class-syndication-page.php
@@ -139,6 +139,10 @@ class Syndication_Page {
 			return;
 		}
 
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
 		$result = $this->syndicate_post( $post_id, $service );
 
 		if ( $result ) {
@@ -179,6 +183,10 @@ class Syndication_Page {
 
 		if ( ! $post_id || ! $service ) {
 			wp_send_json_error( [ 'message' => __( 'Invalid parameters.', 'post-kinds-for-indieweb-in-block-themes' ) ] );
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'post-kinds-for-indieweb-in-block-themes' ) ] );
 		}
 
 		$result = $this->syndicate_post( $post_id, $service );

--- a/tests/phpunit/integration/SyndicationPageAuthorizationTest.php
+++ b/tests/phpunit/integration/SyndicationPageAuthorizationTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Test per-post authorization for syndication handlers.
+ *
+ * @package PKIW
+ */
+
+namespace PKIW\Tests\Integration;
+
+use PKIW\Admin\Admin;
+use PKIW\Admin\Syndication_Page;
+use PKIW\Meta_Fields;
+use PKIW\Plugin;
+use WP_Ajax_UnitTestCase;
+
+/**
+ * Test syndication handler authorization.
+ *
+ * @covers \PKIW\Admin\Syndication_Page
+ */
+class SyndicationPageAuthorizationTest extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Syndication page instance.
+	 *
+	 * @var Syndication_Page
+	 */
+	private Syndication_Page $page;
+
+	/**
+	 * Syndication meta key.
+	 *
+	 * @var string
+	 */
+	private string $meta_key;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->page     = new Syndication_Page( new Admin( Plugin::get_instance() ) );
+		$this->meta_key = Meta_Fields::PREFIX . 'syndicate_lastfm';
+
+		update_option( 'pkiw_settings', [ 'listen_sync_to_lastfm' => true ] );
+		update_option( 'pkiw_api_credentials', [ 'lastfm' => [ 'session_key' => 'test-session' ] ] );
+	}
+
+	/**
+	 * Reset request globals.
+	 */
+	public function tear_down(): void {
+		$_GET     = [];
+		$_POST    = [];
+		$_REQUEST = [];
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test the GET handler cannot syndicate another user's post.
+	 */
+	public function test_handle_actions_does_not_syndicate_post_user_cannot_edit(): void {
+		$post_id = $this->create_post_owned_by_another_user();
+
+		$this->assertTrue( current_user_can( 'edit_posts' ) );
+		$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
+
+		$this->set_get_request( $post_id );
+		$this->page->handle_actions();
+
+		$this->assertFalse( metadata_exists( 'post', $post_id, $this->meta_key ) );
+	}
+
+	/**
+	 * Test the GET handler syndicates a post the user can edit.
+	 */
+	public function test_handle_actions_syndicates_post_user_can_edit(): void {
+		$post_id = $this->create_post_owned_by_current_user();
+
+		$this->assertTrue( current_user_can( 'edit_posts' ) );
+		$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+
+		$this->set_get_request( $post_id );
+		$this->page->handle_actions();
+
+		$this->assertSame( '1', get_post_meta( $post_id, $this->meta_key, true ) );
+	}
+
+	/**
+	 * Test the AJAX handler cannot syndicate another user's post.
+	 */
+	public function test_ajax_syndicate_now_does_not_syndicate_post_user_cannot_edit(): void {
+		$post_id = $this->create_post_owned_by_another_user();
+
+		$this->assertTrue( current_user_can( 'edit_posts' ) );
+		$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
+
+		$this->set_ajax_request( $post_id );
+		$this->call_ajax_handler();
+
+		$this->assertFalse( metadata_exists( 'post', $post_id, $this->meta_key ) );
+	}
+
+	/**
+	 * Test the AJAX handler syndicates a post the user can edit.
+	 */
+	public function test_ajax_syndicate_now_syndicates_post_user_can_edit(): void {
+		$post_id = $this->create_post_owned_by_current_user();
+
+		$this->assertTrue( current_user_can( 'edit_posts' ) );
+		$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+
+		$this->set_ajax_request( $post_id );
+		$this->call_ajax_handler();
+
+		$this->assertSame( '1', get_post_meta( $post_id, $this->meta_key, true ) );
+	}
+
+	/**
+	 * Create a post owned by another user and select a contributor.
+	 *
+	 * @return int Post ID.
+	 */
+	private function create_post_owned_by_another_user(): int {
+		$owner_id = self::factory()->user->create( [ 'role' => 'author' ] );
+		$post_id  = self::factory()->post->create(
+			[
+				'post_author' => $owner_id,
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'contributor' ] ) );
+
+		return $post_id;
+	}
+
+	/**
+	 * Create a post owned by the current contributor.
+	 *
+	 * @return int Post ID.
+	 */
+	private function create_post_owned_by_current_user(): int {
+		$user_id = self::factory()->user->create( [ 'role' => 'contributor' ] );
+
+		wp_set_current_user( $user_id );
+
+		return self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'draft',
+			]
+		);
+	}
+
+	/**
+	 * Populate a valid GET syndication request.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function set_get_request( int $post_id ): void {
+		$_GET = [
+			'action'   => 'syndicate_now',
+			'page'     => 'post-kinds-indieweb-syndication',
+			'post_id'  => (string) $post_id,
+			'service'  => 'lastfm',
+			'_wpnonce' => wp_create_nonce( 'syndicate_now_' . $post_id ),
+		];
+
+		$_REQUEST = $_GET;
+	}
+
+	/**
+	 * Populate a valid AJAX syndication request.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function set_ajax_request( int $post_id ): void {
+		$_POST = [
+			'post_id' => (string) $post_id,
+			'service' => 'lastfm',
+			'nonce'   => wp_create_nonce( 'pkiw_syndicate_now' ),
+		];
+
+		$_REQUEST = $_POST;
+	}
+
+	/**
+	 * Call the AJAX handler and accept its expected JSON termination.
+	 */
+	private function call_ajax_handler(): void {
+		try {
+			$this->page->ajax_syndicate_now();
+		} catch ( \WPAjaxDieContinueException $exception ) {
+			return;
+		}
+
+		$this->fail( 'AJAX handler did not terminate after sending a response.' );
+	}
+}


### PR DESCRIPTION
## Summary

Closes an IDOR in the syndication admin handlers. `ajax_syndicate_now()` and `handle_actions()` gated only on the generic `edit_posts` capability before calling `syndicate_post()`, so any user with `edit_posts` (e.g. a contributor) could syndicate — and flip the `syndicate_lastfm` meta on — **another user's post**. Both handlers now check `current_user_can( 'edit_post', $post_id )` immediately before syndicating; the generic `edit_posts` check stays as defense in depth.

Found by a local prove-by-firing security audit: fired as a seeded contributor against another author's post and observed the meta flip 0→1. The added integration test asserts the syndication meta is **not** written when the per-post cap is denied, and **is** written when allowed (GET and AJAX paths).

Note: the related OAuth-CSRF finding from the same audit was already fixed on `main` (state verification with single-use transient + `hash_equals`), so it's not part of this PR.

## Documentation checklist

Security fix; no user-facing UI, settings, or doc changes.

- [x] User-facing behavior changes are documented in `docs/src/content/docs/` — n/a (no user-facing behavior change beyond blocking an unauthorized action)
- [x] Accessibility implications were reviewed — n/a (no UI change)
- [x] `README.md` / `readme.txt` remain accurate — no version/feature change
- [x] Changelog updated (`CHANGELOG.md` → Unreleased → Fixed)
