### PR TITLE
📦 NEW: Filterable kind labels and a pk-caption strip on cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `AbilitiesRegistrationTest` asserts every declared ability is present in `wp_get_abilities()` after init, that declared names satisfy core's grammar, and that the declared list and the registry agree in both directions. A rejected name now fails CI instead of vanishing into a notice.
+- `pkiw_kind_label` filter. Every card's visible `.pk-kindlabel` text — the block templates and the generic Stream card — now flows through `PKIW\get_kind_label( $label, $kind, $context )`, so a theme can swap the kind noun ("Watch", "Acquisition") for a status verb ("WATCHED", "GOT IT") per kind or per render context. Default output is unchanged when nothing hooks the filter.
+- Card templates group the title, date, and sub lines (year, players, venue, …) in a `<div class="pk-caption">` wrapper so themes can style them as one tight caption strip. Additive markup only; every existing class and microformat stays where it was.
 
 ## [1.0.0] - 2026-07-20
 

--- a/build/blocks/acquisition-card/render.php
+++ b/build/blocks/acquisition-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title       = $attributes['title'] ?? '';
 $pkiw_type        = $attributes['acquisitionType'] ?? '';
@@ -52,32 +53,34 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'acquisition' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php echo esc_html( $pkiw_type_label ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( $pkiw_type_label, 'acquisition', 'acquisition-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_where_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_where_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_where_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_where_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_cost || $pkiw_where ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_cost ) : ?>
-					<span><?php echo esc_html( $pkiw_cost ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_cost && $pkiw_where ) :
-					?>
-					<span class="pk-dot"></span><?php endif; ?>
-				<?php if ( $pkiw_where ) : ?>
-					<span class="p-location"><?php printf( /* translators: %s: place the item was acquired. */ esc_html__( 'from %s', 'post-kinds-for-indieweb-in-block-themes' ), esc_html( $pkiw_where ) ); ?></span>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_cost || $pkiw_where ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_cost ) : ?>
+						<span><?php echo esc_html( $pkiw_cost ); ?></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_cost && $pkiw_where ) :
+						?>
+						<span class="pk-dot"></span><?php endif; ?>
+					<?php if ( $pkiw_where ) : ?>
+						<span class="p-location"><?php printf( /* translators: %s: place the item was acquired. */ esc_html__( 'from %s', 'post-kinds-for-indieweb-in-block-themes' ), esc_html( $pkiw_where ) ); ?></span>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_photo ) : ?>
 			<div class="pk-media">

--- a/build/blocks/bookmark-card/render.php
+++ b/build/blocks/bookmark-card/render.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title         = $attributes['title'] ?? '';
 $pkiw_url           = $attributes['url'] ?? '';
@@ -45,23 +46,25 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'bookmark' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Bookmark', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Bookmark', 'post-kinds-for-indieweb-in-block-themes' ), 'bookmark', 'bookmark-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_description ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_description ); ?></p>

--- a/build/blocks/checkin-card/render.php
+++ b/build/blocks/checkin-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_venue_name       = $attributes['venueName'] ?? '';
 $pkiw_venue_type       = $attributes['venueType'] ?? 'place';
@@ -88,7 +89,7 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'checkin' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Check-in', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Check-in', 'post-kinds-for-indieweb-in-block-themes' ), 'checkin', 'checkin-card' ) ); ?></p>
 
 		<?php if ( $pkiw_is_private ) : ?>
 			<p class="pk-note">
@@ -112,56 +113,58 @@ ob_start();
 				<?php endif; ?>
 			</div>
 		<?php else : ?>
-			<?php if ( $pkiw_venue_name ) : ?>
-				<h2 class="pk-title p-name">
-					<?php if ( $pkiw_venue_url ) : ?>
-						<a class="u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_venue_name ); ?></a>
-					<?php else : ?>
-						<?php echo esc_html( $pkiw_venue_name ); ?>
+			<div class="pk-caption">
+				<?php if ( $pkiw_venue_name ) : ?>
+					<h2 class="pk-title p-name">
+						<?php if ( $pkiw_venue_url ) : ?>
+							<a class="u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_venue_name ); ?></a>
+						<?php else : ?>
+							<?php echo esc_html( $pkiw_venue_name ); ?>
+						<?php endif; ?>
+					</h2>
+				<?php endif; ?>
+
+				<p class="pk-sub p-location h-card">
+					<?php if ( $pkiw_show_address ) : ?>
+						<span class="p-street-address"><?php echo esc_html( $pkiw_address ); ?></span>
 					<?php endif; ?>
-				</h2>
-			<?php endif; ?>
 
-			<p class="pk-sub p-location h-card">
-				<?php if ( $pkiw_show_address ) : ?>
-					<span class="p-street-address"><?php echo esc_html( $pkiw_address ); ?></span>
-				<?php endif; ?>
+					<?php if ( $pkiw_locality || $pkiw_region || $pkiw_country ) : ?>
+						<span class="pk-sub-parts">
+							<?php if ( $pkiw_locality ) : ?>
+								<span class="p-locality"><?php echo esc_html( $pkiw_locality ); ?></span>
+							<?php endif; ?>
+							<?php
+							if ( $pkiw_locality && $pkiw_region ) {
+								echo ', ';
+							}
+							?>
+							<?php if ( $pkiw_region ) : ?>
+								<span class="p-region"><?php echo esc_html( $pkiw_region ); ?></span>
+							<?php endif; ?>
+							<?php
+							if ( ( $pkiw_locality || $pkiw_region ) && $pkiw_country ) {
+								echo ', ';
+							}
+							?>
+							<?php if ( $pkiw_country ) : ?>
+								<span class="p-country-name"><?php echo esc_html( $pkiw_country ); ?></span>
+							<?php endif; ?>
+						</span>
+					<?php endif; ?>
 
-				<?php if ( $pkiw_locality || $pkiw_region || $pkiw_country ) : ?>
-					<span class="pk-sub-parts">
-						<?php if ( $pkiw_locality ) : ?>
-							<span class="p-locality"><?php echo esc_html( $pkiw_locality ); ?></span>
-						<?php endif; ?>
-						<?php
-						if ( $pkiw_locality && $pkiw_region ) {
-							echo ', ';
-						}
-						?>
-						<?php if ( $pkiw_region ) : ?>
-							<span class="p-region"><?php echo esc_html( $pkiw_region ); ?></span>
-						<?php endif; ?>
-						<?php
-						if ( ( $pkiw_locality || $pkiw_region ) && $pkiw_country ) {
-							echo ', ';
-						}
-						?>
-						<?php if ( $pkiw_country ) : ?>
-							<span class="p-country-name"><?php echo esc_html( $pkiw_country ); ?></span>
-						<?php endif; ?>
-					</span>
-				<?php endif; ?>
+					<?php if ( $pkiw_is_public && $pkiw_postal_code ) : ?>
+						<span class="p-postal-code"><?php echo esc_html( $pkiw_postal_code ); ?></span>
+					<?php endif; ?>
 
-				<?php if ( $pkiw_is_public && $pkiw_postal_code ) : ?>
-					<span class="p-postal-code"><?php echo esc_html( $pkiw_postal_code ); ?></span>
-				<?php endif; ?>
-
-				<?php if ( $pkiw_show_coords ) : ?>
-					<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_uri ); ?>">
-						<data class="p-latitude" value="<?php echo esc_attr( (string) $pkiw_latitude ); ?>" hidden></data>
-						<data class="p-longitude" value="<?php echo esc_attr( (string) $pkiw_longitude ); ?>" hidden></data>
-					</data>
-				<?php endif; ?>
-			</p>
+					<?php if ( $pkiw_show_coords ) : ?>
+						<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_uri ); ?>">
+							<data class="p-latitude" value="<?php echo esc_attr( (string) $pkiw_latitude ); ?>" hidden></data>
+							<data class="p-longitude" value="<?php echo esc_attr( (string) $pkiw_longitude ); ?>" hidden></data>
+						</data>
+					<?php endif; ?>
+				</p>
+			</div>
 
 			<?php if ( $pkiw_show_map_emb ) : ?>
 				<div class="pk-embed pk-embed--map">

--- a/build/blocks/drink-card/render.php
+++ b/build/blocks/drink-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_drink_labels = [
 	'coffee'   => __( 'Coffee', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -73,52 +74,54 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'drink' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Drank', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Drank', 'post-kinds-for-indieweb-in-block-themes' ), 'drink', 'drink-card' ) ); ?></p>
 
