### PR TITLE
🐛 Fix: use wp_safe_remote_get for Letterboxd URL fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Letterboxd lookups now use WordPress's safe HTTP fetch and reject unsafe redirect targets.
 - The public OAuth callback now rejects requests with a missing or malformed `code`/`state` as a clean 400 instead of hitting `hash_equals()` with a non-string (a PHP 8 fatal → 500). State validation itself was already sound: single-use transient, constant-time comparison.
 
 ## [1.4.3] - 2026-07-07

--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -1541,11 +1541,12 @@ class REST_API {
 		// Film: /film/slug or /film/slug/.
 		if ( preg_match( '/\/film\/([^\/]+)/', $path, $matches ) ) {
 			// Fetch the Letterboxd page and look for TMDB link.
-			$response = wp_remote_get(
+			$response = wp_safe_remote_get(
 				$url,
 				[
-					'timeout'    => 15,
-					'user-agent' => 'Mozilla/5.0 (compatible; WordPress/' . get_bloginfo( 'version' ) . ')',
+					'timeout'            => 15,
+					'user-agent'         => 'Mozilla/5.0 (compatible; WordPress/' . get_bloginfo( 'version' ) . ')',
+					'reject_unsafe_urls' => true,
 				]
 			);
 

--- a/tests/phpunit/unit/RestApiTest.php
+++ b/tests/phpunit/unit/RestApiTest.php
@@ -347,6 +347,33 @@ class RestApiTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test Letterboxd fetches reject unsafe URLs.
+	 */
+	public function test_letterboxd_fetch_rejects_unsafe_urls() {
+		$request_args = null;
+		$interceptor  = static function ( $preempt, $parsed_args ) use ( &$request_args ) {
+			$request_args = $parsed_args;
+			return new \WP_Error( 'http_request_blocked', 'HTTP request blocked by test.' );
+		};
+
+		add_filter( 'pre_http_request', $interceptor, 10, 2 );
+
+		$request = new WP_REST_Request( 'GET', '/' . REST_API::NAMESPACE . '/lookup/watch-url' );
+		$request->set_param( 'url', 'https://letterboxd.com/film/test-film/' );
+
+		try {
+			$this->rest_api->lookup_watch_url( $request );
+		} finally {
+			remove_filter( 'pre_http_request', $interceptor, 10 );
+		}
+
+		$this->assertTrue(
+			$request_args['reject_unsafe_urls'] ?? false,
+			'Letterboxd fetches must reject unsafe URLs.'
+		);
+	}
+
+	/**
 	 * Test settings routes require admin capabilities.
 	 *
 	 * There's no plain `/settings` route — the API exposes `/settings/apis`,


### PR DESCRIPTION
## Summary

`parse_letterboxd_url()` fetched a request-derived URL with the non-safe `wp_remote_get` (follows redirects, no private-network guard). A host pin limits this to letterboxd.com paths, so severity is low, but the safe variant is the right primitive. Switched that single call to `wp_safe_remote_get` with `'reject_unsafe_urls' => true`; no other fetch touched.

Found by the same local prove-by-firing audit. Test hooks `pre_http_request` and asserts the fetch args carry `reject_unsafe_urls`.

## Documentation checklist

Security hardening; no user-facing UI, settings, or doc changes.

- [x] User-facing behavior — n/a
- [x] Accessibility — n/a
- [x] README/readme.txt — no change
- [x] Changelog updated (Unreleased → Fixed)
