### PR TITLE
🐛 FIX: markdown lint errors breaking the Docs workflow on main

### DIFF
--- a/docs/src/content/docs/screenshots.md
+++ b/docs/src/content/docs/screenshots.md
@@ -84,4 +84,3 @@ The **Check-in Dashboard** block: show your check-in history on any page. See [C
 ![Quick Post page with media search and manual entry form](../../assets/screenshots/admin-quick-post.png)
 
 **Reactions → Quick Post**: create a reaction post without opening the editor. See [Settings](/post-kinds-for-indieweb/settings/).
-

--- a/docs/src/content/docs/standard-site.md
+++ b/docs/src/content/docs/standard-site.md
@@ -48,8 +48,8 @@ Resolution is available directly:
 $result = \PKIW\Standard_Site::resolve_url( 'https://example.com/a-post' );
 
 if ( $result && $result['verified'] ) {
-	echo $result['record']['title'];
-	echo $result['publication']['record']['name'] ?? '';
+    echo $result['record']['title'];
+    echo $result['publication']['record']['name'] ?? '';
 }
 ```
 


### PR DESCRIPTION
`npm run lint:md` fails on `main` right now, so the Docs workflow is red.

```
standard-site.md:51:1  MD010/no-hard-tabs
standard-site.md:52:1  MD010/no-hard-tabs
screenshots.md:88      MD012/no-multiple-blanks
```

The hard tabs are mine — #129 added that page with tab-indented PHP examples, and it is the only docs page that used tabs. Converted to spaces to match the other fourteen.

The blank lines in `screenshots.md` predate this (#121) and fail the same job, so they are fixed here too rather than left to break the next branch.

`lint:md` now reports 0 errors across 15 files, and the docs site builds.

Worth noting for next time: I ran `npm run build` and `npm run check:links` on #129 but not `npm run lint:md`, which is why this reached main.