-		<?php if ( $pkiw_name ) : ?>
-			<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_name ) : ?>
+				<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_brand || $pkiw_badge_label ) : ?>
-			<p class="pk-sub">
-				<span><?php echo esc_html( $pkiw_badge_label ); ?></span>
-				<?php
-				if ( $pkiw_badge_label && $pkiw_brand ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_brand ) : ?>
-					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_brand ); ?></span></span>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_brand || $pkiw_badge_label ) : ?>
+				<p class="pk-sub">
+					<span><?php echo esc_html( $pkiw_badge_label ); ?></span>
+					<?php
+					if ( $pkiw_badge_label && $pkiw_brand ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_brand ) : ?>
+						<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_brand ); ?></span></span>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_location_name ) : ?>
-			<p class="pk-sub p-location h-card">
-				<?php if ( $pkiw_venue_url ) : ?>
-					<a class="pk-chip p-name u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_location_name ); ?></a>
-				<?php else : ?>
-					<span class="pk-chip p-name"><?php echo esc_html( $pkiw_location_name ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_address ) : ?>
-					<span class="p-street-address"><?php echo esc_html( $pkiw_location_address ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_locality ) : ?>
-					<span class="p-locality"><?php echo esc_html( $pkiw_location_locality ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_region ) : ?>
-					<span class="p-region"><?php echo esc_html( $pkiw_location_region ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_country ) : ?>
-					<span class="p-country-name"><?php echo esc_html( $pkiw_location_country ); ?></span>
-				<?php endif; ?>
-				<?php if ( 0.0 !== $pkiw_geo_lat || 0.0 !== $pkiw_geo_lon ) : ?>
-					<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_lat . ',' . $pkiw_geo_lon ); ?>" hidden>
-						<span class="p-latitude"><?php echo esc_html( (string) $pkiw_geo_lat ); ?></span>
-						<span class="p-longitude"><?php echo esc_html( (string) $pkiw_geo_lon ); ?></span>
-					</data>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_location_name ) : ?>
+				<p class="pk-sub p-location h-card">
+					<?php if ( $pkiw_venue_url ) : ?>
+						<a class="pk-chip p-name u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_location_name ); ?></a>
+					<?php else : ?>
+						<span class="pk-chip p-name"><?php echo esc_html( $pkiw_location_name ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_address ) : ?>
+						<span class="p-street-address"><?php echo esc_html( $pkiw_location_address ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_locality ) : ?>
+						<span class="p-locality"><?php echo esc_html( $pkiw_location_locality ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_region ) : ?>
+						<span class="p-region"><?php echo esc_html( $pkiw_location_region ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_country ) : ?>
+						<span class="p-country-name"><?php echo esc_html( $pkiw_location_country ); ?></span>
+					<?php endif; ?>
+					<?php if ( 0.0 !== $pkiw_geo_lat || 0.0 !== $pkiw_geo_lon ) : ?>
+						<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_lat . ',' . $pkiw_geo_lon ); ?>" hidden>
+							<span class="p-latitude"><?php echo esc_html( (string) $pkiw_geo_lat ); ?></span>
+							<span class="p-longitude"><?php echo esc_html( (string) $pkiw_geo_lon ); ?></span>
+						</data>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/build/blocks/eat-card/render.php
+++ b/build/blocks/eat-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_name              = $attributes['name'] ?? '';
 $pkiw_restaurant        = $attributes['restaurant'] ?? '';
@@ -59,54 +60,56 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'eat' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Ate', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Ate', 'post-kinds-for-indieweb-in-block-themes' ), 'eat', 'eat-card' ) ); ?></p>
 
-		<?php if ( $pkiw_name ) : ?>
-			<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_name ) : ?>
+				<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_restaurant || $pkiw_cuisine ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_restaurant ) : ?>
-					<span class="p-location h-card"><span class="p-name"><?php echo esc_html( $pkiw_restaurant ); ?></span></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_restaurant && $pkiw_cuisine ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_cuisine ) : ?>
-					<em><?php echo esc_html( $pkiw_cuisine ); ?></em>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_restaurant || $pkiw_cuisine ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_restaurant ) : ?>
+						<span class="p-location h-card"><span class="p-name"><?php echo esc_html( $pkiw_restaurant ); ?></span></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_restaurant && $pkiw_cuisine ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_cuisine ) : ?>
+						<em><?php echo esc_html( $pkiw_cuisine ); ?></em>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_location_name ) : ?>
-			<p class="pk-sub p-location h-card">
-				<?php if ( $pkiw_restaurant_url ) : ?>
-					<a class="pk-chip p-name u-url" href="<?php echo esc_url( $pkiw_restaurant_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_location_name ); ?></a>
-				<?php else : ?>
-					<span class="pk-chip p-name"><?php echo esc_html( $pkiw_location_name ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_address ) : ?>
-					<span class="p-street-address"><?php echo esc_html( $pkiw_location_address ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_locality ) : ?>
-					<span class="p-locality"><?php echo esc_html( $pkiw_location_locality ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_region ) : ?>
-					<span class="p-region"><?php echo esc_html( $pkiw_location_region ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_country ) : ?>
-					<span class="p-country-name"><?php echo esc_html( $pkiw_location_country ); ?></span>
-				<?php endif; ?>
-				<?php if ( 0.0 !== $pkiw_geo_lat || 0.0 !== $pkiw_geo_lon ) : ?>
-					<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_lat . ',' . $pkiw_geo_lon ); ?>" hidden>
-						<span class="p-latitude"><?php echo esc_html( (string) $pkiw_geo_lat ); ?></span>
-						<span class="p-longitude"><?php echo esc_html( (string) $pkiw_geo_lon ); ?></span>
-					</data>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_location_name ) : ?>
+				<p class="pk-sub p-location h-card">
+					<?php if ( $pkiw_restaurant_url ) : ?>
+						<a class="pk-chip p-name u-url" href="<?php echo esc_url( $pkiw_restaurant_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_location_name ); ?></a>
+					<?php else : ?>
+						<span class="pk-chip p-name"><?php echo esc_html( $pkiw_location_name ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_address ) : ?>
+						<span class="p-street-address"><?php echo esc_html( $pkiw_location_address ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_locality ) : ?>
+						<span class="p-locality"><?php echo esc_html( $pkiw_location_locality ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_region ) : ?>
+						<span class="p-region"><?php echo esc_html( $pkiw_location_region ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_country ) : ?>
+						<span class="p-country-name"><?php echo esc_html( $pkiw_location_country ); ?></span>
+					<?php endif; ?>
+					<?php if ( 0.0 !== $pkiw_geo_lat || 0.0 !== $pkiw_geo_lon ) : ?>
+						<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_lat . ',' . $pkiw_geo_lon ); ?>" hidden>
+							<span class="p-latitude"><?php echo esc_html( (string) $pkiw_geo_lat ); ?></span>
+							<span class="p-longitude"><?php echo esc_html( (string) $pkiw_geo_lon ); ?></span>
+						</data>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/build/blocks/favorite-card/render.php
+++ b/build/blocks/favorite-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title        = $attributes['title'] ?? '';
 $pkiw_url          = $attributes['url'] ?? '';
@@ -42,21 +43,23 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'favorite' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Favorite', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Favorite', 'post-kinds-for-indieweb-in-block-themes' ), 'favorite', 'favorite-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub"><span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span></p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub"><span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span></p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_image ) : ?>
 			<div class="pk-media">

--- a/build/blocks/jam-card/render.php
+++ b/build/blocks/jam-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use function PKIW\get_cached_embed_html;
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title     = $attributes['title'] ?? '';
 $pkiw_artist    = $attributes['artist'] ?? '';
@@ -49,32 +50,34 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'jam' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Jam', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Jam', 'post-kinds-for-indieweb-in-block-themes' ), 'jam', 'jam-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url u-jam-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url u-jam-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_artist || $pkiw_album ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_artist ) : ?>
-					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_artist ); ?></span></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_artist && $pkiw_album ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_album ) : ?>
-					<em><?php echo esc_html( $pkiw_album ); ?></em>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_artist || $pkiw_album ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_artist ) : ?>
+						<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_artist ); ?></span></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_artist && $pkiw_album ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_album ) : ?>
+						<em><?php echo esc_html( $pkiw_album ); ?></em>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_note ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_note ); ?></p>

--- a/build/blocks/like-card/render.php
+++ b/build/blocks/like-card/render.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title       = $attributes['title'] ?? '';
 $pkiw_url         = $attributes['url'] ?? '';
@@ -45,23 +46,25 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'like' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Like', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Like', 'post-kinds-for-indieweb-in-block-themes' ), 'like', 'like-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_description ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_description ); ?></p>

--- a/build/blocks/listen-card/render.php
+++ b/build/blocks/listen-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use function PKIW\get_cached_embed_html;
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_track_title    = $attributes['trackTitle'] ?? '';
 $pkiw_artist_name    = $attributes['artistName'] ?? '';
@@ -46,36 +47,38 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'listen' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Listen', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Listen', 'post-kinds-for-indieweb-in-block-themes' ), 'listen', 'listen-card' ) ); ?></p>
 
-		<?php if ( $pkiw_track_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_listen_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_listen_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_track_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_track_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_track_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_listen_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_listen_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_track_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_track_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_artist_name || $pkiw_album_title ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_artist_name ) : ?>
-					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_artist_name ); ?></span></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_artist_name && $pkiw_album_title ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_album_title ) : ?>
-					<em><?php echo esc_html( $pkiw_album_title ); ?></em>
+			<?php if ( $pkiw_artist_name || $pkiw_album_title ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_artist_name ) : ?>
+						<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_artist_name ); ?></span></span>
+					<?php endif; ?>
 					<?php
-					if ( $pkiw_release_date ) :
+					if ( $pkiw_artist_name && $pkiw_album_title ) :
 						?>
-						(<?php echo esc_html( gmdate( 'Y', (int) strtotime( $pkiw_release_date ) ) ); ?>)<?php endif; ?>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_album_title ) : ?>
+						<em><?php echo esc_html( $pkiw_album_title ); ?></em>
+						<?php
+						if ( $pkiw_release_date ) :
+							?>
+							(<?php echo esc_html( gmdate( 'Y', (int) strtotime( $pkiw_release_date ) ) ); ?>)<?php endif; ?>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/build/blocks/mood-card/render.php
+++ b/build/blocks/mood-card/render.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_mood    = $attributes['mood'] ?? '';
 $pkiw_emoji   = $attributes['emoji'] ?? '😊';
@@ -42,7 +43,7 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'mood' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Mood', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Mood', 'post-kinds-for-indieweb-in-block-themes' ), 'mood', 'mood-card' ) ); ?></p>
 
 		<div class="pk-mood">
 			<?php if ( $pkiw_emoji ) : ?>

