### PR TITLE
📖 Attribute the original Post Kinds plugin by link, not author name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Own your media life.** Track what you listen to, watch, read, play, and experience — all from your WordPress site, with full block editor support and IndieWeb microformats.
 
-A modern, block-editor successor to David Shanske's [IndieWeb Post Kinds](https://wordpress.org/plugins/indieweb-post-kinds/) plugin. Built for IndieWeb users who want to own their listening, watching, reading, and check-in history, and for bloggers migrating from the classic Post Kinds plugin to the block editor.
+A modern, block-editor successor to the classic [IndieWeb Post Kinds](https://wordpress.org/plugins/indieweb-post-kinds/) plugin. Built for IndieWeb users who want to own their listening, watching, reading, and check-in history, and for bloggers migrating from the classic Post Kinds plugin to the block editor.
 
 Try it without installing anything: see the [Playground preview](https://courtneyr-dev.github.io/post-kinds-for-indieweb/playground/) for a one-command browser demo.
 
@@ -235,7 +235,7 @@ GPL v2 or later. See [LICENSE](LICENSE).
 
 ## Credits
 
-Created by [Courtney Robertson](https://courtneyr.dev). Built as a modern successor to [IndieWeb Post Kinds](https://wordpress.org/plugins/indieweb-post-kinds/) by David Shanske.
+Created by [Courtney Robertson](https://courtneyr.dev). Built as a modern successor to [IndieWeb Post Kinds](https://wordpress.org/plugins/indieweb-post-kinds/).
 
 Uses open data from MusicBrainz, TMDB, Open Library, RAWG, OpenStreetMap, and other services.
 

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -3,7 +3,7 @@
  * Post Kinds for IndieWeb in Block Themes
  *
  * Modern block editor support for IndieWeb post kinds and microformats.
- * A successor to the classic IndieWeb Post Kinds plugin by David Shanske.
+ * A successor to the classic IndieWeb Post Kinds plugin.
  *
  * @package     PKIW
  * @author      Courtney Robertson

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Track what you listen to, watch, read, play, and experience — all from your Wo
 
 == Description ==
 
-Post Kinds for IndieWeb in Block Themes is a block-editor successor to David Shanske's [Post Kinds](https://wordpress.org/plugins/indieweb-post-kinds/) plugin.
+Post Kinds for IndieWeb in Block Themes is a block-editor successor to the classic [Post Kinds](https://wordpress.org/plugins/indieweb-post-kinds/) plugin.
 
 A post kind is a label that describes what a post *is* — a note, a check-in, a song you listened to, a movie you watched — rather than what it's about. The idea comes from the [IndieWeb](https://indieweb.org/) movement: publish your activity on your own site instead of (or in addition to) social networks and tracking apps.
 
@@ -224,6 +224,6 @@ Each external service has its own privacy policy. API calls retrieve public meta
 == Credits ==
 
 * **Author:** [Courtney Robertson](https://courtneyr.dev)
-* **Original plugin:** [Post Kinds](https://wordpress.org/plugins/indieweb-post-kinds/) by David Shanske
+* **Original plugin:** [Post Kinds](https://wordpress.org/plugins/indieweb-post-kinds/)
 * Built for the [IndieWeb](https://indieweb.org/) community
 * Uses open data from MusicBrainz, TMDB, Open Library, RAWG, OpenStreetMap, and other services


### PR DESCRIPTION
Reference the original plugin via its wordpress.org link rather than naming the author in prose. Attribution to the original plugin is preserved through the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)