### PR TITLE
🚀 Release 1.0.0 — WordPress.org debut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> **WordPress.org versioning note (2026-07-10):** the plugin's public WordPress.org line starts at **1.0.0**, which contains everything through GitHub build 1.4.3. The entries below record the pre-release GitHub-only builds.
+> **WordPress.org versioning note:** the public WordPress.org debut is **[1.0.0] dated 2026-07-20**, which bundles the full feature set from the pre-release GitHub builds (1.4.3 and earlier, listed below) plus the final pre-launch fixes. The 1.4.x–1.1.0 entries and the earlier `[1.0.0] - 2024-12-23 (pre-release GitHub build)` were GitHub-only and never shipped on WordPress.org.
 
 ## [Unreleased]
 
-## [1.0.1] - 2026-07-20
+## [1.0.0] - 2026-07-20
+
+Initial public WordPress.org release — the full feature set from the pre-release GitHub builds (through 1.4.3, listed below), plus the final pre-launch changes noted here.
 
 ### Removed
 
@@ -177,7 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESLint exhaustive-deps warnings in Jam Card useEffect hooks
 - CSS selector formatting in shared card-editor.css
 
-## [1.0.0] - 2024-12-23
+## [1.0.0] - 2024-12-23 (pre-release GitHub build)
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "post-kinds-for-indieweb-in-block-themes",
-	"version": "1.0.1",
+	"version": "1.0.0",
 	"description": "Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.",
 	"author": "Courtney Robertson",
 	"license": "GPL-2.0-or-later",

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb in Block Themes
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.0.1
+ * Version:           1.0.0
  * Requires at least: 7.0
  * Tested up to:      7.0
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'PKIW_VERSION', '1.0.1' );
+define( 'PKIW_VERSION', '1.0.0' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 1.0.1
+Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -136,13 +136,11 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 
 == Changelog ==
 
-= 1.0.1 =
-* Security: syndication handlers now require the per-post `edit_post` capability, closing an IDOR where a user with generic `edit_posts` could syndicate another user's post.
-* Security: Letterboxd lookups use `wp_safe_remote_get` with `reject_unsafe_urls`, so a redirect target can't reach private or loopback hosts.
-* Fixed: like, reply, repost, bookmark, favorite, listen, watch, and read posts now expose the correct microformats2 markup, so webmention receivers and feed readers recognize them as their kind.
-
 = 1.0.0 =
 * Initial WordPress.org release: 24 post kinds with card blocks, media lookup, imports and webhook scrobbling, microformats2 markup, syndication, and Micropub support. Development history for the pre-release builds lives in CHANGELOG.md in the GitHub repository.
+* Security: syndication handlers require the per-post `edit_post` capability, closing an IDOR where a user with generic `edit_posts` could syndicate another user's post.
+* Security: Letterboxd lookups use `wp_safe_remote_get` with `reject_unsafe_urls`, so a redirect target can't reach private or loopback hosts.
+* Fixed: like, reply, repost, bookmark, favorite, listen, watch, and read posts expose the correct microformats2 markup, so webmention receivers and feed readers recognize them as their kind.
 
 == External services ==
 


### PR DESCRIPTION
Sets the initial public release to **1.0.0** for the WordPress.org debut.

- All four version markers → 1.0.0 (header, `PKIW_VERSION`, readme `Stable tag`, `package.json`).
- Folds the security fixes (syndication IDOR, Letterboxd safe-fetch, OAuth callback) and the microformats2 fix into the `[1.0.0]` changelog entry. Those issues lived only in the pre-release GitHub builds / the old live plugin — never on WordPress.org — so the debut ships clean, not as a patch.
- Disambiguates the ancient `[1.0.0] - 2024-12-23 (pre-release GitHub build)` so the two 1.0.0 entries don't collide.

WordPress Plugin Check already passes clean on main. After merge + green CI, this is ready to tag `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)