### PR TITLE
📦 Firehose feed — /firehose (all posts, including imports)

### DIFF
--- a/includes/class-firehose-feed.php
+++ b/includes/class-firehose-feed.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Firehose Feed
+ *
+ * Registers an RSS feed that includes imported posts.
+ *
+ * @package PKIW
+ * @since   1.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PKIW;
+
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Firehose Feed class.
+ */
+final class Firehose_Feed {
+
+	/**
+	 * Register WordPress hooks.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action( 'init', [ $this, 'register_feed' ] );
+		add_filter( 'query_vars', [ $this, 'register_query_var' ] );
+		add_action( 'pre_get_posts', [ $this, 'include_imported_posts' ], 5 );
+	}
+
+	/**
+	 * Register the feed and its root-level rewrite rule.
+	 *
+	 * @return void
+	 */
+	public function register_feed(): void {
+		add_feed( 'firehose', [ $this, 'render' ] );
+		add_rewrite_rule( '^firehose/?$', 'index.php?feed=firehose&pkiw_include_imported=1', 'top' );
+	}
+
+	/**
+	 * Register the imported-post escape hatch as a public query variable.
+	 *
+	 * @param string[] $query_vars Public query variables.
+	 * @return string[] Public query variables.
+	 */
+	public function register_query_var( array $query_vars ): array {
+		$query_vars[] = 'pkiw_include_imported';
+		return $query_vars;
+	}
+
+	/**
+	 * Include imported posts in every firehose feed entry point.
+	 *
+	 * @param \WP_Query $query The WP_Query instance.
+	 * @return void
+	 */
+	public function include_imported_posts( \WP_Query $query ): void {
+		if ( $query->is_main_query() && $query->is_feed( 'firehose' ) ) {
+			$query->set( 'pkiw_include_imported', true );
+		}
+	}
+
+	/**
+	 * Render the core RSS2 feed template.
+	 *
+	 * @return void
+	 */
+	public function render(): void {
+		load_template( ABSPATH . constant( 'WPINC' ) . '/feed-rss2.php' );
+	}
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -483,6 +483,11 @@ final class Plugin {
 			$this->query_filter = new Query_Filter();
 		}
 
+		// Firehose feed (all posts, including imports).
+		if ( class_exists( __NAMESPACE__ . '\\Firehose_Feed' ) ) {
+			( new Firehose_Feed() )->register();
+		}
+
 		// Initialize sync services.
 		$this->init_checkin_sync_services();
 		$this->init_listen_sync_services();

--- a/includes/class-query-filter.php
+++ b/includes/class-query-filter.php
@@ -81,7 +81,8 @@ class Query_Filter {
 		$should_filter = $query->is_home()
 			|| $query->is_front_page()
 			|| ( $query->is_archive() && ! $query->is_tax( 'kind' ) )
-			|| $query->is_search();
+			|| $query->is_search()
+			|| $query->is_feed();
 
 		if ( ! $should_filter ) {
 			return;

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -233,8 +233,8 @@ function activate(): void {
 	// Store activation timestamp for future reference.
 	add_option( 'pkiw_activated', time() );
 
-	// Flush rewrite rules on activation for taxonomy archives.
-	flush_rewrite_rules();
+	// Flush rewrite rules after feed and taxonomy registration on the next init.
+	update_option( 'pkiw_flush_rewrite', true );
 }
 
 /**

--- a/tests/phpunit/integration/FirehoseFeedTest.php
+++ b/tests/phpunit/integration/FirehoseFeedTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Integration tests for the firehose feed.
+ *
+ * @package PKIW
+ */
+
+declare(strict_types=1);
+
+namespace PKIW\Tests\Integration;
+
+use WP_Query;
+use WP_UnitTestCase;
+
+/**
+ * @group integration
+ */
+final class FirehoseFeedTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		update_option( 'pkiw_settings', [ 'import_storage_mode' => 'hidden' ] );
+	}
+
+	public function tear_down(): void {
+		delete_option( 'pkiw_settings' );
+		parent::tear_down();
+	}
+
+	public function test_main_feed_excludes_imported_posts_and_firehose_includes_them(): void {
+		$normal_id   = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$imported_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		add_post_meta( $imported_id, '_pkiw_imported_from', 'lastfm' );
+
+		$main_feed_ids = $this->query_feed( 'rss2' );
+		$firehose_ids  = $this->query_feed( 'firehose' );
+
+		$this->assertSame( [ $normal_id ], $main_feed_ids );
+		$this->assertSame( [ $normal_id, $imported_id ], $firehose_ids );
+	}
+
+	public function test_firehose_feed_and_rewrite_rule_are_registered(): void {
+		global $wp_rewrite;
+
+		$this->assertContains( 'firehose', $wp_rewrite->feeds );
+		$this->assertArrayHasKey( '^firehose/?$', $wp_rewrite->extra_rules_top );
+		$this->assertSame(
+			'index.php?feed=firehose&pkiw_include_imported=1',
+			$wp_rewrite->extra_rules_top['^firehose/?$']
+		);
+		$this->assertContains( 'pkiw_include_imported', apply_filters( 'query_vars', [] ) );
+	}
+
+	/**
+	 * Run a feed request as the main query and return its post IDs.
+	 *
+	 * @param string $feed Feed name.
+	 * @return int[] Post IDs.
+	 */
+	private function query_feed( string $feed ): array {
+		global $wp_query, $wp_the_query;
+
+		$query        = new WP_Query();
+		$wp_query     = $query;
+		$wp_the_query = $query;
+
+		$query->query(
+			[
+				'feed'           => $feed,
+				'fields'         => 'ids',
+				'order'          => 'ASC',
+				'orderby'        => 'ID',
+				'post_status'    => 'publish',
+				'post_type'      => 'post',
+				'posts_per_page' => -1,
+			]
+		);
+
+		return array_map( 'intval', $query->posts );
+	}
+}


### PR DESCRIPTION
Adds a firehose RSS feed at `/firehose`, `/feed/firehose/`, and `?feed=firehose` that includes bulk-imported posts — parity with the classic Post Kinds `/firehose`. Reuses the existing `pkiw_include_imported` escape hatch in `Query_Filter`; a `pre_get_posts` at priority 5 (before `Query_Filter`'s 10) sets it for all three entry points. Activation flush is deferred to the existing `pkiw_flush_rewrite` init handler so the new rewrite rule is captured. Integration test asserts the main feed excludes an imported post while the firehose includes it, plus feed/rewrite/query-var registration. Verified locally: PHPCS clean, PHPStan L5 clean, php -l clean; integration test needs the WP test DB → **CI validates**.

**⚠️ Behavior change to review:** this also adds `|| $query->is_feed()` to `Query_Filter` so non-kind feeds (not just the home feed) exclude imported posts — making the firehose the one feed that carries imports. The main feed already excluded imports via `is_home()`; kind feeds and the firehose are exempt (early-returns). Low blast radius, but it's a user-visible feed change — flagging for your call before merge. **Not auto-merged.**

**Version note:** `@since 1.1.0` (next minor after the 1.0.0 debut; not tagged — release gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)