--- a/build/blocks/play-card/render.php
+++ b/build/blocks/play-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_status_labels = [
 	'playing'   => __( 'Playing', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -67,45 +68,47 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'play' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Play', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Play', 'post-kinds-for-indieweb-in-block-themes' ), 'play', 'play-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_game_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_game_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_game_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_game_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_status_label || $pkiw_platform || $pkiw_hours_played > 0 ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_status_label ) : ?>
-					<span><?php echo esc_html( $pkiw_status_label ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_status_label && $pkiw_platform ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_platform ) : ?>
-					<span><?php echo esc_html( $pkiw_platform ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( ( $pkiw_status_label || $pkiw_platform ) && $pkiw_hours_played > 0 ) :
-					?>
-					&bull; <?php endif; ?>
-				<?php if ( $pkiw_hours_played > 0 ) : ?>
+			<?php if ( $pkiw_status_label || $pkiw_platform || $pkiw_hours_played > 0 ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_status_label ) : ?>
+						<span><?php echo esc_html( $pkiw_status_label ); ?></span>
+					<?php endif; ?>
 					<?php
-					printf(
-						/* translators: %s: hours played */
-						esc_html__( '%s hours played', 'post-kinds-for-indieweb-in-block-themes' ),
-						'<strong>' . esc_html( (string) $pkiw_hours_played ) . '</strong>'
-					);
-					?>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+					if ( $pkiw_status_label && $pkiw_platform ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_platform ) : ?>
+						<span><?php echo esc_html( $pkiw_platform ); ?></span>
+					<?php endif; ?>
+					<?php
+					if ( ( $pkiw_status_label || $pkiw_platform ) && $pkiw_hours_played > 0 ) :
+						?>
+						&bull; <?php endif; ?>
+					<?php if ( $pkiw_hours_played > 0 ) : ?>
+						<?php
+						printf(
+							/* translators: %s: hours played */
+							esc_html__( '%s hours played', 'post-kinds-for-indieweb-in-block-themes' ),
+							'<strong>' . esc_html( (string) $pkiw_hours_played ) . '</strong>'
+						);
+						?>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/build/blocks/read-card/render.php
+++ b/build/blocks/read-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_book_title     = $attributes['bookTitle'] ?? '';
 $pkiw_author_name    = $attributes['authorName'] ?? '';
@@ -80,46 +81,48 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'read' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Read', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Read', 'post-kinds-for-indieweb-in-block-themes' ), 'read', 'read-card' ) ); ?></p>
 
-		<?php if ( $pkiw_book_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_book_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_book_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_book_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_book_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_book_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_book_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_book_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_book_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_book_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author_name ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author_name ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author_name ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author_name ); ?></span></span>
+				</p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_status_label || $pkiw_publisher || $pkiw_publish_date ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_status_label ) : ?>
-					<span><?php echo esc_html( $pkiw_status_label ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_status_label && ( $pkiw_publisher || $pkiw_publish_date ) ) :
+			<?php if ( $pkiw_status_label || $pkiw_publisher || $pkiw_publish_date ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_status_label ) : ?>
+						<span><?php echo esc_html( $pkiw_status_label ); ?></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_status_label && ( $pkiw_publisher || $pkiw_publish_date ) ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_publisher ) : ?>
+						<span><?php echo esc_html( $pkiw_publisher ); ?></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_publisher && $pkiw_publish_date ) {
+						echo ', ';
+					}
 					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_publisher ) : ?>
-					<span><?php echo esc_html( $pkiw_publisher ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_publisher && $pkiw_publish_date ) {
-					echo ', ';
-				}
-				?>
-				<?php if ( $pkiw_publish_date ) : ?>
-					<span><?php echo esc_html( $pkiw_publish_date ); ?></span>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+					<?php if ( $pkiw_publish_date ) : ?>
+						<span><?php echo esc_html( $pkiw_publish_date ); ?></span>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( 'reading' === $pkiw_read_status && $pkiw_progress_percent > 0 ) : ?>
 			<div class="pk-progress">

--- a/build/blocks/reply-card/render.php
+++ b/build/blocks/reply-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title       = $attributes['title'] ?? '';
 $pkiw_url         = $attributes['url'] ?? '';
@@ -46,23 +47,25 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'reply' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Reply', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Reply', 'post-kinds-for-indieweb-in-block-themes' ), 'reply', 'reply-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_description ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_description ); ?></p>

--- a/build/blocks/repost-card/render.php
+++ b/build/blocks/repost-card/render.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title       = $attributes['title'] ?? '';
 $pkiw_url         = $attributes['url'] ?? '';
@@ -45,23 +46,25 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'repost' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Repost', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Repost', 'post-kinds-for-indieweb-in-block-themes' ), 'repost', 'repost-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_description ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_description ); ?></p>

--- a/build/blocks/rsvp-card/render.php
+++ b/build/blocks/rsvp-card/render.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_event_name        = $attributes['eventName'] ?? '';
 $pkiw_event_url         = $attributes['eventUrl'] ?? '';
@@ -97,41 +98,43 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'rsvp' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'RSVP', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'RSVP', 'post-kinds-for-indieweb-in-block-themes' ), 'rsvp', 'rsvp-card' ) ); ?></p>
 
 		<div class="pk-event p-in-reply-to h-event">
-			<?php if ( $pkiw_event_name ) : ?>
-				<h2 class="pk-title p-name">
-					<?php if ( $pkiw_event_url ) : ?>
-						<a class="u-url" href="<?php echo esc_url( $pkiw_event_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_event_name ); ?></a>
-					<?php else : ?>
-						<?php echo esc_html( $pkiw_event_name ); ?>
-					<?php endif; ?>
-				</h2>
-			<?php endif; ?>
-
-			<?php if ( $pkiw_event_start_iso || $pkiw_event_location ) : ?>
-				<p class="pk-sub">
-					<data class="pk-chip p-rsvp" value="<?php echo esc_attr( $pkiw_rsvp_status ); ?>"><?php echo esc_html( $pkiw_label ); ?></data>
-					<?php if ( $pkiw_event_start_iso ) : ?>
-						<time class="dt-start" datetime="<?php echo esc_attr( $pkiw_event_start_iso ); ?>"><?php echo esc_html( $pkiw_event_range_disp ); ?></time>
-						<?php if ( $pkiw_event_end_iso ) : ?>
-							<data class="dt-end" value="<?php echo esc_attr( $pkiw_event_end_iso ); ?>" hidden></data>
+			<div class="pk-caption">
+				<?php if ( $pkiw_event_name ) : ?>
+					<h2 class="pk-title p-name">
+						<?php if ( $pkiw_event_url ) : ?>
+							<a class="u-url" href="<?php echo esc_url( $pkiw_event_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_event_name ); ?></a>
+						<?php else : ?>
+							<?php echo esc_html( $pkiw_event_name ); ?>
 						<?php endif; ?>
-					<?php endif; ?>
-					<?php
-					if ( $pkiw_event_start_iso && $pkiw_event_location ) :
-						?>
-						<span class="pk-dot"></span><?php endif; ?>
-					<?php if ( $pkiw_event_location ) : ?>
-						<span class="p-location"><?php echo esc_html( $pkiw_event_location ); ?></span>
-					<?php endif; ?>
-				</p>
-			<?php else : ?>
-				<p class="pk-sub">
-					<data class="pk-chip p-rsvp" value="<?php echo esc_attr( $pkiw_rsvp_status ); ?>"><?php echo esc_html( $pkiw_label ); ?></data>
-				</p>
-			<?php endif; ?>
+					</h2>
+				<?php endif; ?>
+
+				<?php if ( $pkiw_event_start_iso || $pkiw_event_location ) : ?>
+					<p class="pk-sub">
+						<data class="pk-chip p-rsvp" value="<?php echo esc_attr( $pkiw_rsvp_status ); ?>"><?php echo esc_html( $pkiw_label ); ?></data>
+						<?php if ( $pkiw_event_start_iso ) : ?>
+							<time class="dt-start" datetime="<?php echo esc_attr( $pkiw_event_start_iso ); ?>"><?php echo esc_html( $pkiw_event_range_disp ); ?></time>
+							<?php if ( $pkiw_event_end_iso ) : ?>
+								<data class="dt-end" value="<?php echo esc_attr( $pkiw_event_end_iso ); ?>" hidden></data>
+							<?php endif; ?>
+						<?php endif; ?>
+						<?php
+						if ( $pkiw_event_start_iso && $pkiw_event_location ) :
+							?>
+							<span class="pk-dot"></span><?php endif; ?>
+						<?php if ( $pkiw_event_location ) : ?>
+							<span class="p-location"><?php echo esc_html( $pkiw_event_location ); ?></span>
+						<?php endif; ?>
+					</p>
+				<?php else : ?>
+					<p class="pk-sub">
+						<data class="pk-chip p-rsvp" value="<?php echo esc_attr( $pkiw_rsvp_status ); ?>"><?php echo esc_html( $pkiw_label ); ?></data>
+					</p>
+				<?php endif; ?>
+			</div>
 
 			<?php if ( $pkiw_event_description ) : ?>
 				<p class="p-summary"><?php echo esc_html( $pkiw_event_description ); ?></p>

--- a/build/blocks/watch-card/render.php
+++ b/build/blocks/watch-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use function PKIW\get_card_embed_html;
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_media_title    = $attributes['mediaTitle'] ?? '';
 $pkiw_media_type     = $attributes['mediaType'] ?? 'movie';
