### PR TITLE
🐛 FIX: Advertise only registered abilities to the WP Pinch MCP server

### DIFF
--- a/includes/class-abilities-manager.php
+++ b/includes/class-abilities-manager.php
@@ -232,7 +232,13 @@ final class Abilities_Manager {
 	}
 
 	/**
-	 * Append Post Kinds abilities to the MCP server abilities list.
+	 * Append registered Post Kinds abilities to the MCP server abilities list.
+	 *
+	 * Only names present in the abilities registry are advertised. In
+	 * lifecycles where wp_abilities_api_init never registered the Post Kinds
+	 * abilities (e.g. WP-CLI building the MCP tool list before init), an
+	 * advertised-but-unregistered name makes the mcp-adapter log an error
+	 * per name, so unregistered names must stay off the list.
 	 *
 	 * @since 1.1.0
 	 *
@@ -240,7 +246,14 @@ final class Abilities_Manager {
 	 * @return array Modified ability name strings.
 	 */
 	public static function filter_mcp_server_abilities( array $abilities ): array {
-		return array_merge( $abilities, self::get_ability_names() );
+		if ( ! function_exists( 'wp_has_ability' ) || ! did_action( 'init' ) ) {
+			return $abilities;
+		}
+
+		return array_merge(
+			$abilities,
+			array_values( array_filter( self::get_ability_names(), 'wp_has_ability' ) )
+		);
 	}
 
 	/**

--- a/tests/phpunit/integration/McpServerAbilitiesTest.php
+++ b/tests/phpunit/integration/McpServerAbilitiesTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * MCP server abilities advertisement coverage.
+ *
+ * @package PKIW
+ */
+
+declare(strict_types=1);
+
+use PKIW\Abilities_Manager;
+
+/**
+ * Verifies the wp_pinch_mcp_server_abilities filter only advertises
+ * abilities that actually exist in the registry.
+ *
+ * WP Pinch's MCP adapter builds its tool list from the advertised names and
+ * logs a "WordPress ability '<name>' does not exist" error for every name it
+ * can't resolve. Under WP-CLI the adapter can run in a lifecycle where
+ * wp_abilities_api_init never registered the Post Kinds abilities, so an
+ * unconditional advertise produces one logged error per declared ability on
+ * every wp invocation.
+ *
+ * @group integration
+ * @covers \PKIW\Abilities_Manager
+ */
+final class McpServerAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Reset registry state so later tests rebuild it lazily.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'wp_pinch_mcp_server_abilities' );
+		$this->reset_abilities_registry();
+		parent::tear_down();
+	}
+
+	/**
+	 * Discard the WP_Abilities_Registry singleton so the next abilities call
+	 * rebuilds it lazily from whatever wp_abilities_api_init listeners exist.
+	 *
+	 * WP_UnitTestCase restores $wp_filter between tests, so resetting here
+	 * leaves no registry or hook state behind for later tests.
+	 */
+	private function reset_abilities_registry(): void {
+		if ( ! class_exists( 'WP_Abilities_Registry' ) ) {
+			return;
+		}
+
+		$property = new \ReflectionProperty( \WP_Abilities_Registry::class, 'instance' );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Skip when running against a WordPress without the Abilities API.
+	 */
+	private function skip_without_abilities_api(): void {
+		if ( ! function_exists( 'wp_has_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available on this WordPress version (needs 6.9+).' );
+		}
+	}
+
+	/**
+	 * Regression for the staging mcp-adapter errors: in a lifecycle where
+	 * wp_abilities_api_init never registered the Post Kinds abilities,
+	 * advertising the declared names makes the adapter log one "ability does
+	 * not exist" error per name. With no registered abilities, the filter
+	 * must return the incoming list untouched.
+	 */
+	public function test_filter_advertises_nothing_when_no_abilities_registered(): void {
+		$this->skip_without_abilities_api();
+
+		$this->reset_abilities_registry();
+		remove_all_actions( 'wp_abilities_api_init' );
+
+		$result = Abilities_Manager::filter_mcp_server_abilities( [] );
+
+		$this->assertSame( [], $result );
+	}
+
+	/**
+	 * Existing non-Post-Kinds entries pass through unchanged when the Post
+	 * Kinds abilities never registered.
+	 */
+	public function test_filter_preserves_existing_entries_when_no_abilities_registered(): void {
+		$this->skip_without_abilities_api();
+
+		$this->reset_abilities_registry();
+		remove_all_actions( 'wp_abilities_api_init' );
+
+		$result = Abilities_Manager::filter_mcp_server_abilities( [ 'other/ability' ] );
+
+		$this->assertSame( [ 'other/ability' ], $result );
+	}
+
+	/**
+	 * Once the registry initializes and the plugin's wp_abilities_api_init
+	 * listener registers the abilities, the filter advertises all of them.
+	 */
+	public function test_filter_advertises_registered_abilities(): void {
+		$this->skip_without_abilities_api();
+
+		$this->reset_abilities_registry();
+
+		$result = Abilities_Manager::filter_mcp_server_abilities( [ 'other/ability' ] );
+
+		$this->assertContains( 'other/ability', $result );
+		foreach ( Abilities_Manager::get_ability_names() as $name ) {
+			$this->assertContains( $name, $result );
+			$this->assertTrue( wp_has_ability( $name ), sprintf( 'Ability "%s" should be registered.', $name ) );
+		}
+	}
+
+	/**
+	 * When only part of the declared set is registered, the filter advertises
+	 * exactly that registered subset.
+	 */
+	public function test_filter_advertises_only_registered_subset(): void {
+		$this->skip_without_abilities_api();
+
+		$this->reset_abilities_registry();
+		wp_get_abilities(); // Force lazy registry init so the abilities register.
+
+		$missing = [ 'post-kinds/lookup-venue', 'post-kinds/lookup-game' ];
+		foreach ( $missing as $name ) {
+			wp_unregister_ability( $name );
+		}
+
+		$result = Abilities_Manager::filter_mcp_server_abilities( [] );
+
+		$expected = array_values( array_diff( Abilities_Manager::get_ability_names(), $missing ) );
+		$this->assertSame( $expected, $result );
+	}
+}


