### PR TITLE
📖 Reference Micropub plugin by package name; document IndieWeb validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,19 @@ Block editor support for IndieWeb post kinds (listen, watch, read, checkin, play
 - No OR-assertions, no self-grading tests
 - CI green is the source of truth over local runs
 
+### IndieWeb validation
+
+The plugin's whole value is interop — output that consuming parsers (webmention receivers, feed readers) actually recognize. Validate it, don't assume it.
+
+- **Automated gate (CI):** `tests/phpunit/integration/MicroformatsRenderTest.php` renders each response-kind card, parses it with the `mf2/mf2` parser, and asserts the post's `h-entry` carries the canonical property (`like-of`, `in-reply-to`, `repost-of`, `bookmark-of`, `favorite-of`, `listen-of`, `watch-of`, `read-of`). A property class must sit on the same element as its microformat root or it won't attach to the entry — this test catches that regression. Extend it when adding a kind (rsvp, and the experimental kinds, still need their own coverage).
+- **Pre-release manual pass** (a representative published post of each kind, before tagging):
+  - [indiewebify.me](https://indiewebify.me/) — `h-entry` / `h-card` recognized
+  - [pin13.net/mf2](https://pin13.net/mf2/) or [microformats.io](https://microformats.io/) — eyeball the parsed mf2 JSON
+  - [monocle.p3k.io/preview](https://monocle.p3k.io/preview) — the `h-feed` parses as intended (nothing missing/extra)
+  - [webmention.rocks](https://webmention.rocks/) — the webmention sender conforms
+  - [micropub.rocks](https://micropub.rocks/) — the Micropub server conforms (also exercised by the `micropub-kinds` e2e)
+  - W3C validator — no malformed HTML
+
 ### Accessibility floor: WCAG 2.2 AA
 
 - Semantic HTML first; ARIA only where semantics can't cover it

--- a/includes/class-micropub-content-builder.php
+++ b/includes/class-micropub-content-builder.php
@@ -2,7 +2,7 @@
 /**
  * Micropub content builder — converts h-entry properties into block markup.
  *
- * The Micropub plugin (David Shanske) creates a wp_posts row whose
+ * The upstream Micropub plugin (`wordpress-micropub`) creates a wp_posts row whose
  * `post_content` is the literal `content` property string. Front-end render
  * is then "whatever the user typed" — no card, no map, no venue detail.
  *
@@ -699,7 +699,7 @@ final class Micropub_Content_Builder {
 		}
 
 		// Deduplicate photo URLs while preserving alt-text alignment.
-		// The upstream Micropub plugin (David Shanske's `wordpress-micropub`)
+		// The upstream Micropub plugin (`wordpress-micropub`)
 		// enriches `$input['photo']` post-sideload — when an Outpost
 		// gallery uploads 3 images and posts them as `photo[]=url1&...`,
 		// the plugin's processing produces a 6-entry array (the original


### PR DESCRIPTION
Two small docs changes:

- Reference the upstream Micropub plugin by its package name (`wordpress-micropub`) in two code comments rather than naming the author. Keeps the technical context.
- Add an **IndieWeb validation** section to CLAUDE.md: the automated mf2-parse CI gate plus a pre-release manual validator checklist (indiewebify.me, pin13.net/mf2, monocle.p3k.io/preview, webmention.rocks, micropub.rocks, W3C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)