@@ -78,43 +79,45 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'watch' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Watch', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Watch', 'post-kinds-for-indieweb-in-block-themes' ), 'watch', 'watch-card' ) ); ?></p>
 
-		<?php if ( $pkiw_media_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_watch_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_watch_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_media_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_media_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_media_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_watch_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_watch_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_media_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_media_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( 'episode' === $pkiw_media_type && $pkiw_show_title ) : ?>
-			<p class="pk-sub"><?php echo esc_html( $pkiw_show_title ); ?></p>
-		<?php endif; ?>
+			<?php if ( 'episode' === $pkiw_media_type && $pkiw_show_title ) : ?>
+				<p class="pk-sub"><?php echo esc_html( $pkiw_show_title ); ?></p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_episode_string ) : ?>
-			<p class="pk-sub"><?php echo esc_html( $pkiw_episode_string ); ?></p>
-		<?php endif; ?>
+			<?php if ( $pkiw_episode_string ) : ?>
+				<p class="pk-sub"><?php echo esc_html( $pkiw_episode_string ); ?></p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_release_year || $pkiw_director || $pkiw_is_rewatch ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_release_year ) : ?>
-					<span>(<?php echo esc_html( $pkiw_release_year ); ?>)</span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_release_year && $pkiw_director ) :
-					?>
-					&bull; <?php endif; ?>
-				<?php if ( $pkiw_director ) : ?>
-					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_director ); ?></span></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_is_rewatch ) : ?>
-					<span class="pk-rewatch"><?php esc_html_e( 'Rewatch', 'post-kinds-for-indieweb-in-block-themes' ); ?></span>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_release_year || $pkiw_director || $pkiw_is_rewatch ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_release_year ) : ?>
+						<span>(<?php echo esc_html( $pkiw_release_year ); ?>)</span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_release_year && $pkiw_director ) :
+						?>
+						&bull; <?php endif; ?>
+					<?php if ( $pkiw_director ) : ?>
+						<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_director ); ?></span></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_is_rewatch ) : ?>
+						<span class="pk-rewatch"><?php esc_html_e( 'Rewatch', 'post-kinds-for-indieweb-in-block-themes' ); ?></span>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/build/blocks/wish-card/render.php
+++ b/build/blocks/wish-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title     = $attributes['title'] ?? '';
 $pkiw_url       = $attributes['url'] ?? '';
@@ -42,21 +43,23 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'wish' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Wish', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Wish', 'post-kinds-for-indieweb-in-block-themes' ), 'wish', 'wish-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url u-wish-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url u-wish-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_price ) : ?>
-			<p class="pk-sub"><span class="pk-chip"><?php echo esc_html( $pkiw_price ); ?></span></p>
-		<?php endif; ?>
+			<?php if ( $pkiw_price ) : ?>
+				<p class="pk-sub"><span class="pk-chip"><?php echo esc_html( $pkiw_price ); ?></span></p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_image ) : ?>
 			<div class="pk-media">

--- a/includes/functions-card-labels.php
+++ b/includes/functions-card-labels.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Card kind-label helper.
+ *
+ * The visible `.pk-kindlabel` text on every card (block templates and the
+ * generic Stream card) flows through get_kind_label(), so a theme can swap
+ * the kind noun ("Watch", "Read") for a status verb ("WATCHED", "FINISHED")
+ * without touching markup. The label is the card badge's accessible name —
+ * the badge SVG itself is decorative — so replacements must stay visible text.
+ *
+ * @package PKIW
+ * @since 1.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PKIW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The display text for a card's kind label, filterable per site.
+ *
+ * Returns the default label unchanged when nothing hooks the filter, and
+ * falls back to it when a callback returns a non-string.
+ *
+ * @since 1.1.0
+ *
+ * @param string $label   Default label text (e.g. "Watch", "Purchase").
+ * @param string $kind    Kind slug the card represents (watch, listen, …).
+ * @param string $context Render context: the card template slug
+ *                        (e.g. 'watch-card'), or 'stream-card' for the
+ *                        generic Stream card.
+ * @return string Label text to display (escape at output).
+ */
+function get_kind_label( string $label, string $kind, string $context = '' ): string {
+	/**
+	 * Filter the visible kind-label text on a rendered card.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $label   Default label text (e.g. "Watch", "Purchase").
+	 * @param string $kind    Kind slug the card represents (watch, listen, …).
+	 * @param string $context Render context: the card template slug
+	 *                        (e.g. 'watch-card'), or 'stream-card' for the
+	 *                        generic Stream card.
+	 */
+	$filtered = apply_filters( 'pkiw_kind_label', $label, $kind, $context );
+
+	return is_string( $filtered ) ? $filtered : $label;
+}

--- a/includes/functions-stream-card.php
+++ b/includes/functions-stream-card.php
@@ -130,7 +130,8 @@ function render_generic_stream_card( \WP_Post $post ): string {
 	// Badge SVG is a static, decorative glyph from get_kind_icon_svg().
 	$out .= '<div class="pk-badge">' . get_kind_icon_svg( $badge_kind ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	$out .= '<div class="pk-body">';
-	$out .= '<p class="pk-kindlabel">' . esc_html( $kind_label ) . '</p>';
+	$out .= '<p class="pk-kindlabel">' . esc_html( get_kind_label( $kind_label, $badge_kind, 'stream-card' ) ) . '</p>';
+	$out .= '<div class="pk-caption">';
 	$out .= '<h2 class="pk-title p-name"><a href="' . $permalink . '">' . esc_html( $title ) . '</a></h2>';
 
 	$date_display = get_the_date( '', $post );
@@ -139,6 +140,8 @@ function render_generic_stream_card( \WP_Post $post ): string {
 			. esc_attr( (string) get_post_time( 'c', true, $post ) ) . '">'
 			. esc_html( $date_display ) . '</time></p>';
 	}
+
+	$out .= '</div>';
 
 	if ( '' !== $thumb_html ) {
 		// get_the_post_thumbnail() returns core-generated, escaped <img> markup.

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -340,6 +340,7 @@ function maybe_migrate_option_prefixes(): void {
 require_once PKIW_PATH . 'includes/functions-checkin.php';
 require_once PKIW_PATH . 'includes/functions-embeds.php';
 require_once PKIW_PATH . 'includes/functions-card-icons.php';
+require_once PKIW_PATH . 'includes/functions-card-labels.php';
 require_once PKIW_PATH . 'includes/functions-stream-card.php';
 
 // Hook into WordPress init (priority 0 so component registrations land

--- a/src/blocks/acquisition-card/render.php
+++ b/src/blocks/acquisition-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title       = $attributes['title'] ?? '';
 $pkiw_type        = $attributes['acquisitionType'] ?? '';
@@ -52,32 +53,34 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'acquisition' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php echo esc_html( $pkiw_type_label ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( $pkiw_type_label, 'acquisition', 'acquisition-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_where_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_where_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_where_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_where_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_cost || $pkiw_where ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_cost ) : ?>
-					<span><?php echo esc_html( $pkiw_cost ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_cost && $pkiw_where ) :
-					?>
-					<span class="pk-dot"></span><?php endif; ?>
-				<?php if ( $pkiw_where ) : ?>
-					<span class="p-location"><?php printf( /* translators: %s: place the item was acquired. */ esc_html__( 'from %s', 'post-kinds-for-indieweb-in-block-themes' ), esc_html( $pkiw_where ) ); ?></span>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_cost || $pkiw_where ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_cost ) : ?>
+						<span><?php echo esc_html( $pkiw_cost ); ?></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_cost && $pkiw_where ) :
+						?>
+						<span class="pk-dot"></span><?php endif; ?>
+					<?php if ( $pkiw_where ) : ?>
+						<span class="p-location"><?php printf( /* translators: %s: place the item was acquired. */ esc_html__( 'from %s', 'post-kinds-for-indieweb-in-block-themes' ), esc_html( $pkiw_where ) ); ?></span>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_photo ) : ?>
 			<div class="pk-media">

--- a/src/blocks/bookmark-card/render.php
+++ b/src/blocks/bookmark-card/render.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title         = $attributes['title'] ?? '';
 $pkiw_url           = $attributes['url'] ?? '';
@@ -45,23 +46,25 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'bookmark' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Bookmark', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Bookmark', 'post-kinds-for-indieweb-in-block-themes' ), 'bookmark', 'bookmark-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_description ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_description ); ?></p>

--- a/src/blocks/checkin-card/render.php
+++ b/src/blocks/checkin-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_venue_name       = $attributes['venueName'] ?? '';
 $pkiw_venue_type       = $attributes['venueType'] ?? 'place';
@@ -88,7 +89,7 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'checkin' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Check-in', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Check-in', 'post-kinds-for-indieweb-in-block-themes' ), 'checkin', 'checkin-card' ) ); ?></p>
 
 		<?php if ( $pkiw_is_private ) : ?>
 			<p class="pk-note">
@@ -112,56 +113,58 @@ ob_start();
 				<?php endif; ?>
 			</div>
 		<?php else : ?>
-			<?php if ( $pkiw_venue_name ) : ?>
-				<h2 class="pk-title p-name">
-					<?php if ( $pkiw_venue_url ) : ?>
-						<a class="u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_venue_name ); ?></a>
-					<?php else : ?>
-						<?php echo esc_html( $pkiw_venue_name ); ?>
+			<div class="pk-caption">
+				<?php if ( $pkiw_venue_name ) : ?>
+					<h2 class="pk-title p-name">
+						<?php if ( $pkiw_venue_url ) : ?>
+							<a class="u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_venue_name ); ?></a>
+						<?php else : ?>
+							<?php echo esc_html( $pkiw_venue_name ); ?>
+						<?php endif; ?>
+					</h2>
+				<?php endif; ?>
+
+				<p class="pk-sub p-location h-card">
+					<?php if ( $pkiw_show_address ) : ?>
+						<span class="p-street-address"><?php echo esc_html( $pkiw_address ); ?></span>
 					<?php endif; ?>