### PR DESCRIPTION
On staging, every `wp` invocation logs one mcp-adapter error per Post Kinds ability: `WordPress ability 'post_kinds/list_kinds' does not exist.` The underscore names in that log are the pre-#126 build — updating the staging plugin clears those specifically — but the mechanism outlives the rename: `Abilities_Manager::filter_mcp_server_abilities()` appends all 13 declared names to `wp_pinch_mcp_server_abilities` unconditionally, and under WP-CLI the MCP adapter builds its tool list in a lifecycle where `wp_abilities_api_init` never registered them. Any advertised-but-unregistered name gets logged as an error by the adapter.

Same defect and fix as link-extension-for-xfn#19.

## What changed

The filter now bails before `init` (which also keeps it from triggering the abilities registry's lazy init earlier than core intends), then advertises only the names `wp_has_ability()` confirms. `wp_has_ability()` rather than `wp_get_ability()` because the getter fires `_doing_it_wrong()` for missing names — the guard shouldn't swap adapter errors for core notices.

## Test

`tests/phpunit/integration/McpServerAbilitiesTest.php` (mirrors the link-extension-for-xfn regression tests, reflection-reset of `WP_Abilities_Registry::$instance` in `tear_down`) asserts:

- with no abilities registered, the filter returns the incoming list untouched
- existing non-Post-Kinds entries pass through unchanged
- once the registry initializes, all 13 registered abilities are advertised
- with two abilities unregistered, exactly the remaining subset is advertised

Confirmed the tests bite: 3 of 4 fail against the unguarded filter.

Local runs: full unit (1090) and integration (146) suites green, PHPCS 0 errors, PHPStan level 5 clean.
