### PR TITLE
📖 Consolidate 1.0.1: log mf2 fix in changelog + sync package.json version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Response-kind cards (like, reply, repost, bookmark, favorite, listen, watch, read) now carry their microformats2 property (`u-like-of`, `u-in-reply-to`, `u-repost-of`, and so on) on the card's `h-cite` root instead of a nested element, so the post's `h-entry` actually exposes the property. Webmention receivers and feed readers now recognize these posts as their kind. Added an integration test that parses each rendered card with a real microformats2 parser to guard against regressions.
 - Letterboxd lookups now use WordPress's safe HTTP fetch and reject unsafe redirect targets.
 - The public OAuth callback now rejects requests with a missing or malformed `code`/`state` as a clean 400 instead of hitting `hash_equals()` with a non-string (a PHP 8 fatal → 500). State validation itself was already sound: single-use transient, constant-time comparison.
 - The syndication admin handlers (`ajax_syndicate_now`, `handle_actions`) now require the per-post `edit_post` capability before syndicating, closing an IDOR where any user with the generic `edit_posts` capability could syndicate another user's post.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "post-kinds-for-indieweb-in-block-themes",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.",
 	"author": "Courtney Robertson",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 = 1.0.1 =
 * Security: syndication handlers now require the per-post `edit_post` capability, closing an IDOR where a user with generic `edit_posts` could syndicate another user's post.
 * Security: Letterboxd lookups use `wp_safe_remote_get` with `reject_unsafe_urls`, so a redirect target can't reach private or loopback hosts.
+* Fixed: like, reply, repost, bookmark, favorite, listen, watch, and read posts now expose the correct microformats2 markup, so webmention receivers and feed readers recognize them as their kind.
 
 = 1.0.0 =
 * Initial WordPress.org release: 24 post kinds with card blocks, media lookup, imports and webhook scrobbling, microformats2 markup, syndication, and Micropub support. Development history for the pre-release builds lives in CHANGELOG.md in the GitHub repository.


### PR DESCRIPTION
Makes main a clean, consistent 1.0.1 for the WordPress.org debut. **Prep only — no tag, no deploy.**

- Adds the response-kind microformats2 fix to CHANGELOG.md and readme.txt under 1.0.1.
- Syncs `package.json` (was 1.0.0) to 1.0.1, matching the plugin header, `PKIW_VERSION`, and readme `Stable tag`.

After this merges and CI is green, main is ready to tag `1.0.1` — which stays held for Courtney's explicit go, along with the manual wp.org SVN commit and live deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)