-				</h2>
-			<?php endif; ?>
 
-			<p class="pk-sub p-location h-card">
-				<?php if ( $pkiw_show_address ) : ?>
-					<span class="p-street-address"><?php echo esc_html( $pkiw_address ); ?></span>
-				<?php endif; ?>
+					<?php if ( $pkiw_locality || $pkiw_region || $pkiw_country ) : ?>
+						<span class="pk-sub-parts">
+							<?php if ( $pkiw_locality ) : ?>
+								<span class="p-locality"><?php echo esc_html( $pkiw_locality ); ?></span>
+							<?php endif; ?>
+							<?php
+							if ( $pkiw_locality && $pkiw_region ) {
+								echo ', ';
+							}
+							?>
+							<?php if ( $pkiw_region ) : ?>
+								<span class="p-region"><?php echo esc_html( $pkiw_region ); ?></span>
+							<?php endif; ?>
+							<?php
+							if ( ( $pkiw_locality || $pkiw_region ) && $pkiw_country ) {
+								echo ', ';
+							}
+							?>
+							<?php if ( $pkiw_country ) : ?>
+								<span class="p-country-name"><?php echo esc_html( $pkiw_country ); ?></span>
+							<?php endif; ?>
+						</span>
+					<?php endif; ?>
 
-				<?php if ( $pkiw_locality || $pkiw_region || $pkiw_country ) : ?>
-					<span class="pk-sub-parts">
-						<?php if ( $pkiw_locality ) : ?>
-							<span class="p-locality"><?php echo esc_html( $pkiw_locality ); ?></span>
-						<?php endif; ?>
-						<?php
-						if ( $pkiw_locality && $pkiw_region ) {
-							echo ', ';
-						}
-						?>
-						<?php if ( $pkiw_region ) : ?>
-							<span class="p-region"><?php echo esc_html( $pkiw_region ); ?></span>
-						<?php endif; ?>
-						<?php
-						if ( ( $pkiw_locality || $pkiw_region ) && $pkiw_country ) {
-							echo ', ';
-						}
-						?>
-						<?php if ( $pkiw_country ) : ?>
-							<span class="p-country-name"><?php echo esc_html( $pkiw_country ); ?></span>
-						<?php endif; ?>
-					</span>
-				<?php endif; ?>
+					<?php if ( $pkiw_is_public && $pkiw_postal_code ) : ?>
+						<span class="p-postal-code"><?php echo esc_html( $pkiw_postal_code ); ?></span>
+					<?php endif; ?>
 
-				<?php if ( $pkiw_is_public && $pkiw_postal_code ) : ?>
-					<span class="p-postal-code"><?php echo esc_html( $pkiw_postal_code ); ?></span>
-				<?php endif; ?>
-
-				<?php if ( $pkiw_show_coords ) : ?>
-					<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_uri ); ?>">
-						<data class="p-latitude" value="<?php echo esc_attr( (string) $pkiw_latitude ); ?>" hidden></data>
-						<data class="p-longitude" value="<?php echo esc_attr( (string) $pkiw_longitude ); ?>" hidden></data>
-					</data>
-				<?php endif; ?>
-			</p>
+					<?php if ( $pkiw_show_coords ) : ?>
+						<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_uri ); ?>">
+							<data class="p-latitude" value="<?php echo esc_attr( (string) $pkiw_latitude ); ?>" hidden></data>
+							<data class="p-longitude" value="<?php echo esc_attr( (string) $pkiw_longitude ); ?>" hidden></data>
+						</data>
+					<?php endif; ?>
+				</p>
+			</div>
 
 			<?php if ( $pkiw_show_map_emb ) : ?>
 				<div class="pk-embed pk-embed--map">

--- a/src/blocks/drink-card/render.php
+++ b/src/blocks/drink-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_drink_labels = [
 	'coffee'   => __( 'Coffee', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -73,52 +74,54 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'drink' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Drank', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Drank', 'post-kinds-for-indieweb-in-block-themes' ), 'drink', 'drink-card' ) ); ?></p>
 
-		<?php if ( $pkiw_name ) : ?>
-			<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_name ) : ?>
+				<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_brand || $pkiw_badge_label ) : ?>
-			<p class="pk-sub">
-				<span><?php echo esc_html( $pkiw_badge_label ); ?></span>
-				<?php
-				if ( $pkiw_badge_label && $pkiw_brand ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_brand ) : ?>
-					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_brand ); ?></span></span>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_brand || $pkiw_badge_label ) : ?>
+				<p class="pk-sub">
+					<span><?php echo esc_html( $pkiw_badge_label ); ?></span>
+					<?php
+					if ( $pkiw_badge_label && $pkiw_brand ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_brand ) : ?>
+						<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_brand ); ?></span></span>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_location_name ) : ?>
-			<p class="pk-sub p-location h-card">
-				<?php if ( $pkiw_venue_url ) : ?>
-					<a class="pk-chip p-name u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_location_name ); ?></a>
-				<?php else : ?>
-					<span class="pk-chip p-name"><?php echo esc_html( $pkiw_location_name ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_address ) : ?>
-					<span class="p-street-address"><?php echo esc_html( $pkiw_location_address ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_locality ) : ?>
-					<span class="p-locality"><?php echo esc_html( $pkiw_location_locality ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_region ) : ?>
-					<span class="p-region"><?php echo esc_html( $pkiw_location_region ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_country ) : ?>
-					<span class="p-country-name"><?php echo esc_html( $pkiw_location_country ); ?></span>
-				<?php endif; ?>
-				<?php if ( 0.0 !== $pkiw_geo_lat || 0.0 !== $pkiw_geo_lon ) : ?>
-					<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_lat . ',' . $pkiw_geo_lon ); ?>" hidden>
-						<span class="p-latitude"><?php echo esc_html( (string) $pkiw_geo_lat ); ?></span>
-						<span class="p-longitude"><?php echo esc_html( (string) $pkiw_geo_lon ); ?></span>
-					</data>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_location_name ) : ?>
+				<p class="pk-sub p-location h-card">
+					<?php if ( $pkiw_venue_url ) : ?>
+						<a class="pk-chip p-name u-url" href="<?php echo esc_url( $pkiw_venue_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_location_name ); ?></a>
+					<?php else : ?>
+						<span class="pk-chip p-name"><?php echo esc_html( $pkiw_location_name ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_address ) : ?>
+						<span class="p-street-address"><?php echo esc_html( $pkiw_location_address ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_locality ) : ?>
+						<span class="p-locality"><?php echo esc_html( $pkiw_location_locality ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_region ) : ?>
+						<span class="p-region"><?php echo esc_html( $pkiw_location_region ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_country ) : ?>
+						<span class="p-country-name"><?php echo esc_html( $pkiw_location_country ); ?></span>
+					<?php endif; ?>
+					<?php if ( 0.0 !== $pkiw_geo_lat || 0.0 !== $pkiw_geo_lon ) : ?>
+						<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_lat . ',' . $pkiw_geo_lon ); ?>" hidden>
+							<span class="p-latitude"><?php echo esc_html( (string) $pkiw_geo_lat ); ?></span>
+							<span class="p-longitude"><?php echo esc_html( (string) $pkiw_geo_lon ); ?></span>
+						</data>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/src/blocks/eat-card/render.php
+++ b/src/blocks/eat-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_name              = $attributes['name'] ?? '';
 $pkiw_restaurant        = $attributes['restaurant'] ?? '';
@@ -59,54 +60,56 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'eat' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Ate', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Ate', 'post-kinds-for-indieweb-in-block-themes' ), 'eat', 'eat-card' ) ); ?></p>
 
