### PR TITLE
🐛 FIX: Register all 13 abilities, names used underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- All 13 abilities now actually register. Their names used underscores (`post_kinds/list_kinds`, `post_kinds/lookup_book`), and core's `WP_Abilities_Registry::register()` only accepts `/^[a-z0-9-]+\/[a-z0-9-]+$/` — lowercase alphanumerics, dashes, one slash. Every one was refused with a `_doing_it_wrong()` notice and nothing else, so with `WP_DEBUG` off they had been missing since 1.1.0 without a trace. Renamed to dashes throughout (`post-kinds/list-kinds`, `post-kinds/lookup-book`), including the MCP server list and the `post_kinds/` prefix check in `Abilities_Manager::filter_ability_args()`. No aliases: the old names never registered, so nothing can be calling them.
+
+### Added
+
+- `AbilitiesRegistrationTest` asserts every declared ability is present in `wp_get_abilities()` after init, that declared names satisfy core's grammar, and that the declared list and the registry agree in both directions. A rejected name now fails CI instead of vanishing into a notice.
+
 ## [1.0.0] - 2026-07-20
 
 Initial public WordPress.org release — the full feature set from the pre-release GitHub builds (through 1.4.3, listed below), plus the final pre-launch changes noted here.

--- a/includes/abilities/class-core-abilities.php
+++ b/includes/abilities/class-core-abilities.php
@@ -137,7 +137,7 @@ final class Core_Abilities {
 	 */
 	private function register_list_kinds(): void {
 		wp_register_ability(
-			'post_kinds/list_kinds',
+			'post-kinds/list-kinds',
 			[
 				'label'               => __( 'List Kinds', 'post-kinds-for-indieweb-in-block-themes' ),
 				'description'         => __( 'Lists all available post kinds with slugs, labels, and descriptions.', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -177,7 +177,7 @@ final class Core_Abilities {
 	 */
 	private function register_list_kind_fields(): void {
 		wp_register_ability(
-			'post_kinds/list_kind_fields',
+			'post-kinds/list-kind-fields',
 			[
 				'label'               => __( 'List Kind Fields', 'post-kinds-for-indieweb-in-block-themes' ),
 				'description'         => __( 'Lists meta fields available for a specific kind.', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -222,7 +222,7 @@ final class Core_Abilities {
 	 */
 	private function register_create_post(): void {
 		wp_register_ability(
-			'post_kinds/create_post',
+			'post-kinds/create-post',
 			[
 				'label'               => __( 'Create Post', 'post-kinds-for-indieweb-in-block-themes' ),
 				'description'         => __( 'Creates a post with a kind and optional meta fields.', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -274,7 +274,7 @@ final class Core_Abilities {
 	 */
 	private function register_set_kind(): void {
 		wp_register_ability(
-			'post_kinds/set_kind',
+			'post-kinds/set-kind',
 			[
 				'label'               => __( 'Set Kind', 'post-kinds-for-indieweb-in-block-themes' ),
 				'description'         => __( 'Sets the kind on an existing post.', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -315,7 +315,7 @@ final class Core_Abilities {
 	 */
 	private function register_get_kind(): void {
 		wp_register_ability(
-			'post_kinds/get_kind',
+			'post-kinds/get-kind',
 			[
 				'label'               => __( 'Get Kind', 'post-kinds-for-indieweb-in-block-themes' ),
 				'description'         => __( 'Gets the kind assigned to a post.', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -352,7 +352,7 @@ final class Core_Abilities {
 	 */
 	private function register_update_post_meta(): void {
 		wp_register_ability(
-			'post_kinds/update_post_meta',
+			'post-kinds/update-post-meta',
 			[
 				'label'               => __( 'Update Post Meta', 'post-kinds-for-indieweb-in-block-themes' ),
 				'description'         => __( 'Updates a single meta field on a post.', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -396,7 +396,7 @@ final class Core_Abilities {
 	 */
 	private function register_get_post_meta(): void {
 		wp_register_ability(
-			'post_kinds/get_post_meta',
+			'post-kinds/get-post-meta',
 			[
 				'label'               => __( 'Get Post Meta', 'post-kinds-for-indieweb-in-block-themes' ),
 				'description'         => __( 'Gets meta fields from a post.', 'post-kinds-for-indieweb-in-block-themes' ),

--- a/includes/abilities/class-lookup-abilities.php
+++ b/includes/abilities/class-lookup-abilities.php
@@ -89,7 +89,7 @@ final class Lookup_Abilities {
 	public function register(): void {
 		foreach ( $this->get_lookup_definitions() as $slug => $definition ) {
 			wp_register_ability(
-				'post_kinds/lookup_' . $slug,
+				'post-kinds/lookup-' . $slug,
 				[
 					'label'               => $definition['label'],
 					'description'         => $definition['description'],

--- a/includes/class-abilities-manager.php
+++ b/includes/class-abilities-manager.php
@@ -205,19 +205,19 @@ final class Abilities_Manager {
 	 */
 	public static function get_ability_names(): array {
 		return [
-			'post_kinds/list_kinds',
-			'post_kinds/list_kind_fields',
-			'post_kinds/create_post',
-			'post_kinds/set_kind',
-			'post_kinds/get_kind',
-			'post_kinds/update_post_meta',
-			'post_kinds/get_post_meta',
-			'post_kinds/lookup_music',
-			'post_kinds/lookup_video',
-			'post_kinds/lookup_book',
-			'post_kinds/lookup_podcast',
-			'post_kinds/lookup_venue',
-			'post_kinds/lookup_game',
+			'post-kinds/list-kinds',
+			'post-kinds/list-kind-fields',
+			'post-kinds/create-post',
+			'post-kinds/set-kind',
+			'post-kinds/get-kind',
+			'post-kinds/update-post-meta',
+			'post-kinds/get-post-meta',
+			'post-kinds/lookup-music',
+			'post-kinds/lookup-video',
+			'post-kinds/lookup-book',
+			'post-kinds/lookup-podcast',
+			'post-kinds/lookup-venue',
+			'post-kinds/lookup-game',
 		];
 	}
 
@@ -253,7 +253,7 @@ final class Abilities_Manager {
 	 * @return array Modified arguments.
 	 */
 	public static function filter_ability_args( array $args, string $name ): array {
-		if ( ! str_starts_with( $name, 'post_kinds/' ) ) {
+		if ( ! str_starts_with( $name, 'post-kinds/' ) ) {
 			return $args;
 		}
 

--- a/tests/phpunit/integration/AbilitiesRegistrationTest.php
+++ b/tests/phpunit/integration/AbilitiesRegistrationTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Abilities registration integration coverage.
+ *
+ * @package PKIW
+ */
+
+declare(strict_types=1);
+
+use PKIW\Abilities_Manager;
+
+/**
+ * Verifies every declared ability actually lands in the registry.
+ *
+ * Core rejects an ability name that doesn't match /^[a-z0-9-]+\/[a-z0-9-]+$/
+ * with a _doing_it_wrong() notice and registers nothing. With WP_DEBUG off
+ * that is completely silent, which is how thirteen `post_kinds/*` names sat
+ * unregistered from 1.1.0 until the WP 7.1-RC1 audit found them. Asserting on
+ * wp_get_abilities() is what separates "we called wp_register_ability()" from
+ * "the ability exists" — the manager-level unit tests can't tell the two apart.
+ *
+ * @group integration
+ * @covers \PKIW\Abilities_Manager
+ */
+final class AbilitiesRegistrationTest extends WP_UnitTestCase {
+
+	/**
+	 * Core's ability name grammar, copied from WP_Abilities_Registry::register().
+	 */
+	private const NAME_PATTERN = '/^[a-z0-9-]+\/[a-z0-9-]+$/';
+
+	/**
+	 * Every declared name must satisfy core's grammar.
+	 *
+	 * Runs without the Abilities API present so a bad name fails fast and
+	 * points at itself, rather than surfacing as a missing-key assertion.
+	 */
+	public function test_declared_names_match_core_grammar(): void {
+		foreach ( Abilities_Manager::get_ability_names() as $name ) {
+			$this->assertMatchesRegularExpression(
+				self::NAME_PATTERN,
+				$name,
+				sprintf( 'Ability "%s" would be rejected by WP_Abilities_Registry::register().', $name )
+			);
+		}
+	}
+
+	/**
+	 * Every declared ability is present in the registry after init.
+	 */
+	public function test_declared_abilities_are_registered(): void {
+		$this->skip_without_abilities_api();
+
+		$registered = array_keys( wp_get_abilities() );
+		$declared   = Abilities_Manager::get_ability_names();
+
+		$missing = array_diff( $declared, $registered );
+
+		$this->assertSame(
+			[],
+			array_values( $missing ),
+			'Declared abilities are missing from the registry: ' . implode( ', ', $missing )
+		);
+	}
+
+	/**
+	 * Nothing registers under post-kinds/ without being declared.
+	 *
+	 * Abilities_Manager::get_ability_names() is what feeds the WP Pinch MCP
+	 * server list, so an ability that registers but isn't declared is invisible
+	 * to MCP callers.
+	 */
+	public function test_registered_abilities_are_all_declared(): void {
+		$this->skip_without_abilities_api();
+
+		$registered = array_keys( wp_get_abilities( [ 'namespace' => 'post-kinds' ] ) );
+		$undeclared = array_diff( $registered, Abilities_Manager::get_ability_names() );
+
+		$this->assertSame(
+			[],
+			array_values( $undeclared ),
+			'Abilities registered but not declared in get_ability_names(): ' . implode( ', ', $undeclared )
+		);
+	}
+
+	/**
+	 * The declared set is the full 13 — 7 core plus 6 lookups.
+	 */
+	public function test_declared_ability_count(): void {
+		$this->assertCount( 13, Abilities_Manager::get_ability_names() );
+	}
+
+	/**
+	 * Skip when running against a WordPress without the Abilities API.
+	 */
+	private function skip_without_abilities_api(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available on this WordPress version (needs 6.9+).' );
+		}
+	}
+}


### PR DESCRIPTION
None of this plugin's 13 abilities have ever registered.

`WP_Abilities_Registry::register()` validates names against `/^[a-z0-9-]+\/[a-z0-9-]+$/` — lowercase alphanumerics, dashes, one slash. Every `post_kinds/*` name had underscores in both halves, so each was refused with a `_doing_it_wrong()` notice and nothing else. With `WP_DEBUG` off that's completely silent, which is why they've been missing since 1.1.0 without anyone noticing.

Not a WordPress 7.1 regression. The regex is byte-identical in 7.0.2 and 7.1-RC1 and the check dates to 6.9.0; testing RC1 is just what surfaced it.

## What changed

`post_kinds/list_kinds` -> `post-kinds/list-kinds`, and so on for all 13 (7 core plus the 6 loop-built `lookup_<slug>` names). That covers the ability names themselves, the MCP server list in `Abilities_Manager::get_ability_names()`, and the `post_kinds/` prefix check in `filter_ability_args()`.

No back-compat aliases or deprecation shims. The old names never made it into the registry, so nothing external can be calling them.

## Test

`tests/phpunit/integration/AbilitiesRegistrationTest.php` asserts:

- every declared name satisfies core's grammar (runs even without the Abilities API, so a bad name fails fast and names itself)
- every declared ability is present in `wp_get_abilities()` after init
- nothing registers under `post-kinds/` without being declared, since `get_ability_names()` is what feeds the MCP server list
- the declared set is still 13

Confirmed the test actually bites: reverting one name to `post_kinds/list_kinds` fails it.

## Verification

On a WP 7.1-RC1 site with `WP_DEBUG` on, via a `doing_it_wrong_run` probe across all three plugins:

| | before | after |
|---|---|---|
| registry rejections | 33 | 0 |
| abilities registered | 12 | 44 |

Suites: `phpunit --testsuite=unit` 1070 pass, `--testsuite=integration` 142 pass (2 pre-existing risky output-buffer warnings in `SyndicationPageAuthorizationTest`, unchanged on a clean checkout). `composer lint` and `composer analyze` clean.