### PR TITLE
🚀 Release 1.0.1 — security patch (syndication IDOR + Letterboxd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-20
+
 ### Removed
 
 - The "Enabled Reaction Types" control on the General settings tab. The `enabled_kinds` option it saved had no runtime consumers — disabling a kind never removed it from the editor, taxonomy, or blocks, despite the on-screen promise. The renderer and any saved values are kept so the control can return together with real enforcement.

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb in Block Themes
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Requires at least: 7.0
  * Tested up to:      7.0
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'PKIW_VERSION', '1.0.0' );
+define( 'PKIW_VERSION', '1.0.1' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -135,6 +135,10 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 7. Block inserter showing all post kind blocks
 
 == Changelog ==
+
+= 1.0.1 =
+* Security: syndication handlers now require the per-post `edit_post` capability, closing an IDOR where a user with generic `edit_posts` could syndicate another user's post.
+* Security: Letterboxd lookups use `wp_safe_remote_get` with `reject_unsafe_urls`, so a redirect target can't reach private or loopback hosts.
 
 = 1.0.0 =
 * Initial WordPress.org release: 24 post kinds with card blocks, media lookup, imports and webhook scrobbling, microformats2 markup, syndication, and Micropub support. Development history for the pre-release builds lives in CHANGELOG.md in the GitHub repository.


### PR DESCRIPTION
## Summary

Version bump to **1.0.1** shipping the two merged security fixes that are NOT in the published 1.0.0: the syndication IDOR (#105, per-post `edit_post` cap) and the Letterboxd `wp_safe_remote_get` hardening (#106). Bumps the plugin header, `PKIW_VERSION`, and the readme `Stable tag`; dates the changelog.

## Ship steps (after merge — need your hand)\n- [ ] Tag `1.0.1`\n- [ ] Push to the WordPress.org SVN `trunk` + `tags/1.0.1` (your wp.org credentials)\n- [ ] Deploy to the live site\n\n⚠️ The published **1.0.0 is live and still carries the exploitable IDOR** — this is the urgent one.