-		<?php if ( $pkiw_name ) : ?>
-			<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_name ) : ?>
+				<h2 class="pk-title p-name"><?php echo esc_html( $pkiw_name ); ?></h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_restaurant || $pkiw_cuisine ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_restaurant ) : ?>
-					<span class="p-location h-card"><span class="p-name"><?php echo esc_html( $pkiw_restaurant ); ?></span></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_restaurant && $pkiw_cuisine ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_cuisine ) : ?>
-					<em><?php echo esc_html( $pkiw_cuisine ); ?></em>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_restaurant || $pkiw_cuisine ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_restaurant ) : ?>
+						<span class="p-location h-card"><span class="p-name"><?php echo esc_html( $pkiw_restaurant ); ?></span></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_restaurant && $pkiw_cuisine ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_cuisine ) : ?>
+						<em><?php echo esc_html( $pkiw_cuisine ); ?></em>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_location_name ) : ?>
-			<p class="pk-sub p-location h-card">
-				<?php if ( $pkiw_restaurant_url ) : ?>
-					<a class="pk-chip p-name u-url" href="<?php echo esc_url( $pkiw_restaurant_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_location_name ); ?></a>
-				<?php else : ?>
-					<span class="pk-chip p-name"><?php echo esc_html( $pkiw_location_name ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_address ) : ?>
-					<span class="p-street-address"><?php echo esc_html( $pkiw_location_address ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_locality ) : ?>
-					<span class="p-locality"><?php echo esc_html( $pkiw_location_locality ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_region ) : ?>
-					<span class="p-region"><?php echo esc_html( $pkiw_location_region ); ?></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_location_country ) : ?>
-					<span class="p-country-name"><?php echo esc_html( $pkiw_location_country ); ?></span>
-				<?php endif; ?>
-				<?php if ( 0.0 !== $pkiw_geo_lat || 0.0 !== $pkiw_geo_lon ) : ?>
-					<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_lat . ',' . $pkiw_geo_lon ); ?>" hidden>
-						<span class="p-latitude"><?php echo esc_html( (string) $pkiw_geo_lat ); ?></span>
-						<span class="p-longitude"><?php echo esc_html( (string) $pkiw_geo_lon ); ?></span>
-					</data>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_location_name ) : ?>
+				<p class="pk-sub p-location h-card">
+					<?php if ( $pkiw_restaurant_url ) : ?>
+						<a class="pk-chip p-name u-url" href="<?php echo esc_url( $pkiw_restaurant_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_location_name ); ?></a>
+					<?php else : ?>
+						<span class="pk-chip p-name"><?php echo esc_html( $pkiw_location_name ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_address ) : ?>
+						<span class="p-street-address"><?php echo esc_html( $pkiw_location_address ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_locality ) : ?>
+						<span class="p-locality"><?php echo esc_html( $pkiw_location_locality ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_region ) : ?>
+						<span class="p-region"><?php echo esc_html( $pkiw_location_region ); ?></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_location_country ) : ?>
+						<span class="p-country-name"><?php echo esc_html( $pkiw_location_country ); ?></span>
+					<?php endif; ?>
+					<?php if ( 0.0 !== $pkiw_geo_lat || 0.0 !== $pkiw_geo_lon ) : ?>
+						<data class="p-geo h-geo" value="<?php echo esc_attr( $pkiw_geo_lat . ',' . $pkiw_geo_lon ); ?>" hidden>
+							<span class="p-latitude"><?php echo esc_html( (string) $pkiw_geo_lat ); ?></span>
+							<span class="p-longitude"><?php echo esc_html( (string) $pkiw_geo_lon ); ?></span>
+						</data>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/src/blocks/favorite-card/render.php
+++ b/src/blocks/favorite-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title        = $attributes['title'] ?? '';
 $pkiw_url          = $attributes['url'] ?? '';
@@ -42,21 +43,23 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'favorite' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Favorite', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Favorite', 'post-kinds-for-indieweb-in-block-themes' ), 'favorite', 'favorite-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub"><span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span></p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub"><span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span></p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_image ) : ?>
 			<div class="pk-media">

--- a/src/blocks/jam-card/render.php
+++ b/src/blocks/jam-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use function PKIW\get_cached_embed_html;
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title     = $attributes['title'] ?? '';
 $pkiw_artist    = $attributes['artist'] ?? '';
@@ -49,32 +50,34 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'jam' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Jam', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Jam', 'post-kinds-for-indieweb-in-block-themes' ), 'jam', 'jam-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url u-jam-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url u-jam-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_artist || $pkiw_album ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_artist ) : ?>
-					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_artist ); ?></span></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_artist && $pkiw_album ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_album ) : ?>
-					<em><?php echo esc_html( $pkiw_album ); ?></em>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_artist || $pkiw_album ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_artist ) : ?>
+						<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_artist ); ?></span></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_artist && $pkiw_album ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_album ) : ?>
+						<em><?php echo esc_html( $pkiw_album ); ?></em>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_note ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_note ); ?></p>

--- a/src/blocks/like-card/render.php
+++ b/src/blocks/like-card/render.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title       = $attributes['title'] ?? '';
 $pkiw_url         = $attributes['url'] ?? '';
@@ -45,23 +46,25 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'like' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Like', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Like', 'post-kinds-for-indieweb-in-block-themes' ), 'like', 'like-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_description ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_description ); ?></p>

--- a/src/blocks/listen-card/render.php
+++ b/src/blocks/listen-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use function PKIW\get_cached_embed_html;
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_track_title    = $attributes['trackTitle'] ?? '';
 $pkiw_artist_name    = $attributes['artistName'] ?? '';
@@ -46,36 +47,38 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'listen' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Listen', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Listen', 'post-kinds-for-indieweb-in-block-themes' ), 'listen', 'listen-card' ) ); ?></p>
 
-		<?php if ( $pkiw_track_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_listen_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_listen_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_track_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_track_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_track_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_listen_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_listen_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_track_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_track_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_artist_name || $pkiw_album_title ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_artist_name ) : ?>
-					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_artist_name ); ?></span></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_artist_name && $pkiw_album_title ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_album_title ) : ?>
-					<em><?php echo esc_html( $pkiw_album_title ); ?></em>
+			<?php if ( $pkiw_artist_name || $pkiw_album_title ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_artist_name ) : ?>
+						<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_artist_name ); ?></span></span>
+					<?php endif; ?>
 					<?php
-					if ( $pkiw_release_date ) :
+					if ( $pkiw_artist_name && $pkiw_album_title ) :
 						?>
-						(<?php echo esc_html( gmdate( 'Y', (int) strtotime( $pkiw_release_date ) ) ); ?>)<?php endif; ?>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_album_title ) : ?>
+						<em><?php echo esc_html( $pkiw_album_title ); ?></em>
+						<?php
+						if ( $pkiw_release_date ) :
+							?>
+							(<?php echo esc_html( gmdate( 'Y', (int) strtotime( $pkiw_release_date ) ) ); ?>)<?php endif; ?>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/src/blocks/mood-card/render.php
+++ b/src/blocks/mood-card/render.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_mood    = $attributes['mood'] ?? '';
 $pkiw_emoji   = $attributes['emoji'] ?? '😊';
@@ -42,7 +43,7 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'mood' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Mood', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Mood', 'post-kinds-for-indieweb-in-block-themes' ), 'mood', 'mood-card' ) ); ?></p>
 
 		<div class="pk-mood">
 			<?php if ( $pkiw_emoji ) : ?>

--- a/src/blocks/play-card/render.php
+++ b/src/blocks/play-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_status_labels = [
 	'playing'   => __( 'Playing', 'post-kinds-for-indieweb-in-block-themes' ),
@@ -67,45 +68,47 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'play' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Play', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Play', 'post-kinds-for-indieweb-in-block-themes' ), 'play', 'play-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_game_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_game_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_game_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_game_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_status_label || $pkiw_platform || $pkiw_hours_played > 0 ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_status_label ) : ?>
-					<span><?php echo esc_html( $pkiw_status_label ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_status_label && $pkiw_platform ) :
-					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_platform ) : ?>
-					<span><?php echo esc_html( $pkiw_platform ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( ( $pkiw_status_label || $pkiw_platform ) && $pkiw_hours_played > 0 ) :
-					?>
-					&bull; <?php endif; ?>
-				<?php if ( $pkiw_hours_played > 0 ) : ?>
+			<?php if ( $pkiw_status_label || $pkiw_platform || $pkiw_hours_played > 0 ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_status_label ) : ?>
+						<span><?php echo esc_html( $pkiw_status_label ); ?></span>
+					<?php endif; ?>
 					<?php
-					printf(
-						/* translators: %s: hours played */
-						esc_html__( '%s hours played', 'post-kinds-for-indieweb-in-block-themes' ),
-						'<strong>' . esc_html( (string) $pkiw_hours_played ) . '</strong>'
-					);
-					?>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+					if ( $pkiw_status_label && $pkiw_platform ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_platform ) : ?>
+						<span><?php echo esc_html( $pkiw_platform ); ?></span>
+					<?php endif; ?>
+					<?php
+					if ( ( $pkiw_status_label || $pkiw_platform ) && $pkiw_hours_played > 0 ) :
+						?>
+						&bull; <?php endif; ?>
+					<?php if ( $pkiw_hours_played > 0 ) : ?>
+						<?php
+						printf(
+							/* translators: %s: hours played */
+							esc_html__( '%s hours played', 'post-kinds-for-indieweb-in-block-themes' ),
+							'<strong>' . esc_html( (string) $pkiw_hours_played ) . '</strong>'
+						);
+						?>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/src/blocks/read-card/render.php
+++ b/src/blocks/read-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_book_title     = $attributes['bookTitle'] ?? '';
 $pkiw_author_name    = $attributes['authorName'] ?? '';
@@ -80,46 +81,48 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'read' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Read', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Read', 'post-kinds-for-indieweb-in-block-themes' ), 'read', 'read-card' ) ); ?></p>
 
-		<?php if ( $pkiw_book_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_book_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_book_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_book_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_book_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_book_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_book_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_book_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_book_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_book_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author_name ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author_name ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author_name ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author_name ); ?></span></span>
+				</p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_status_label || $pkiw_publisher || $pkiw_publish_date ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_status_label ) : ?>
-					<span><?php echo esc_html( $pkiw_status_label ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_status_label && ( $pkiw_publisher || $pkiw_publish_date ) ) :
+			<?php if ( $pkiw_status_label || $pkiw_publisher || $pkiw_publish_date ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_status_label ) : ?>
+						<span><?php echo esc_html( $pkiw_status_label ); ?></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_status_label && ( $pkiw_publisher || $pkiw_publish_date ) ) :
+						?>
+						&mdash; <?php endif; ?>
+					<?php if ( $pkiw_publisher ) : ?>
+						<span><?php echo esc_html( $pkiw_publisher ); ?></span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_publisher && $pkiw_publish_date ) {
+						echo ', ';
+					}
 					?>
