### PR TITLE
Defer block bindings registration when another plugin owns the source

### DIFF
--- a/includes/class-block-bindings-formats.php
+++ b/includes/class-block-bindings-formats.php
@@ -92,12 +92,42 @@ final class Block_Bindings_Formats {
 	}
 
 	/**
+	 * Is the shared source name already registered by another plugin?
+	 *
+	 * `post-formats/format-data` is a shared namespace, not ours alone. Post
+	 * Formats for Block Themes registers the same source with a superset of our
+	 * keys, and it registers earlier (`after_setup_theme`, priority 99) than we
+	 * do (`init`). Calling register_block_bindings_source() a second time is
+	 * rejected by core with a _doing_it_wrong() notice on every request.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @return bool True when some other plugin has already registered it.
+	 */
+	private static function already_registered(): bool {
+		if ( ! class_exists( '\WP_Block_Bindings_Registry' ) ) {
+			return false;
+		}
+
+		return null !== \WP_Block_Bindings_Registry::get_instance()->get_registered( self::SOURCE_NAME );
+	}
+
+	/**
 	 * Register the block bindings source.
+	 *
+	 * Defers to whichever plugin registered `post-formats/format-data` first.
+	 * Bindings in content keep resolving either way — the other provider serves
+	 * the same keys — so deferring costs nothing and removes the duplicate
+	 * registration notice.
 	 *
 	 * @since 1.3.0
 	 */
 	public function register_source(): void {
 		if ( ! function_exists( 'register_block_bindings_source' ) ) {
+			return;
+		}
+
+		if ( self::already_registered() ) {
 			return;
 		}
 


### PR DESCRIPTION
## What

`register_source()` now checks `WP_Block_Bindings_Registry` and defers if `post-formats/format-data` is already registered.

## Why

`post-formats/format-data` is a shared source name, not ours alone. **Post Formats for Block Themes registers the same source**, on `after_setup_theme` priority 99 — before our `init`. Core rejects the second registration with a `_doing_it_wrong()` notice on every front-end and admin request, and **our source never registers**, so anyone running both plugins silently gets pfbt's implementation only.

pfbt implements a strict superset — our 7 keys plus `format_icon_svg`, `link_url`, `format_permalink_archive` — so deferring to it costs nothing.

## Evidence

Found while building a WP 7.1 RC1 test fixture. Backtrace from a `doing_it_wrong_run` probe:

```
WP_Block_Bindings_Registry->register <- register_block_bindings_source
  <- PKIW\\Block_Bindings_Formats->register_source
```

Isolation control, which is what makes this a collision rather than a self-double-registration:

| Configuration | Notices per request |
|---|---|
| this plugin active, pfbt **deactivated** | 0 |
| both active | 1 |

## Verified after the fix

WordPress 7.0.2, PHP 8.4.23:

- both active → **0 notices**, source still registered
- pfbt deactivated → **we still register it**, 0 notices

That second check matters — a guard that silently broke this plugin standalone would be worse than the bug.

## Evidence ceiling

Not tested: whether the two implementations return equivalent values for the same keys. If they differ, this is a wrong-data bug rather than only a noisy one, and deferring would be the wrong fix. Worth checking separately.