-					&mdash; <?php endif; ?>
-				<?php if ( $pkiw_publisher ) : ?>
-					<span><?php echo esc_html( $pkiw_publisher ); ?></span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_publisher && $pkiw_publish_date ) {
-					echo ', ';
-				}
-				?>
-				<?php if ( $pkiw_publish_date ) : ?>
-					<span><?php echo esc_html( $pkiw_publish_date ); ?></span>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+					<?php if ( $pkiw_publish_date ) : ?>
+						<span><?php echo esc_html( $pkiw_publish_date ); ?></span>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( 'reading' === $pkiw_read_status && $pkiw_progress_percent > 0 ) : ?>
 			<div class="pk-progress">

--- a/src/blocks/reply-card/render.php
+++ b/src/blocks/reply-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title       = $attributes['title'] ?? '';
 $pkiw_url         = $attributes['url'] ?? '';
@@ -46,23 +47,25 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'reply' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Reply', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Reply', 'post-kinds-for-indieweb-in-block-themes' ), 'reply', 'reply-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_description ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_description ); ?></p>

--- a/src/blocks/repost-card/render.php
+++ b/src/blocks/repost-card/render.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title       = $attributes['title'] ?? '';
 $pkiw_url         = $attributes['url'] ?? '';
@@ -45,23 +46,25 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'repost' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Repost', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Repost', 'post-kinds-for-indieweb-in-block-themes' ), 'repost', 'repost-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_author ) : ?>
-			<p class="pk-sub">
-				<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_author ) : ?>
+				<p class="pk-sub">
+					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_author ); ?></span></span>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_description ) : ?>
 			<p class="pk-note p-content"><?php echo esc_html( $pkiw_description ); ?></p>

--- a/src/blocks/rsvp-card/render.php
+++ b/src/blocks/rsvp-card/render.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_event_name        = $attributes['eventName'] ?? '';
 $pkiw_event_url         = $attributes['eventUrl'] ?? '';
@@ -97,41 +98,43 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'rsvp' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'RSVP', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'RSVP', 'post-kinds-for-indieweb-in-block-themes' ), 'rsvp', 'rsvp-card' ) ); ?></p>
 
 		<div class="pk-event p-in-reply-to h-event">
-			<?php if ( $pkiw_event_name ) : ?>
-				<h2 class="pk-title p-name">
-					<?php if ( $pkiw_event_url ) : ?>
-						<a class="u-url" href="<?php echo esc_url( $pkiw_event_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_event_name ); ?></a>
-					<?php else : ?>
-						<?php echo esc_html( $pkiw_event_name ); ?>
-					<?php endif; ?>
-				</h2>
-			<?php endif; ?>
-
-			<?php if ( $pkiw_event_start_iso || $pkiw_event_location ) : ?>
-				<p class="pk-sub">
-					<data class="pk-chip p-rsvp" value="<?php echo esc_attr( $pkiw_rsvp_status ); ?>"><?php echo esc_html( $pkiw_label ); ?></data>
-					<?php if ( $pkiw_event_start_iso ) : ?>
-						<time class="dt-start" datetime="<?php echo esc_attr( $pkiw_event_start_iso ); ?>"><?php echo esc_html( $pkiw_event_range_disp ); ?></time>
-						<?php if ( $pkiw_event_end_iso ) : ?>
-							<data class="dt-end" value="<?php echo esc_attr( $pkiw_event_end_iso ); ?>" hidden></data>
+			<div class="pk-caption">
+				<?php if ( $pkiw_event_name ) : ?>
+					<h2 class="pk-title p-name">
+						<?php if ( $pkiw_event_url ) : ?>
+							<a class="u-url" href="<?php echo esc_url( $pkiw_event_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_event_name ); ?></a>
+						<?php else : ?>
+							<?php echo esc_html( $pkiw_event_name ); ?>
 						<?php endif; ?>
-					<?php endif; ?>
-					<?php
-					if ( $pkiw_event_start_iso && $pkiw_event_location ) :
-						?>
-						<span class="pk-dot"></span><?php endif; ?>
-					<?php if ( $pkiw_event_location ) : ?>
-						<span class="p-location"><?php echo esc_html( $pkiw_event_location ); ?></span>
-					<?php endif; ?>
-				</p>
-			<?php else : ?>
-				<p class="pk-sub">
-					<data class="pk-chip p-rsvp" value="<?php echo esc_attr( $pkiw_rsvp_status ); ?>"><?php echo esc_html( $pkiw_label ); ?></data>
-				</p>
-			<?php endif; ?>
+					</h2>
+				<?php endif; ?>
+
+				<?php if ( $pkiw_event_start_iso || $pkiw_event_location ) : ?>
+					<p class="pk-sub">
+						<data class="pk-chip p-rsvp" value="<?php echo esc_attr( $pkiw_rsvp_status ); ?>"><?php echo esc_html( $pkiw_label ); ?></data>
+						<?php if ( $pkiw_event_start_iso ) : ?>
+							<time class="dt-start" datetime="<?php echo esc_attr( $pkiw_event_start_iso ); ?>"><?php echo esc_html( $pkiw_event_range_disp ); ?></time>
+							<?php if ( $pkiw_event_end_iso ) : ?>
+								<data class="dt-end" value="<?php echo esc_attr( $pkiw_event_end_iso ); ?>" hidden></data>
+							<?php endif; ?>
+						<?php endif; ?>
+						<?php
+						if ( $pkiw_event_start_iso && $pkiw_event_location ) :
+							?>
+							<span class="pk-dot"></span><?php endif; ?>
+						<?php if ( $pkiw_event_location ) : ?>
+							<span class="p-location"><?php echo esc_html( $pkiw_event_location ); ?></span>
+						<?php endif; ?>
+					</p>
+				<?php else : ?>
+					<p class="pk-sub">
+						<data class="pk-chip p-rsvp" value="<?php echo esc_attr( $pkiw_rsvp_status ); ?>"><?php echo esc_html( $pkiw_label ); ?></data>
+					</p>
+				<?php endif; ?>
+			</div>
 
 			<?php if ( $pkiw_event_description ) : ?>
 				<p class="p-summary"><?php echo esc_html( $pkiw_event_description ); ?></p>

--- a/src/blocks/watch-card/render.php
+++ b/src/blocks/watch-card/render.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use function PKIW\get_card_embed_html;
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_media_title    = $attributes['mediaTitle'] ?? '';
 $pkiw_media_type     = $attributes['mediaType'] ?? 'movie';
@@ -78,43 +79,45 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'watch' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Watch', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Watch', 'post-kinds-for-indieweb-in-block-themes' ), 'watch', 'watch-card' ) ); ?></p>
 
-		<?php if ( $pkiw_media_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_watch_url ) : ?>
-					<a class="u-url" href="<?php echo esc_url( $pkiw_watch_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_media_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_media_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_media_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_watch_url ) : ?>
+						<a class="u-url" href="<?php echo esc_url( $pkiw_watch_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pkiw_media_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_media_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( 'episode' === $pkiw_media_type && $pkiw_show_title ) : ?>
-			<p class="pk-sub"><?php echo esc_html( $pkiw_show_title ); ?></p>
-		<?php endif; ?>
+			<?php if ( 'episode' === $pkiw_media_type && $pkiw_show_title ) : ?>
+				<p class="pk-sub"><?php echo esc_html( $pkiw_show_title ); ?></p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_episode_string ) : ?>
-			<p class="pk-sub"><?php echo esc_html( $pkiw_episode_string ); ?></p>
-		<?php endif; ?>
+			<?php if ( $pkiw_episode_string ) : ?>
+				<p class="pk-sub"><?php echo esc_html( $pkiw_episode_string ); ?></p>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_release_year || $pkiw_director || $pkiw_is_rewatch ) : ?>
-			<p class="pk-sub">
-				<?php if ( $pkiw_release_year ) : ?>
-					<span>(<?php echo esc_html( $pkiw_release_year ); ?>)</span>
-				<?php endif; ?>
-				<?php
-				if ( $pkiw_release_year && $pkiw_director ) :
-					?>
-					&bull; <?php endif; ?>
-				<?php if ( $pkiw_director ) : ?>
-					<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_director ); ?></span></span>
-				<?php endif; ?>
-				<?php if ( $pkiw_is_rewatch ) : ?>
-					<span class="pk-rewatch"><?php esc_html_e( 'Rewatch', 'post-kinds-for-indieweb-in-block-themes' ); ?></span>
-				<?php endif; ?>
-			</p>
-		<?php endif; ?>
+			<?php if ( $pkiw_release_year || $pkiw_director || $pkiw_is_rewatch ) : ?>
+				<p class="pk-sub">
+					<?php if ( $pkiw_release_year ) : ?>
+						<span>(<?php echo esc_html( $pkiw_release_year ); ?>)</span>
+					<?php endif; ?>
+					<?php
+					if ( $pkiw_release_year && $pkiw_director ) :
+						?>
+						&bull; <?php endif; ?>
+					<?php if ( $pkiw_director ) : ?>
+						<span class="p-author h-card"><span class="p-name"><?php echo esc_html( $pkiw_director ); ?></span></span>
+					<?php endif; ?>
+					<?php if ( $pkiw_is_rewatch ) : ?>
+						<span class="pk-rewatch"><?php esc_html_e( 'Rewatch', 'post-kinds-for-indieweb-in-block-themes' ); ?></span>
+					<?php endif; ?>
+				</p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_rating > 0 ) : ?>
 			<div class="pk-stars p-rating" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: rating out of five. */ __( 'Rated %d of 5', 'post-kinds-for-indieweb-in-block-themes' ), $pkiw_rating ) ); ?>">

--- a/src/blocks/wish-card/render.php
+++ b/src/blocks/wish-card/render.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- render.php variables are scoped by WordPress block rendering.
 
 use function PKIW\get_kind_icon_svg;
+use function PKIW\get_kind_label;
 
 $pkiw_title     = $attributes['title'] ?? '';
 $pkiw_url       = $attributes['url'] ?? '';
@@ -42,21 +43,23 @@ ob_start();
 <article <?php echo $pkiw_wrapper_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div class="pk-badge"><?php echo get_kind_icon_svg( 'wish' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 	<div class="pk-body">
-		<p class="pk-kindlabel"><?php esc_html_e( 'Wish', 'post-kinds-for-indieweb-in-block-themes' ); ?></p>
+		<p class="pk-kindlabel"><?php echo esc_html( get_kind_label( __( 'Wish', 'post-kinds-for-indieweb-in-block-themes' ), 'wish', 'wish-card' ) ); ?></p>
 
-		<?php if ( $pkiw_title ) : ?>
-			<h2 class="pk-title p-name">
-				<?php if ( $pkiw_url ) : ?>
-					<a class="u-url u-wish-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pkiw_title ); ?>
-				<?php endif; ?>
-			</h2>
-		<?php endif; ?>
+		<div class="pk-caption">
+			<?php if ( $pkiw_title ) : ?>
+				<h2 class="pk-title p-name">
+					<?php if ( $pkiw_url ) : ?>
+						<a class="u-url u-wish-of" href="<?php echo esc_url( $pkiw_url ); ?>" target="_blank" rel="<?php echo esc_attr( $pkiw_link_rel ); ?>"><?php echo esc_html( $pkiw_title ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pkiw_title ); ?>
+					<?php endif; ?>
+				</h2>
+			<?php endif; ?>
 
-		<?php if ( $pkiw_price ) : ?>
-			<p class="pk-sub"><span class="pk-chip"><?php echo esc_html( $pkiw_price ); ?></span></p>
-		<?php endif; ?>
+			<?php if ( $pkiw_price ) : ?>
+				<p class="pk-sub"><span class="pk-chip"><?php echo esc_html( $pkiw_price ); ?></span></p>
+			<?php endif; ?>
+		</div>
 
 		<?php if ( $pkiw_image ) : ?>
 			<div class="pk-media">

--- a/tests/phpunit/unit/KindLabelTest.php
+++ b/tests/phpunit/unit/KindLabelTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Coverage for the filterable card kind label.
+ *
+ * @package PKIW
+ */
+
+declare(strict_types=1);
+
+namespace PKIW\Tests\Unit;
+
+use WP_UnitTestCase;
+use function PKIW\get_kind_label;
+
+/**
+ * Every card's visible kind label flows through get_kind_label(), so a theme
+ * can swap the kind noun ("Watch") for a status verb ("WATCHED") via the
+ * pkiw_kind_label filter without touching markup.
+ *
+ * @covers \PKIW\get_kind_label
+ */
+final class KindLabelTest extends WP_UnitTestCase {
+
+	/**
+	 * With nothing hooked, the default label passes through untouched.
+	 */
+	public function test_default_label_passes_through(): void {
+		$this->assertSame( 'Watch', get_kind_label( 'Watch', 'watch', 'watch-card' ) );
+	}
+
+	/**
+	 * A filter callback receives the label, kind slug, and render context.
+	 */
+	public function test_filter_receives_label_kind_and_context(): void {
+		$received = [];
+		add_filter(
+			'pkiw_kind_label',
+			static function ( $label, $kind, $context ) use ( &$received ) {
+				$received = [ $label, $kind, $context ];
+				return 'WATCHED';
+			},
+			10,
+			3
+		);
+
+		$this->assertSame( 'WATCHED', get_kind_label( 'Watch', 'watch', 'watch-card' ) );
+		$this->assertSame( [ 'Watch', 'watch', 'watch-card' ], $received );
+	}
+
+	/**
+	 * A non-string filter return falls back to the default label instead of
+	 * fataling or emitting garbage.
+	 */
+	public function test_non_string_filter_return_falls_back(): void {
+		add_filter( 'pkiw_kind_label', '__return_null' );
+
+		$this->assertSame( 'Watch', get_kind_label( 'Watch', 'watch', 'watch-card' ) );
+	}
+
+	/**
+	 * A rendered watch card shows the filtered label text.
+	 */
+	public function test_watch_card_render_uses_filtered_label(): void {
+		add_filter(
+			'pkiw_kind_label',
+			static function ( $label, $kind, $context ) {
+				return 'watch-card' === $context ? 'WATCHED' : $label;
+			},
+			10,
+			3
+		);
+
+		$html = $this->render_watch_card();
+
+		$this->assertStringContainsString( '<p class="pk-kindlabel">WATCHED</p>', $html );
+	}
+
+	/**
+	 * A filtered label is escaped at output — markup in a filter return
+	 * renders as text.
+	 */
+	public function test_filtered_label_is_escaped_at_output(): void {
+		add_filter(
+			'pkiw_kind_label',
+			static function () {
+				return '<script>alert(1)</script>';
+			}
+		);
+
+		$html = $this->render_watch_card();
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	/**
+	 * The card title and its sub lines render inside one pk-caption wrapper,
+	 * after the kind label.
+	 */
+	public function test_watch_card_groups_title_in_caption(): void {
+		$html = $this->render_watch_card();
+
+		$this->assertStringContainsString( '<div class="pk-caption">', $html );
+
+		$label_pos   = strpos( $html, 'pk-kindlabel' );
+		$caption_pos = strpos( $html, '<div class="pk-caption">' );
+		$title_pos   = strpos( $html, 'pk-title' );
+		$this->assertNotFalse( $label_pos );
+		$this->assertNotFalse( $title_pos );
+		$this->assertTrue( $label_pos < $caption_pos, 'Label renders before the caption wrapper.' );
+		$this->assertTrue( $caption_pos < $title_pos, 'Caption wrapper opens before the title.' );
+	}
+
+	/**
+	 * The generic Stream card passes the kind slug and 'stream-card' context,
+	 * and groups its title and date in a pk-caption.
+	 */
+	public function test_generic_stream_card_filters_label_and_groups_caption(): void {
+		$received = [];
+		add_filter(
+			'pkiw_kind_label',
+			static function ( $label, $kind, $context ) use ( &$received ) {
+				$received = [ $label, $kind, $context ];
+				return 'POSTED';
+			},
+			10,
+			3
+		);
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_title'   => 'Untagged thought',
+				'post_content' => "<!-- wp:paragraph -->\n<p>Just a thought.</p>\n<!-- /wp:paragraph -->",
+			]
+		);
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$html = \PKIW\render_stream_card();
+
+		$this->assertStringContainsString( '<p class="pk-kindlabel">POSTED</p>', $html );
+		$this->assertSame( [ 'Note', 'note', 'stream-card' ], $received );
+
+		// Title and date sit together inside the caption wrapper.
+		$this->assertMatchesRegularExpression(
+			'#<div class="pk-caption"><h2 class="pk-title p-name">.*</h2><p class="pk-sub pk-stream-date">.*</p></div>#s',
+			$html
+		);
+	}
+
+	/**
+	 * Render a watch card block with a title and year.
+	 *
+	 * @return string Rendered card HTML.
+	 */
+	private function render_watch_card(): string {
+		return render_block(
+			[
+				'blockName'    => 'post-kinds-indieweb/watch-card',
+				'attrs'        => [
+					'mediaTitle'  => 'Enola Holmes 3',
+					'releaseYear' => 2026,
+				],
+				'innerBlocks'  => [],
+				'innerHTML'    => '',
+				'innerContent' => [],
+			]
+		);
+	}
+}


### PR DESCRIPTION
Two stream-presentation changes flagged by the courtneyr.dev stream redesign (SPEC.md in the "Stream and Blog mocks review" design project).

**Filterable kind-label text.** The `.pk-kindlabel` text in every card render — the 17 block templates and the generic Stream card — now flows through a new `PKIW\get_kind_label( $label, $kind, $context )` helper, which applies a `pkiw_kind_label` filter. Themes can swap the kind noun ("Watch", "Acquisition") for a status verb ("WATCHED", "GOT IT", "PLAYED") per kind or per render context (`'watch-card'`, `'stream-card'`, …). Unfiltered output is byte-identical to before, a non-string filter return falls back to the default, and the result is still escaped at output.

One naming note: the spec suggested `post_kinds_indieweb_kind_label`, but every existing hook in the plugin uses the `pkiw_` prefix and PHPCS's PrefixAllGlobals config only allows `pkiw`/`PKIW`, so the hook is **`pkiw_kind_label`**. The courtneyr-child theme should hook that name when it adds the verb stickers.

**Caption grouping.** Card title, the stream-injected date, and the small `pk-sub` lines (year, players, venue) now sit inside one `<div class="pk-caption">` so themes can style them as a single tight caption strip instead of loose siblings. Additive markup only: every existing class and microformat is untouched, and mf2 properties still attach to their `h-entry`/`h-cite`/`h-event` roots through the plain div. Three templates needed judgment calls: the mood card gets no caption (no title or subs to group), the checkin card only gets one in its public branch, and the RSVP card's caption sits inside the `h-event` cite so `dt-start` stays a property of the event.

`build/blocks` render.php copies are synced (`bin/sync-block-assets.mjs`); no JS was rebuilt.

Tested with `composer lint` (clean, same pre-existing warnings as main), `composer analyze` (PHPStan level 5, no errors), and the full PHPUnit suite against the local WP tests install — 1097 unit + 146 integration tests pass, including a new `KindLabelTest` covering filter passthrough, argument passing, non-string fallback, output escaping, and caption placement on both render paths.