### PR TITLE
📦 NEW: kind artwork reaches schema and featured images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Card_Meta_Sync` never reached cards nested inside wrapper blocks — including the h-entry `core/group` the Micropub bridge wraps around every card it generates, so Micropub-created posts got no `_pkiw_*` meta at all. The block walk now descends into `innerBlocks` (first card in document order still wins).
 
+- Kind auto-detection (`Taxonomy::get_first_block_kind`) now sees a card nested first inside a wrapper block — the shape the Micropub bridge writes — instead of leaving those posts with no kind term. A wrapper whose first visible child is not a card still gets no auto-kind, same as a paragraph-first post.
+
 ### Added
 
 - `AbilitiesRegistrationTest` asserts every declared ability is present in `wp_get_abilities()` after init, that declared names satisfy core's grammar, and that the declared list and the registry agree in both directions. A rejected name now fails CI instead of vanishing into a notice.
@@ -22,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Yoast SEO integration: kind posts without a featured image now expose their representative media (album cover, movie poster, book cover, game art, checkin photo) as the schema.org primary image. Kind cards are dynamic blocks, so their artwork never appears as an `<img>` in raw post content and Yoast's featured-image/first-content-image resolution couldn't see it — Article schema on kind micro-posts lost its optional `image` and site audits warned about it. The integration hooks Yoast's documented `wpseo_schema_graph` filter, fills in only when Yoast itself found no image, reuses Yoast's native `#primaryimage` node shape (Article `image`/`thumbnailUrl`, WebPage `primaryImageOfPage`), reads normalized `_pkiw_*` meta with a block-attribute fallback for posts saved before the meta sync covered their kind, accepts only valid http(s) URLs, and is completely inert when Yoast is inactive. A featured image always wins untouched; posts with no real artwork truthfully emit no image; `wordCount` is never altered.
 
 - `Card_Meta_Sync` now mirrors listen, watch, jam, and play cards into `_pkiw_*` meta (previously only read and checkin): track/artist/album/cover for listen, title/year/poster and show/episode fields for watch, and title/platform/status/art for jam and play.
+
+- Featured images from kind artwork: a kind post saved without a featured image now gets one from its representative media — remote artwork is sideloaded into the media library once per URL (with the post title as alt text when the image has none), and artwork that is already a local attachment is reused without any fetch. Editorial choice stays in charge: an image you picked is never replaced, removing the auto-set image sticks (the same URL is not re-applied), a failed fetch is not retried until the artwork URL changes, and `add_filter( 'pkiw_set_featured_from_artwork', '__return_false' )` turns the behavior off. `wp postkind featured-artwork backfill [--dry-run]` applies it to existing posts. Shared resolution lives in the new `Kind_Artwork` class, so the featured image and the Yoast schema image always agree.
 
 ## [1.0.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All 13 abilities now actually register. Their names used underscores (`post_kinds/list_kinds`, `post_kinds/lookup_book`), and core's `WP_Abilities_Registry::register()` only accepts `/^[a-z0-9-]+\/[a-z0-9-]+$/` — lowercase alphanumerics, dashes, one slash. Every one was refused with a `_doing_it_wrong()` notice and nothing else, so with `WP_DEBUG` off they had been missing since 1.1.0 without a trace. Renamed to dashes throughout (`post-kinds/list-kinds`, `post-kinds/lookup-book`), including the MCP server list and the `post_kinds/` prefix check in `Abilities_Manager::filter_ability_args()`. No aliases: the old names never registered, so nothing can be calling them.
 
+- `Card_Meta_Sync` never reached cards nested inside wrapper blocks — including the h-entry `core/group` the Micropub bridge wraps around every card it generates, so Micropub-created posts got no `_pkiw_*` meta at all. The block walk now descends into `innerBlocks` (first card in document order still wins).
+
 ### Added
 
 - `AbilitiesRegistrationTest` asserts every declared ability is present in `wp_get_abilities()` after init, that declared names satisfy core's grammar, and that the declared list and the registry agree in both directions. A rejected name now fails CI instead of vanishing into a notice.
+
+- Yoast SEO integration: kind posts without a featured image now expose their representative media (album cover, movie poster, book cover, game art, checkin photo) as the schema.org primary image. Kind cards are dynamic blocks, so their artwork never appears as an `<img>` in raw post content and Yoast's featured-image/first-content-image resolution couldn't see it — Article schema on kind micro-posts lost its optional `image` and site audits warned about it. The integration hooks Yoast's documented `wpseo_schema_graph` filter, fills in only when Yoast itself found no image, reuses Yoast's native `#primaryimage` node shape (Article `image`/`thumbnailUrl`, WebPage `primaryImageOfPage`), reads normalized `_pkiw_*` meta with a block-attribute fallback for posts saved before the meta sync covered their kind, accepts only valid http(s) URLs, and is completely inert when Yoast is inactive. A featured image always wins untouched; posts with no real artwork truthfully emit no image; `wordCount` is never altered.
+
+- `Card_Meta_Sync` now mirrors listen, watch, jam, and play cards into `_pkiw_*` meta (previously only read and checkin): track/artist/album/cover for listen, title/year/poster and show/episode fields for watch, and title/platform/status/art for jam and play.
 
 ## [1.0.0] - 2026-07-20
 

--- a/includes/class-card-meta-sync.php
+++ b/includes/class-card-meta-sync.php
@@ -63,6 +63,56 @@ class Card_Meta_Sync {
 			'osmId'           => 'checkin_osm_id',
 			'photo'           => 'checkin_photo',
 		],
+		'post-kinds-indieweb/listen-card'  => [
+			'trackTitle'    => 'listen_track',
+			'artistName'    => 'listen_artist',
+			'albumTitle'    => 'listen_album',
+			'coverImage'    => 'listen_cover',
+			'musicbrainzId' => 'listen_mbid',
+			'listenUrl'     => 'listen_url',
+			'rating'        => 'listen_rating',
+			'releaseDate'   => 'listen_release_date',
+			'listenedAt'    => 'listen_listened_at',
+		],
+		'post-kinds-indieweb/watch-card'   => [
+			'mediaTitle'    => 'watch_title',
+			'releaseYear'   => 'watch_year',
+			'posterImage'   => 'watch_poster',
+			'tmdbId'        => 'watch_tmdb_id',
+			'watchUrl'      => 'watch_url',
+			'rating'        => 'watch_rating',
+			'review'        => 'watch_review',
+			'isRewatch'     => 'watch_is_rewatch',
+			'mediaType'     => 'watch_media_type',
+			'director'      => 'watch_director',
+			'imdbId'        => 'watch_imdb_id',
+			'showTitle'     => 'watch_show_title',
+			'seasonNumber'  => 'watch_season',
+			'episodeNumber' => 'watch_episode',
+			'episodeTitle'  => 'watch_episode_title',
+		],
+		'post-kinds-indieweb/jam-card'     => [
+			'title'  => 'jam_track',
+			'artist' => 'jam_artist',
+			'album'  => 'jam_album',
+			'cover'  => 'jam_cover',
+			'url'    => 'jam_url',
+		],
+		'post-kinds-indieweb/play-card'    => [
+			'title'       => 'play_title',
+			'platform'    => 'play_platform',
+			'status'      => 'play_status',
+			'hoursPlayed' => 'play_hours',
+			'cover'       => 'play_cover',
+			'rating'      => 'play_rating',
+			'review'      => 'play_review',
+			'gameUrl'     => 'play_game_url',
+			'officialUrl' => 'play_official_url',
+			'purchaseUrl' => 'play_purchase_url',
+			'steamId'     => 'play_steam_id',
+			'bggId'       => 'play_bgg_id',
+			'rawgId'      => 'play_rawg_id',
+		],
 		// Other card blocks join this map in follow-on work; the class is
 		// deliberately map-driven so each is one entry, no new code.
 	];
@@ -91,11 +141,9 @@ class Card_Meta_Sync {
 			return;
 		}
 
-		foreach ( parse_blocks( $post->post_content ) as $block ) {
-			$map = self::ATTR_META_MAP[ $block['blockName'] ?? '' ] ?? null;
-			if ( null === $map ) {
-				continue;
-			}
+		$block = self::find_first_mapped_block( parse_blocks( $post->post_content ) );
+		if ( null !== $block ) {
+			$map = self::ATTR_META_MAP[ $block['blockName'] ];
 
 			foreach ( $map as $attr => $suffix ) {
 				$value = $block['attrs'][ $attr ] ?? null;
@@ -123,8 +171,32 @@ class Card_Meta_Sync {
 
 				update_post_meta( $post_id, Meta_Fields::PREFIX . $suffix, sanitize_text_field( $value ) );
 			}
-
-			break; // First card block wins, mirroring the kind-sync semantics.
 		}
+	}
+
+	/**
+	 * Depth-first search for the first card block present in
+	 * ATTR_META_MAP. Recursion matters: Micropub-generated content
+	 * wraps its card inside an h-entry core/group, and editors can
+	 * nest cards in groups/columns too — a top-level-only walk never
+	 * sees those cards at all. First match in document order wins,
+	 * mirroring the kind-sync semantics.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed blocks.
+	 * @return array<string, mixed>|null The first mapped block, or null.
+	 */
+	private static function find_first_mapped_block( array $blocks ): ?array {
+		foreach ( $blocks as $block ) {
+			if ( isset( self::ATTR_META_MAP[ $block['blockName'] ?? '' ] ) ) {
+				return $block;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = self::find_first_mapped_block( $block['innerBlocks'] );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+		return null;
 	}
 }

--- a/includes/class-cli-commands.php
+++ b/includes/class-cli-commands.php
@@ -110,6 +110,65 @@ class CLI_Commands {
 	}
 
 	/**
+	 * Set featured images from kind artwork for existing posts.
+	 *
+	 * New saves handle this automatically; this backfills posts created
+	 * before the feature existed. Posts with a featured image are left
+	 * alone, and a previously attempted artwork URL is never re-tried,
+	 * so deliberate removals stay removed.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Must be 'backfill'.
+	 *
+	 * [--dry-run]
+	 * : Report what would change without fetching or writing anything.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp postkind featured-artwork backfill
+	 *     wp postkind featured-artwork backfill --dry-run
+	 *
+	 * @subcommand featured-artwork
+	 *
+	 * @param array $args       Positional arguments; expects 'backfill'.
+	 * @param array $assoc_args Associative arguments (dry-run).
+	 * @return void
+	 */
+	public function featured_artwork( array $args, array $assoc_args ): void {
+		$sub = $args[0] ?? '';
+		if ( 'backfill' !== $sub ) {
+			WP_CLI::error( 'Usage: wp postkind featured-artwork backfill [--dry-run]' );
+		}
+
+		$dry_run = (bool) Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$stats   = ( new Featured_Artwork() )->backfill( $dry_run );
+
+		if ( $dry_run ) {
+			WP_CLI::success(
+				sprintf(
+					'Dry run: %d kind post(s) scanned, %d would get a featured image, %d skipped.',
+					$stats['scanned'],
+					$stats['updated'],
+					$stats['skipped']
+				)
+			);
+			return;
+		}
+
+		WP_CLI::success(
+			sprintf(
+				'%d kind post(s) scanned, %d featured image(s) set, %d skipped, %d failed.',
+				$stats['scanned'],
+				$stats['updated'],
+				$stats['skipped'],
+				$stats['failed']
+			)
+		);
+	}
+
+	/**
 	 * Display check-in statistics.
 	 *
 	 * ## EXAMPLES

--- a/includes/class-featured-artwork.php
+++ b/includes/class-featured-artwork.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Featured image from kind artwork.
+ *
+ * @package PKIW
+ * @since   1.3.0
+ */
+
+declare(strict_types=1);
+
+namespace PKIW;
+
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sets a kind post's featured image from its representative artwork
+ * (album cover, movie poster, book cover, game art, checkin photo)
+ * when the post has none. Remote artwork is sideloaded into the media
+ * library once per URL; artwork that already resolves to a local
+ * attachment is reused without any network request.
+ *
+ * Ownership rules keep editorial choice in charge:
+ *
+ * - A featured image this class did not set is never replaced.
+ * - Removing the auto-set image is respected — the same artwork URL is
+ *   never re-applied (the attempt marker survives the removal).
+ * - A failed fetch is not retried on every save; a new artwork URL
+ *   resets the attempt.
+ * - Disable entirely with `add_filter( 'pkiw_set_featured_from_artwork',
+ *   '__return_false' )`.
+ *
+ * @since 1.3.0
+ */
+class Featured_Artwork {
+
+	/**
+	 * Meta key recording the last artwork URL attempted (set on both
+	 * success and failure — it's the "don't repeat yourself" marker).
+	 */
+	public const SOURCE_META = '_pkiw_featured_artwork_source';
+
+	/**
+	 * Meta key recording the attachment ID this class set as the
+	 * featured image (the ownership marker: only this attachment is
+	 * ever replaced when artwork changes).
+	 */
+	public const ATTACHMENT_META = '_pkiw_featured_artwork_attachment';
+
+	/**
+	 * Constructor.
+	 *
+	 * Hooked after Card_Meta_Sync (25) and Book_Completion (30) so the
+	 * normalized meta this reads is current for the same save.
+	 */
+	public function __construct() {
+		add_action( 'save_post', [ $this, 'maybe_set_featured' ], 35, 2 );
+	}
+
+	/**
+	 * Set the featured image from kind artwork when appropriate.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 * @return void
+	 */
+	public function maybe_set_featured( int $post_id, \WP_Post $post ): void {
+		if ( 'post' !== $post->post_type || wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+		if ( in_array( $post->post_status, [ 'auto-draft', 'trash' ], true ) ) {
+			return;
+		}
+
+		$url = Kind_Artwork::get_representative_image_url( $post_id );
+		if ( null === $url ) {
+			return; // No real artwork — never invent or remove anything.
+		}
+
+		/**
+		 * Filters whether kind artwork may become the featured image.
+		 *
+		 * @since 1.3.0
+		 *
+		 * @param bool   $enabled Default true.
+		 * @param int    $post_id Post ID.
+		 * @param string $url     Resolved artwork URL.
+		 */
+		if ( ! apply_filters( 'pkiw_set_featured_from_artwork', true, $post_id, $url ) ) {
+			return;
+		}
+
+		$attempted      = (string) get_post_meta( $post_id, self::SOURCE_META, true );
+		$our_attachment = (int) get_post_meta( $post_id, self::ATTACHMENT_META, true );
+		$thumbnail_id   = (int) get_post_thumbnail_id( $post_id );
+
+		if ( $thumbnail_id > 0 ) {
+			// Replace only an image we set ourselves, and only because
+			// the artwork actually changed.
+			if ( $thumbnail_id !== $our_attachment || $url === $attempted ) {
+				return;
+			}
+		} elseif ( $url === $attempted ) {
+			// Same URL as the last attempt: either the fetch failed (don't
+			// hammer it on every save) or the user removed the image we
+			// set (respect the removal).
+			return;
+		}
+
+		self::apply( $post_id, $url );
+	}
+
+	/**
+	 * Apply an artwork URL as the featured image.
+	 *
+	 * Records the attempt first so a failing URL is only fetched once,
+	 * reuses an existing local attachment when the URL is our own, and
+	 * sideloads otherwise.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $url     Validated artwork URL.
+	 * @return int|\WP_Error Attachment ID, or the sideload error.
+	 */
+	public static function apply( int $post_id, string $url ) {
+		update_post_meta( $post_id, self::SOURCE_META, $url );
+
+		$attachment_id = attachment_url_to_postid( $url );
+		if ( 0 === $attachment_id ) {
+			$attachment_id = self::sideload( $post_id, $url );
+		}
+
+		if ( is_wp_error( $attachment_id ) ) {
+			delete_post_meta( $post_id, self::ATTACHMENT_META );
+			return $attachment_id;
+		}
+
+		set_post_thumbnail( $post_id, $attachment_id );
+		update_post_meta( $post_id, self::ATTACHMENT_META, $attachment_id );
+
+		// Give the artwork a usable alt if it has none — the post title
+		// is the entity name for every kind card ("American Obituary").
+		if ( '' === (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', get_the_title( $post_id ) );
+		}
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Sideload a remote artwork URL into the media library.
+	 *
+	 * @param int    $post_id Post the attachment is for.
+	 * @param string $url     Remote image URL.
+	 * @return int|\WP_Error Attachment ID or error.
+	 */
+	private static function sideload( int $post_id, string $url ) {
+		// save_post can fire on the front end (Micropub, REST); the
+		// sideload stack lives in admin includes.
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		return media_sideload_image( $url, $post_id, get_the_title( $post_id ), 'id' );
+	}
+
+	/**
+	 * Backfill featured images for existing kind posts.
+	 *
+	 * Skips posts that already have a featured image and posts whose
+	 * artwork URL was already attempted (so removals stay removed and
+	 * dead URLs aren't re-fetched).
+	 *
+	 * @param bool $dry_run When true, count without writing.
+	 * @return array{scanned: int, updated: int, skipped: int, failed: int} Stats.
+	 */
+	public function backfill( bool $dry_run = false ): array {
+		$stats = [
+			'scanned' => 0,
+			'updated' => 0,
+			'skipped' => 0,
+			'failed'  => 0,
+		];
+
+		$post_ids = get_posts(
+			[
+				'post_type'        => 'post',
+				'post_status'      => [ 'publish', 'future', 'draft', 'pending', 'private' ],
+				'posts_per_page'   => -1,
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => false,
+				'tax_query'        => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- One-shot CLI backfill, not a front-end query.
+					[
+						'taxonomy' => Taxonomy::TAXONOMY,
+						'field'    => 'slug',
+						'terms'    => array_keys( Kind_Artwork::KIND_IMAGE_META ),
+					],
+				],
+			]
+		);
+
+		foreach ( $post_ids as $post_id ) {
+			++$stats['scanned'];
+
+			$url = Kind_Artwork::get_representative_image_url( $post_id );
+			if ( null === $url
+				|| get_post_thumbnail_id( $post_id ) > 0
+				|| (string) get_post_meta( $post_id, self::SOURCE_META, true ) === $url
+				|| ! apply_filters( 'pkiw_set_featured_from_artwork', true, $post_id, $url ) ) {
+				++$stats['skipped'];
+				continue;
+			}
+
+			if ( $dry_run ) {
+				++$stats['updated'];
+				continue;
+			}
+
+			$result = self::apply( $post_id, $url );
+			if ( is_wp_error( $result ) ) {
+				++$stats['failed'];
+			} else {
+				++$stats['updated'];
+			}
+		}
+
+		return $stats;
+	}
+}

--- a/includes/class-featured-artwork.php
+++ b/includes/class-featured-artwork.php
@@ -74,6 +74,17 @@ class Featured_Artwork {
 			return;
 		}
 
+		// Sideloading mints media library attachments, so a user-context
+		// save requires the upload_files capability (a contributor can
+		// edit their own drafts but must not create attachments this
+		// way). System contexts — cron, WP-CLI — carry no user and are
+		// deliberate operator actions. Checked before any state is
+		// written so a blocked save leaves no attempt marker and a
+		// capable user's later save still applies the artwork.
+		if ( get_current_user_id() > 0 && ! current_user_can( 'upload_files' ) ) {
+			return;
+		}
+
 		$url = Kind_Artwork::get_representative_image_url( $post_id );
 		if ( null === $url ) {
 			return; // No real artwork — never invent or remove anything.

--- a/includes/class-kind-artwork.php
+++ b/includes/class-kind-artwork.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Kind artwork resolution.
+ *
+ * @package PKIW
+ * @since   1.3.0
+ */
+
+declare(strict_types=1);
+
+namespace PKIW;
+
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves a kind post's representative media (album cover, movie
+ * poster, book cover, game art, checkin photo) from normalized post
+ * meta, with a block-attribute fallback for posts saved before
+ * Card_Meta_Sync covered their kind. Shared by the Yoast schema
+ * integration and the featured-artwork behavior so both expose the
+ * same image for the same post.
+ *
+ * @since 1.3.0
+ */
+final class Kind_Artwork {
+
+	/**
+	 * Kind slug => meta suffix (appended to Meta_Fields::PREFIX) that
+	 * stores the kind's representative image URL.
+	 *
+	 * Only kinds whose card defines real entity media belong here; a
+	 * kind without an entry truthfully contributes no image.
+	 *
+	 * @var array<string, string>
+	 */
+	public const KIND_IMAGE_META = [
+		'listen'  => 'listen_cover',
+		'watch'   => 'watch_poster',
+		'read'    => 'read_cover',
+		'jam'     => 'jam_cover',
+		'play'    => 'play_cover',
+		'checkin' => 'checkin_photo',
+	];
+
+	/**
+	 * Card block name => attribute holding the representative image
+	 * URL. Fallback for posts saved before Card_Meta_Sync mirrored
+	 * these blocks into meta (the attrs are the source the sync reads,
+	 * so both paths yield the same value).
+	 *
+	 * @var array<string, string>
+	 */
+	public const BLOCK_IMAGE_ATTR = [
+		'post-kinds-indieweb/listen-card'  => 'coverImage',
+		'post-kinds-indieweb/watch-card'   => 'posterImage',
+		'post-kinds-indieweb/read-card'    => 'coverImage',
+		'post-kinds-indieweb/jam-card'     => 'cover',
+		'post-kinds-indieweb/play-card'    => 'cover',
+		'post-kinds-indieweb/checkin-card' => 'photo',
+	];
+
+	/**
+	 * Not instantiable — static resolver only.
+	 */
+	private function __construct() {
+	}
+
+	/**
+	 * Resolve the representative image URL for a kind post.
+	 *
+	 * Normalized post meta first (written by Card_Meta_Sync on save);
+	 * falls back to the first kind card block's image attribute for
+	 * posts saved before the sync covered their block. Returns null
+	 * when the post's kind defines no representative media or the
+	 * stored value isn't a usable http(s) URL.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string|null Validated image URL, or null.
+	 */
+	public static function get_representative_image_url( int $post_id ): ?string {
+		$url = '';
+
+		$terms = get_the_terms( $post_id, Taxonomy::TAXONOMY );
+		if ( is_array( $terms ) && ! empty( $terms ) ) {
+			$suffix = self::KIND_IMAGE_META[ $terms[0]->slug ] ?? null;
+			if ( null !== $suffix ) {
+				$url = (string) get_post_meta( $post_id, Meta_Fields::PREFIX . $suffix, true );
+			}
+		}
+
+		if ( '' === $url ) {
+			$post = get_post( $post_id );
+			if ( ! $post instanceof \WP_Post || ! has_blocks( $post->post_content ) ) {
+				return null;
+			}
+			$url = (string) self::first_card_image_attr( parse_blocks( $post->post_content ) );
+		}
+
+		return self::validate_image_url( $url );
+	}
+
+	/**
+	 * Depth-first search for the first kind card block carrying an
+	 * image attribute (cards sit inside an h-entry group in
+	 * Micropub-generated content, so nesting is the common case).
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed blocks.
+	 * @return string|null Image attribute value, or null.
+	 */
+	private static function first_card_image_attr( array $blocks ): ?string {
+		foreach ( $blocks as $block ) {
+			$attr = self::BLOCK_IMAGE_ATTR[ $block['blockName'] ?? '' ] ?? null;
+			if ( null !== $attr ) {
+				$value = $block['attrs'][ $attr ] ?? null;
+				return ( is_string( $value ) && '' !== $value ) ? $value : null;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = self::first_card_image_attr( $block['innerBlocks'] );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Validate a candidate image URL.
+	 *
+	 * Accepts only well-formed absolute http(s) URLs; anything else
+	 * (relative paths, data:/javascript: URIs, malformed values)
+	 * returns null so the image is omitted rather than used broken.
+	 *
+	 * @param string $url Candidate URL.
+	 * @return string|null Sanitized URL, or null.
+	 */
+	public static function validate_image_url( string $url ): ?string {
+		$url = esc_url_raw( trim( $url ), [ 'http', 'https' ] );
+		if ( '' === $url || false === wp_http_validate_url( $url ) ) {
+			return null;
+		}
+
+		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
+		if ( ! in_array( $scheme, [ 'http', 'https' ], true ) ) {
+			return null;
+		}
+
+		return $url;
+	}
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -231,6 +231,13 @@ final class Plugin {
 	private ?Integrations\Yoast_SEO $yoast_integration = null;
 
 	/**
+	 * Featured-artwork behavior instance.
+	 *
+	 * @var Featured_Artwork|null
+	 */
+	private ?Featured_Artwork $featured_artwork = null;
+
+	/**
 	 * Get the singleton instance.
 	 *
 	 * @return Plugin The singleton instance.
@@ -437,6 +444,12 @@ final class Plugin {
 
 		if ( class_exists( __NAMESPACE__ . '\\Card_Meta_Sync' ) ) {
 			$this->card_meta_sync = new Card_Meta_Sync();
+		}
+
+		// Featured image from kind artwork (sideloads once per URL,
+		// respects editorial choice — see Featured_Artwork).
+		if ( class_exists( __NAMESPACE__ . '\\Featured_Artwork' ) ) {
+			$this->featured_artwork = new Featured_Artwork();
 		}
 
 		// Resolves cited URLs to standard.site document records on AT
@@ -1336,6 +1349,15 @@ final class Plugin {
 	 */
 	public function get_card_meta_sync(): ?Card_Meta_Sync {
 		return $this->card_meta_sync;
+	}
+
+	/**
+	 * Get the Featured_Artwork component.
+	 *
+	 * @return Featured_Artwork|null The Featured_Artwork instance or null if not loaded.
+	 */
+	public function get_featured_artwork(): ?Featured_Artwork {
+		return $this->featured_artwork;
 	}
 
 	/**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -224,6 +224,13 @@ final class Plugin {
 	private ?Integrations\WP_Recipe_Maker $wprm_integration = null;
 
 	/**
+	 * Yoast SEO integration instance.
+	 *
+	 * @var Integrations\Yoast_SEO|null
+	 */
+	private ?Integrations\Yoast_SEO $yoast_integration = null;
+
+	/**
 	 * Get the singleton instance.
 	 *
 	 * @return Plugin The singleton instance.
@@ -572,6 +579,12 @@ final class Plugin {
 		// WP Recipe Maker integration.
 		if ( class_exists( __NAMESPACE__ . '\\Integrations\\WP_Recipe_Maker' ) ) {
 			$this->wprm_integration = new Integrations\WP_Recipe_Maker();
+		}
+
+		// Yoast SEO integration (inert unless Yoast is active).
+		if ( class_exists( __NAMESPACE__ . '\\Integrations\\Yoast_SEO' ) ) {
+			$this->yoast_integration = new Integrations\Yoast_SEO();
+			$this->yoast_integration->register();
 		}
 
 		/**

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -476,7 +476,35 @@ class Taxonomy {
 				continue;
 			}
 
-			return self::KIND_CARD_BLOCKS[ $block['blockName'] ] ?? null;
+			return self::first_visible_block_kind( $block );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve a block to a kind, descending through wrapper blocks.
+	 *
+	 * A card nested first inside a group (the shape the Micropub bridge
+	 * writes: card inside an h-entry core/group) is still the first
+	 * thing a person sees, so it decides the kind. A wrapper whose
+	 * first real child is not a card resolves to null — same as a
+	 * paragraph-first post.
+	 *
+	 * @param array<string, mixed> $block Parsed block.
+	 * @return string|null Kind slug, or null.
+	 */
+	private static function first_visible_block_kind( array $block ): ?string {
+		$kind = self::KIND_CARD_BLOCKS[ $block['blockName'] ] ?? null;
+		if ( null !== $kind ) {
+			return $kind;
+		}
+
+		foreach ( $block['innerBlocks'] ?? [] as $inner ) {
+			if ( null === ( $inner['blockName'] ?? null ) ) {
+				continue;
+			}
+			return self::first_visible_block_kind( $inner );
 		}
 
 		return null;

--- a/includes/integrations/class-yoast-seo.php
+++ b/includes/integrations/class-yoast-seo.php
@@ -19,8 +19,7 @@ declare(strict_types=1);
 
 namespace PKIW\Integrations;
 
-use PKIW\Meta_Fields;
-use PKIW\Taxonomy;
+use PKIW\Kind_Artwork;
 
 // Prevent direct access.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -46,41 +45,6 @@ class Yoast_SEO {
 	 * natively-resolved main image for consuming parsers.
 	 */
 	private const PRIMARY_IMAGE_HASH = '#primaryimage';
-
-	/**
-	 * Kind slug => meta suffix (appended to Meta_Fields::PREFIX) that
-	 * stores the kind's representative image URL.
-	 *
-	 * Only kinds whose card defines real entity media belong here; a
-	 * kind without an entry truthfully contributes no image.
-	 *
-	 * @var array<string, string>
-	 */
-	public const KIND_IMAGE_META = [
-		'listen'  => 'listen_cover',
-		'watch'   => 'watch_poster',
-		'read'    => 'read_cover',
-		'jam'     => 'jam_cover',
-		'play'    => 'play_cover',
-		'checkin' => 'checkin_photo',
-	];
-
-	/**
-	 * Card block name => attribute holding the representative image
-	 * URL. Fallback for posts saved before Card_Meta_Sync mirrored
-	 * these blocks into meta (the attrs are the source the sync reads,
-	 * so both paths yield the same value).
-	 *
-	 * @var array<string, string>
-	 */
-	public const BLOCK_IMAGE_ATTR = [
-		'post-kinds-indieweb/listen-card'  => 'coverImage',
-		'post-kinds-indieweb/watch-card'   => 'posterImage',
-		'post-kinds-indieweb/read-card'    => 'coverImage',
-		'post-kinds-indieweb/jam-card'     => 'cover',
-		'post-kinds-indieweb/play-card'    => 'cover',
-		'post-kinds-indieweb/checkin-card' => 'photo',
-	];
 
 	/**
 	 * Register hooks. No-op unless Yoast SEO is active.
@@ -124,7 +88,7 @@ class Yoast_SEO {
 			return $graph;
 		}
 
-		$image_url = self::get_representative_image_url( $post_id );
+		$image_url = Kind_Artwork::get_representative_image_url( $post_id );
 		if ( null === $image_url ) {
 			return $graph;
 		}
@@ -171,90 +135,6 @@ class Yoast_SEO {
 		$graph[] = self::generate_image_object( $image_schema_id, $image_url );
 
 		return $graph;
-	}
-
-	/**
-	 * Resolve the representative image URL for a kind post.
-	 *
-	 * Normalized post meta first (written by Card_Meta_Sync on save);
-	 * falls back to the first kind card block's image attribute for
-	 * posts saved before the sync covered their block. Returns null
-	 * when the post's kind defines no representative media or the
-	 * stored value isn't a usable http(s) URL — the schema image is
-	 * then truthfully omitted.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return string|null Validated image URL, or null.
-	 */
-	public static function get_representative_image_url( int $post_id ): ?string {
-		$url = '';
-
-		$terms = get_the_terms( $post_id, Taxonomy::TAXONOMY );
-		if ( is_array( $terms ) && ! empty( $terms ) ) {
-			$suffix = self::KIND_IMAGE_META[ $terms[0]->slug ] ?? null;
-			if ( null !== $suffix ) {
-				$url = (string) get_post_meta( $post_id, Meta_Fields::PREFIX . $suffix, true );
-			}
-		}
-
-		if ( '' === $url ) {
-			$post = get_post( $post_id );
-			if ( ! $post instanceof \WP_Post || ! has_blocks( $post->post_content ) ) {
-				return null;
-			}
-			$url = (string) self::first_card_image_attr( parse_blocks( $post->post_content ) );
-		}
-
-		return self::validate_image_url( $url );
-	}
-
-	/**
-	 * Depth-first search for the first kind card block carrying an
-	 * image attribute (cards sit inside an h-entry group in
-	 * Micropub-generated content, so nesting is the common case).
-	 *
-	 * @param array<int, array<string, mixed>> $blocks Parsed blocks.
-	 * @return string|null Image attribute value, or null.
-	 */
-	private static function first_card_image_attr( array $blocks ): ?string {
-		foreach ( $blocks as $block ) {
-			$attr = self::BLOCK_IMAGE_ATTR[ $block['blockName'] ?? '' ] ?? null;
-			if ( null !== $attr ) {
-				$value = $block['attrs'][ $attr ] ?? null;
-				return ( is_string( $value ) && '' !== $value ) ? $value : null;
-			}
-			if ( ! empty( $block['innerBlocks'] ) ) {
-				$found = self::first_card_image_attr( $block['innerBlocks'] );
-				if ( null !== $found ) {
-					return $found;
-				}
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * Validate a candidate image URL for schema output.
-	 *
-	 * Accepts only well-formed absolute http(s) URLs; anything else
-	 * (relative paths, data:/javascript: URIs, malformed values)
-	 * returns null so the image is omitted rather than emitted broken.
-	 *
-	 * @param string $url Candidate URL.
-	 * @return string|null Sanitized URL, or null.
-	 */
-	private static function validate_image_url( string $url ): ?string {
-		$url = esc_url_raw( trim( $url ), [ 'http', 'https' ] );
-		if ( '' === $url || false === wp_http_validate_url( $url ) ) {
-			return null;
-		}
-
-		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
-		if ( ! in_array( $scheme, [ 'http', 'https' ], true ) ) {
-			return null;
-		}
-
-		return $url;
 	}
 
 	/**

--- a/includes/integrations/class-yoast-seo.php
+++ b/includes/integrations/class-yoast-seo.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * Yoast SEO Integration
+ *
+ * Exposes a kind post's representative media (album cover, movie
+ * poster, book cover, game art, checkin photo) to Yoast SEO's
+ * schema.org graph when the post has no image Yoast can find on its
+ * own. Kind cards are dynamic blocks — their artwork lives in block
+ * attributes and post meta, not as an `<img>` in raw post_content — so
+ * Yoast's featured-image / first-content-image resolution never sees
+ * it, and Article schema on kind micro-posts loses its (optional but
+ * recommended) `image` property.
+ *
+ * @package PKIW
+ * @since   1.3.0
+ */
+
+declare(strict_types=1);
+
+namespace PKIW\Integrations;
+
+use PKIW\Meta_Fields;
+use PKIW\Taxonomy;
+
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Yoast SEO schema integration.
+ *
+ * Fills the schema graph's primary image from normalized kind meta —
+ * never overriding an image Yoast already resolved (featured image or
+ * first content image), never inventing media, and never emitting a
+ * competing graph. Inert unless Yoast SEO is active.
+ *
+ * @since 1.3.0
+ */
+class Yoast_SEO {
+
+	/**
+	 * Schema @id fragment Yoast uses for the page's primary image
+	 * (mirrors Yoast\WP\SEO\Config\Schema_IDs::PRIMARY_IMAGE_HASH).
+	 * Reusing it makes the injected node indistinguishable from a
+	 * natively-resolved main image for consuming parsers.
+	 */
+	private const PRIMARY_IMAGE_HASH = '#primaryimage';
+
+	/**
+	 * Kind slug => meta suffix (appended to Meta_Fields::PREFIX) that
+	 * stores the kind's representative image URL.
+	 *
+	 * Only kinds whose card defines real entity media belong here; a
+	 * kind without an entry truthfully contributes no image.
+	 *
+	 * @var array<string, string>
+	 */
+	public const KIND_IMAGE_META = [
+		'listen'  => 'listen_cover',
+		'watch'   => 'watch_poster',
+		'read'    => 'read_cover',
+		'jam'     => 'jam_cover',
+		'play'    => 'play_cover',
+		'checkin' => 'checkin_photo',
+	];
+
+	/**
+	 * Card block name => attribute holding the representative image
+	 * URL. Fallback for posts saved before Card_Meta_Sync mirrored
+	 * these blocks into meta (the attrs are the source the sync reads,
+	 * so both paths yield the same value).
+	 *
+	 * @var array<string, string>
+	 */
+	public const BLOCK_IMAGE_ATTR = [
+		'post-kinds-indieweb/listen-card'  => 'coverImage',
+		'post-kinds-indieweb/watch-card'   => 'posterImage',
+		'post-kinds-indieweb/read-card'    => 'coverImage',
+		'post-kinds-indieweb/jam-card'     => 'cover',
+		'post-kinds-indieweb/play-card'    => 'cover',
+		'post-kinds-indieweb/checkin-card' => 'photo',
+	];
+
+	/**
+	 * Register hooks. No-op unless Yoast SEO is active.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			return;
+		}
+
+		// Priority 11: after Yoast's own pieces and default-priority
+		// third parties have shaped the graph.
+		add_filter( 'wpseo_schema_graph', [ $this, 'filter_schema_graph' ], 11, 2 );
+	}
+
+	/**
+	 * Add the kind's representative image to the schema graph.
+	 *
+	 * Runs only when Yoast found no image of its own; adds one
+	 * ImageObject node and wires it into the Article and WebPage
+	 * pieces exactly the way Yoast wires a featured image.
+	 *
+	 * @param array<int, array<string, mixed>>|mixed $graph   Schema graph pieces.
+	 * @param object                                 $context Yoast Meta_Tags_Context.
+	 * @return array<int, array<string, mixed>>|mixed Filtered graph.
+	 */
+	public function filter_schema_graph( $graph, $context ) {
+		if ( ! is_array( $graph ) || ! is_singular( 'post' ) ) {
+			return $graph;
+		}
+
+		// Yoast already resolved a main image (featured image, or the
+		// first image in the raw post content). Never compete with it.
+		if ( ! empty( $context->main_image_url ) ) {
+			return $graph;
+		}
+
+		$post_id = get_queried_object_id();
+		if ( $post_id < 1 ) {
+			return $graph;
+		}
+
+		$image_url = self::get_representative_image_url( $post_id );
+		if ( null === $image_url ) {
+			return $graph;
+		}
+
+		$canonical = ( isset( $context->canonical ) && is_string( $context->canonical ) && '' !== $context->canonical )
+			? $context->canonical
+			: get_permalink( $post_id );
+		if ( ! is_string( $canonical ) || '' === $canonical ) {
+			return $graph;
+		}
+
+		$image_schema_id = $canonical . self::PRIMARY_IMAGE_HASH;
+		$wired           = false;
+
+		foreach ( $graph as &$piece ) {
+			if ( ! is_array( $piece ) || ! isset( $piece['@type'] ) ) {
+				continue;
+			}
+
+			$types = (array) $piece['@type'];
+
+			// Article piece: mirror Article::add_image().
+			if ( array_intersect( $types, [ 'Article', 'BlogPosting', 'SocialMediaPosting', 'NewsArticle', 'TechArticle', 'Report' ] )
+				&& ! isset( $piece['image'] ) ) {
+				$piece['image']        = [ '@id' => $image_schema_id ];
+				$piece['thumbnailUrl'] = $image_url;
+				$wired                 = true;
+			}
+
+			// WebPage piece: mirror WebPage's primaryImageOfPage wiring.
+			if ( in_array( 'WebPage', $types, true ) && ! isset( $piece['primaryImageOfPage'] ) ) {
+				$piece['image']              = [ '@id' => $image_schema_id ];
+				$piece['thumbnailUrl']       = $image_url;
+				$piece['primaryImageOfPage'] = [ '@id' => $image_schema_id ];
+				$wired                       = true;
+			}
+		}
+		unset( $piece );
+
+		if ( ! $wired ) {
+			return $graph;
+		}
+
+		$graph[] = self::generate_image_object( $image_schema_id, $image_url );
+
+		return $graph;
+	}
+
+	/**
+	 * Resolve the representative image URL for a kind post.
+	 *
+	 * Normalized post meta first (written by Card_Meta_Sync on save);
+	 * falls back to the first kind card block's image attribute for
+	 * posts saved before the sync covered their block. Returns null
+	 * when the post's kind defines no representative media or the
+	 * stored value isn't a usable http(s) URL — the schema image is
+	 * then truthfully omitted.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string|null Validated image URL, or null.
+	 */
+	public static function get_representative_image_url( int $post_id ): ?string {
+		$url = '';
+
+		$terms = get_the_terms( $post_id, Taxonomy::TAXONOMY );
+		if ( is_array( $terms ) && ! empty( $terms ) ) {
+			$suffix = self::KIND_IMAGE_META[ $terms[0]->slug ] ?? null;
+			if ( null !== $suffix ) {
+				$url = (string) get_post_meta( $post_id, Meta_Fields::PREFIX . $suffix, true );
+			}
+		}
+
+		if ( '' === $url ) {
+			$post = get_post( $post_id );
+			if ( ! $post instanceof \WP_Post || ! has_blocks( $post->post_content ) ) {
+				return null;
+			}
+			$url = (string) self::first_card_image_attr( parse_blocks( $post->post_content ) );
+		}
+
+		return self::validate_image_url( $url );
+	}
+
+	/**
+	 * Depth-first search for the first kind card block carrying an
+	 * image attribute (cards sit inside an h-entry group in
+	 * Micropub-generated content, so nesting is the common case).
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed blocks.
+	 * @return string|null Image attribute value, or null.
+	 */
+	private static function first_card_image_attr( array $blocks ): ?string {
+		foreach ( $blocks as $block ) {
+			$attr = self::BLOCK_IMAGE_ATTR[ $block['blockName'] ?? '' ] ?? null;
+			if ( null !== $attr ) {
+				$value = $block['attrs'][ $attr ] ?? null;
+				return ( is_string( $value ) && '' !== $value ) ? $value : null;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = self::first_card_image_attr( $block['innerBlocks'] );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Validate a candidate image URL for schema output.
+	 *
+	 * Accepts only well-formed absolute http(s) URLs; anything else
+	 * (relative paths, data:/javascript: URIs, malformed values)
+	 * returns null so the image is omitted rather than emitted broken.
+	 *
+	 * @param string $url Candidate URL.
+	 * @return string|null Sanitized URL, or null.
+	 */
+	private static function validate_image_url( string $url ): ?string {
+		$url = esc_url_raw( trim( $url ), [ 'http', 'https' ] );
+		if ( '' === $url || false === wp_http_validate_url( $url ) ) {
+			return null;
+		}
+
+		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
+		if ( ! in_array( $scheme, [ 'http', 'https' ], true ) ) {
+			return null;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Build the ImageObject node.
+	 *
+	 * Uses Yoast's own schema image helper when available so the node
+	 * carries the same shape (inLanguage, resolved dimensions for
+	 * local attachments) as a native main image; falls back to the
+	 * minimal valid ImageObject otherwise.
+	 *
+	 * @param string $image_schema_id Schema @id for the node.
+	 * @param string $image_url       Image URL.
+	 * @return array<string, mixed> ImageObject piece.
+	 */
+	private static function generate_image_object( string $image_schema_id, string $image_url ): array {
+		if ( function_exists( 'YoastSEO' ) ) {
+			$helpers = YoastSEO()->helpers ?? null;
+			if ( is_object( $helpers )
+				&& isset( $helpers->schema->image )
+				&& method_exists( $helpers->schema->image, 'generate_from_url' ) ) {
+				$generated = $helpers->schema->image->generate_from_url( $image_schema_id, $image_url );
+				if ( is_array( $generated ) && ! empty( $generated ) ) {
+					return $generated;
+				}
+			}
+		}
+
+		return [
+			'@type'      => 'ImageObject',
+			'@id'        => $image_schema_id,
+			'url'        => $image_url,
+			'contentUrl' => $image_url,
+		];
+	}
+}

--- a/tests/phpunit/integration/CardMetaSyncTest.php
+++ b/tests/phpunit/integration/CardMetaSyncTest.php
@@ -46,6 +46,32 @@ final class CardMetaSyncTest extends WP_UnitTestCase {
 		$this->assertSame( 'https://example.com/photo.jpg', get_post_meta( $post_id, '_pkiw_checkin_photo', true ) );
 	}
 
+	public function test_listen_card_attrs_mirror_into_pkiw_meta(): void {
+		$post_id = self::factory()->post->create( [
+			'post_content' => '<!-- wp:post-kinds-indieweb/listen-card {"trackTitle":"One","artistName":"U2","albumTitle":"Achtung Baby","coverImage":"https://coverartarchive.org/release/abc/front-500.jpg","musicbrainzId":"mbid-123","listenUrl":"https://musicbrainz.org/recording/one","rating":5} /-->',
+		] );
+
+		$this->assertSame( 'One', get_post_meta( $post_id, '_pkiw_listen_track', true ) );
+		$this->assertSame( 'U2', get_post_meta( $post_id, '_pkiw_listen_artist', true ) );
+		$this->assertSame( 'Achtung Baby', get_post_meta( $post_id, '_pkiw_listen_album', true ) );
+		$this->assertSame( 'https://coverartarchive.org/release/abc/front-500.jpg', get_post_meta( $post_id, '_pkiw_listen_cover', true ) );
+		$this->assertSame( 'mbid-123', get_post_meta( $post_id, '_pkiw_listen_mbid', true ) );
+		$this->assertSame( 'https://musicbrainz.org/recording/one', get_post_meta( $post_id, '_pkiw_listen_url', true ) );
+		$this->assertSame( '5', get_post_meta( $post_id, '_pkiw_listen_rating', true ) );
+	}
+
+	public function test_card_nested_in_h_entry_group_still_syncs(): void {
+		// Regression: the Micropub bridge wraps its card inside an h-entry
+		// core/group, and a top-level-only block walk never reached it —
+		// Micropub-created posts got no _pkiw_* meta at all.
+		$post_id = self::factory()->post->create( [
+			'post_content' => '<!-- wp:group {"className":"h-entry","layout":{"type":"constrained"}} --><div class="wp-block-group h-entry"><!-- wp:post-kinds-indieweb/listen-card {"trackTitle":"American Obituary","artistName":"U2"} /--></div><!-- /wp:group -->',
+		] );
+
+		$this->assertSame( 'American Obituary', get_post_meta( $post_id, '_pkiw_listen_track', true ) );
+		$this->assertSame( 'U2', get_post_meta( $post_id, '_pkiw_listen_artist', true ) );
+	}
+
 	public function test_manual_meta_not_clobbered_by_empty_attr(): void {
 		$post_id = self::factory()->post->create( [
 			'post_content' => '<!-- wp:post-kinds-indieweb/read-card {"bookTitle":"Fourth Wing"} /-->',

--- a/tests/phpunit/integration/FeaturedArtworkTest.php
+++ b/tests/phpunit/integration/FeaturedArtworkTest.php
@@ -193,6 +193,32 @@ final class FeaturedArtworkTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $this->http_requests );
 	}
 
+	public function test_user_without_upload_files_cannot_trigger_sideload(): void {
+		$contributor = self::factory()->user->create( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $contributor );
+
+		$post_id = self::factory()->post->create( [
+			'post_author'  => $contributor,
+			'post_status'  => 'draft',
+			'post_content' => '<!-- wp:post-kinds-indieweb/listen-card {"trackTitle":"One","coverImage":"' . self::COVER . '"} /-->',
+		] );
+
+		$this->assertSame( 0, (int) get_post_thumbnail_id( $post_id ) );
+		$this->assertSame( 0, $this->http_requests, 'no sideload for a user without upload_files' );
+		$this->assertSame(
+			'',
+			get_post_meta( $post_id, Featured_Artwork::SOURCE_META, true ),
+			'a blocked save must leave no attempt marker'
+		);
+
+		// A capable user's later save applies the same artwork normally.
+		$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor );
+		wp_update_post( [ 'ID' => $post_id, 'post_title' => 'touch' ] );
+
+		$this->assertGreaterThan( 0, get_post_thumbnail_id( $post_id ), 'an upload-capable save still applies the artwork' );
+	}
+
 	public function test_backfill_sets_missing_featured_images(): void {
 		// A post that predates the feature: artwork attr present, no
 		// featured image, no attempt marker.

--- a/tests/phpunit/integration/FeaturedArtworkTest.php
+++ b/tests/phpunit/integration/FeaturedArtworkTest.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Featured_Artwork integration coverage.
+ *
+ * All remote fetches are intercepted with pre_http_request — no test
+ * touches the network. The stub writes a real 1x1 PNG to the stream
+ * filename download_url() passes, which is exactly what a successful
+ * sideload consumes.
+ *
+ * @package PKIW
+ */
+
+declare(strict_types=1);
+
+use PKIW\Featured_Artwork;
+
+/**
+ * @group integration
+ */
+final class FeaturedArtworkTest extends WP_UnitTestCase {
+
+	private const COVER   = 'https://coverartarchive.org/release/abc/front-500.png';
+	private const COVER_2 = 'https://coverartarchive.org/release/def/front-500.png';
+
+	/**
+	 * Number of HTTP requests the stub intercepted.
+	 *
+	 * @var int
+	 */
+	private int $http_requests = 0;
+
+	/**
+	 * Whether the stub should answer 200-with-PNG (true) or 404 (false).
+	 *
+	 * @var bool
+	 */
+	private bool $http_ok = true;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->http_requests = 0;
+		$this->http_ok       = true;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) {
+				++$this->http_requests;
+
+				if ( ! $this->http_ok ) {
+					return [
+						'response' => [
+							'code'    => 404,
+							'message' => 'Not Found',
+						],
+						'headers'  => [],
+						'body'     => '',
+						'cookies'  => [],
+					];
+				}
+
+				// 1x1 transparent PNG.
+				$png = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==' );
+
+				if ( ! empty( $parsed_args['filename'] ) ) {
+					file_put_contents( $parsed_args['filename'], $png ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test stub writing the streamed download.
+				}
+
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'headers'  => [ 'content-type' => 'image/png' ],
+					'body'     => $png,
+					'cookies'  => [],
+				];
+			},
+			10,
+			3
+		);
+	}
+
+	private function make_listen_post( array $attrs, array $post_args = [] ): int {
+		$json = wp_json_encode( $attrs );
+		return self::factory()->post->create(
+			array_merge(
+				[
+					'post_content' => '<!-- wp:group {"className":"h-entry","layout":{"type":"constrained"}} --><div class="wp-block-group h-entry"><!-- wp:post-kinds-indieweb/listen-card ' . $json . ' /--></div><!-- /wp:group -->',
+				],
+				$post_args
+			)
+		);
+	}
+
+	public function test_artwork_becomes_featured_image_on_save(): void {
+		$post_id = $this->make_listen_post(
+			[ 'trackTitle' => 'One', 'coverImage' => self::COVER ],
+			[ 'post_title' => 'One' ]
+		);
+
+		$thumbnail_id = get_post_thumbnail_id( $post_id );
+		$this->assertGreaterThan( 0, $thumbnail_id, 'featured image must be set from artwork' );
+		$this->assertSame( 1, $this->http_requests, 'exactly one sideload fetch' );
+		$this->assertSame( self::COVER, get_post_meta( $post_id, Featured_Artwork::SOURCE_META, true ) );
+		$this->assertSame( (string) $thumbnail_id, get_post_meta( $post_id, Featured_Artwork::ATTACHMENT_META, true ) );
+		$this->assertSame(
+			'One',
+			get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true ),
+			'sideloaded artwork gets the post title as alt text'
+		);
+	}
+
+	public function test_existing_featured_image_is_never_replaced(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+
+		// Create with artwork AND a pre-chosen featured image: the save
+		// hook must leave the editorial choice alone.
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+		set_post_thumbnail( $post_id, $attachment_id );
+		$requests_before = $this->http_requests;
+
+		wp_update_post( [ 'ID' => $post_id, 'post_title' => 'touch' ] );
+
+		$this->assertSame( $attachment_id, get_post_thumbnail_id( $post_id ), 'user-chosen featured image must survive' );
+		$this->assertSame( $requests_before, $this->http_requests, 'no fetch when a featured image exists' );
+	}
+
+	public function test_removed_auto_featured_image_stays_removed(): void {
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+		$this->assertGreaterThan( 0, get_post_thumbnail_id( $post_id ) );
+
+		delete_post_thumbnail( $post_id );
+		wp_update_post( [ 'ID' => $post_id, 'post_title' => 'touch' ] );
+
+		$this->assertSame( 0, (int) get_post_thumbnail_id( $post_id ), 'a deliberate removal must not be undone' );
+		$this->assertSame( 1, $this->http_requests, 'the same URL must not be re-fetched' );
+	}
+
+	public function test_changed_artwork_replaces_only_our_own_image(): void {
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+		$first   = get_post_thumbnail_id( $post_id );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:post-kinds-indieweb/listen-card {"trackTitle":"One","coverImage":"' . self::COVER_2 . '"} /-->',
+			]
+		);
+
+		$second = get_post_thumbnail_id( $post_id );
+		$this->assertGreaterThan( 0, $second );
+		$this->assertNotSame( $first, $second, 'new artwork must replace the auto-set image' );
+		$this->assertSame( self::COVER_2, get_post_meta( $post_id, Featured_Artwork::SOURCE_META, true ) );
+	}
+
+	public function test_failed_fetch_records_attempt_and_never_retries(): void {
+		$this->http_ok = false;
+		$post_id       = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+
+		$this->assertSame( 0, (int) get_post_thumbnail_id( $post_id ) );
+		$this->assertSame( self::COVER, get_post_meta( $post_id, Featured_Artwork::SOURCE_META, true ) );
+		$this->assertSame( '', get_post_meta( $post_id, Featured_Artwork::ATTACHMENT_META, true ) );
+		$fetches = $this->http_requests;
+
+		wp_update_post( [ 'ID' => $post_id, 'post_title' => 'touch' ] );
+		$this->assertSame( $fetches, $this->http_requests, 'a failed URL must not be re-fetched on the next save' );
+	}
+
+	public function test_local_attachment_url_is_reused_without_fetch(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$local_url     = wp_get_attachment_url( $attachment_id );
+
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => $local_url ] );
+
+		$this->assertSame( $attachment_id, get_post_thumbnail_id( $post_id ), 'existing local attachment must be reused' );
+		$this->assertSame( 0, $this->http_requests, 'no sideload for a URL that is already in the media library' );
+	}
+
+	public function test_post_without_artwork_is_untouched(): void {
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'American Obituary', 'artistName' => 'U2' ] );
+
+		$this->assertSame( 0, (int) get_post_thumbnail_id( $post_id ) );
+		$this->assertSame( 0, $this->http_requests );
+		$this->assertSame( '', get_post_meta( $post_id, Featured_Artwork::SOURCE_META, true ) );
+	}
+
+	public function test_filter_disables_the_behavior(): void {
+		add_filter( 'pkiw_set_featured_from_artwork', '__return_false' );
+
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+
+		$this->assertSame( 0, (int) get_post_thumbnail_id( $post_id ) );
+		$this->assertSame( 0, $this->http_requests );
+	}
+
+	public function test_backfill_sets_missing_featured_images(): void {
+		// A post that predates the feature: artwork attr present, no
+		// featured image, no attempt marker.
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+		delete_post_thumbnail( $post_id );
+		delete_post_meta( $post_id, Featured_Artwork::SOURCE_META );
+		delete_post_meta( $post_id, Featured_Artwork::ATTACHMENT_META );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+
+		$dry = ( new Featured_Artwork() )->backfill( true );
+		$this->assertSame( 1, $dry['updated'], 'dry run must count the candidate' );
+		$this->assertSame( 0, (int) get_post_thumbnail_id( $post_id ), 'dry run must not write' );
+
+		$stats = ( new Featured_Artwork() )->backfill( false );
+		$this->assertSame( 1, $stats['updated'] );
+		$this->assertGreaterThan( 0, get_post_thumbnail_id( $post_id ), 'backfill must set the featured image' );
+	}
+}

--- a/tests/phpunit/integration/YoastSeoIntegrationTest.php
+++ b/tests/phpunit/integration/YoastSeoIntegrationTest.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Yoast SEO schema integration coverage.
+ *
+ * The full Yoast pipeline (graph generation, context, output) was
+ * verified manually against Yoast SEO 28.2 in wp-env; these tests
+ * cover the plugin's own halves at the PHP layer: representative-image
+ * resolution (meta first, block-attr fallback, URL validation) and
+ * graph wiring against a Yoast-28.2-shaped synthetic graph. Yoast is
+ * intentionally absent here — the suite also proves the integration
+ * is inert without it.
+ *
+ * @package PKIW
+ */
+
+declare(strict_types=1);
+
+use PKIW\Integrations\Yoast_SEO;
+
+/**
+ * @group integration
+ */
+final class YoastSeoIntegrationTest extends WP_UnitTestCase {
+
+	private const COVER = 'https://coverartarchive.org/release/abc/front-500.jpg';
+
+	/**
+	 * Build a published post whose content is a listen card nested in
+	 * the h-entry group — the exact shape the Micropub bridge writes.
+	 */
+	private function make_listen_post( array $attrs, array $post_args = [] ): int {
+		$json = wp_json_encode( $attrs );
+		return self::factory()->post->create(
+			array_merge(
+				[
+					'post_content' => '<!-- wp:group {"className":"h-entry","layout":{"type":"constrained"}} --><div class="wp-block-group h-entry"><!-- wp:post-kinds-indieweb/listen-card ' . $json . ' /--></div><!-- /wp:group -->',
+				],
+				$post_args
+			)
+		);
+	}
+
+	/**
+	 * A minimal Yoast-28.2-shaped graph for a singular post.
+	 */
+	private function make_graph( string $permalink ): array {
+		return [
+			[
+				'@type'     => 'Article',
+				'@id'       => $permalink . '#article',
+				'headline'  => 'Test',
+				'wordCount' => 2,
+			],
+			[
+				'@type' => 'WebPage',
+				'@id'   => $permalink,
+				'url'   => $permalink,
+			],
+		];
+	}
+
+	private function make_context( string $permalink, ?string $main_image_url = null ): object {
+		return (object) [
+			'canonical'      => $permalink,
+			'main_image_url' => $main_image_url,
+		];
+	}
+
+	// --- Inertness without Yoast (matrix case 8) ---------------------------
+
+	public function test_register_is_inert_without_yoast(): void {
+		( new Yoast_SEO() )->register();
+		$this->assertFalse(
+			defined( 'WPSEO_VERSION' ),
+			'precondition: Yoast must not be loaded in the test suite'
+		);
+		$this->assertFalse(
+			has_filter( 'wpseo_schema_graph' ),
+			'register() must not hook anything when Yoast is absent'
+		);
+	}
+
+	// --- Representative-image resolution -----------------------------------
+
+	public function test_listen_cover_resolves_from_normalized_meta(): void {
+		// Meta only, no block content: proves the meta path stands alone.
+		$post_id = self::factory()->post->create( [ 'post_content' => 'plain text' ] );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+		update_post_meta( $post_id, '_pkiw_listen_cover', self::COVER );
+
+		$this->assertSame( self::COVER, Yoast_SEO::get_representative_image_url( $post_id ) );
+	}
+
+	public function test_block_attr_fallback_covers_posts_saved_before_sync(): void {
+		// Matrix case 11: existing posts predate the Card_Meta_Sync map
+		// extension, so they have the attr but no meta.
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+		delete_post_meta( $post_id, '_pkiw_listen_cover' ); // Simulate the pre-change save.
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+
+		$this->assertSame( self::COVER, Yoast_SEO::get_representative_image_url( $post_id ) );
+	}
+
+	public function test_listen_without_artwork_resolves_null(): void {
+		// Matrix case 5 — the American Obituary shape.
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'American Obituary', 'artistName' => 'U2' ] );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+
+		$this->assertNull( Yoast_SEO::get_representative_image_url( $post_id ) );
+	}
+
+	public function test_ordinary_post_resolves_null(): void {
+		// Matrix case 2: no kind media, no card — nothing to expose.
+		$post_id = self::factory()->post->create( [ 'post_content' => 'Just words.' ] );
+
+		$this->assertNull( Yoast_SEO::get_representative_image_url( $post_id ) );
+	}
+
+	public function test_watch_poster_resolves_from_meta(): void {
+		// Matrix case 6: another media kind.
+		$post_id = self::factory()->post->create( [
+			'post_content' => '<!-- wp:post-kinds-indieweb/watch-card {"mediaTitle":"Dune","posterImage":"https://image.tmdb.org/t/p/w500/dune.jpg"} /-->',
+		] );
+		wp_set_object_terms( $post_id, 'watch', 'kind' );
+
+		$this->assertSame(
+			'https://image.tmdb.org/t/p/w500/dune.jpg',
+			Yoast_SEO::get_representative_image_url( $post_id ),
+			'watch poster must resolve (via the meta Card_Meta_Sync mirrored on create)'
+		);
+	}
+
+	/**
+	 * Matrix case 10: invalid, unsafe, relative, or non-http(s) image
+	 * metadata must yield a truthful omission, never a broken node.
+	 *
+	 * @dataProvider bad_url_provider
+	 */
+	public function test_unusable_image_urls_are_omitted( string $bad_url ): void {
+		$post_id = self::factory()->post->create( [ 'post_content' => 'x' ] );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+		// Bypass registered-meta sanitization on purpose — simulates
+		// hostile or corrupted stored data reaching the resolver.
+		update_metadata( 'post', $post_id, '_pkiw_listen_cover', $bad_url );
+
+		$this->assertNull( Yoast_SEO::get_representative_image_url( $post_id ) );
+	}
+
+	public function bad_url_provider(): array {
+		return [
+			'javascript scheme' => [ 'javascript:alert(1)' ],
+			'data uri'          => [ 'data:image/png;base64,iVBORw0KGgo=' ],
+			'relative path'     => [ '/wp-content/uploads/cover.jpg' ],
+			'not a url'         => [ 'american obituary' ],
+			'ftp scheme'        => [ 'ftp://example.com/cover.jpg' ],
+			'scheme only'       => [ 'https://' ],
+		];
+	}
+
+	public function test_plain_http_url_is_accepted(): void {
+		// http(s) both pass: a non-TLS self-hosted image is still a real,
+		// fetchable image — only unsafe/malformed values are omitted.
+		$post_id = self::factory()->post->create( [ 'post_content' => 'x' ] );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+		update_metadata( 'post', $post_id, '_pkiw_listen_cover', 'http://example.com/cover.jpg' );
+
+		$this->assertSame( 'http://example.com/cover.jpg', Yoast_SEO::get_representative_image_url( $post_id ) );
+	}
+
+	// --- Graph wiring -------------------------------------------------------
+
+	public function test_graph_gains_native_shaped_image_when_yoast_found_none(): void {
+		// Matrix case 4, wiring half.
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+		$permalink = get_permalink( $post_id );
+		$this->go_to( $permalink );
+
+		$graph = ( new Yoast_SEO() )->filter_schema_graph(
+			$this->make_graph( $permalink ),
+			$this->make_context( $permalink )
+		);
+
+		$image_id = $permalink . '#primaryimage';
+		$this->assertSame( [ '@id' => $image_id ], $graph[0]['image'], 'Article.image must reference #primaryimage' );
+		$this->assertSame( self::COVER, $graph[0]['thumbnailUrl'] );
+		$this->assertSame( [ '@id' => $image_id ], $graph[1]['primaryImageOfPage'], 'WebPage.primaryImageOfPage must reference #primaryimage' );
+		$this->assertCount( 3, $graph, 'exactly one ImageObject node must be appended' );
+		$this->assertSame( 'ImageObject', $graph[2]['@type'] );
+		$this->assertSame( $image_id, $graph[2]['@id'] );
+		$this->assertSame( self::COVER, $graph[2]['url'] );
+		$this->assertSame( self::COVER, $graph[2]['contentUrl'] );
+		$this->assertSame( 2, $graph[0]['wordCount'], 'wordCount must never be touched' );
+	}
+
+	public function test_graph_untouched_when_yoast_already_has_an_image(): void {
+		// Matrix cases 1 and 3: featured image (or content image) present
+		// means Yoast resolved main_image_url — the filter must not compete.
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+		$permalink = get_permalink( $post_id );
+		$this->go_to( $permalink );
+
+		$graph  = $this->make_graph( $permalink );
+		$result = ( new Yoast_SEO() )->filter_schema_graph(
+			$graph,
+			$this->make_context( $permalink, 'https://example.com/featured.jpg' )
+		);
+
+		$this->assertSame( $graph, $result );
+	}
+
+	public function test_graph_untouched_outside_singular_post_views(): void {
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'One', 'coverImage' => self::COVER ] );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+		$permalink = get_permalink( $post_id );
+		$this->go_to( home_url( '/' ) );
+
+		$graph  = $this->make_graph( $permalink );
+		$result = ( new Yoast_SEO() )->filter_schema_graph( $graph, $this->make_context( $permalink ) );
+
+		$this->assertSame( $graph, $result );
+	}
+
+	public function test_draft_post_gets_no_wiring(): void {
+		// Matrix case 9: a draft's permalink doesn't resolve to a singular
+		// public view, so the anonymous request path never wires an image.
+		$post_id = $this->make_listen_post(
+			[ 'trackTitle' => 'One', 'coverImage' => self::COVER ],
+			[ 'post_status' => 'draft' ]
+		);
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+		$permalink = get_permalink( $post_id );
+		$this->go_to( $permalink );
+
+		$graph  = $this->make_graph( $permalink );
+		$result = ( new Yoast_SEO() )->filter_schema_graph( $graph, $this->make_context( $permalink ) );
+
+		$this->assertSame( $graph, $result );
+	}
+
+	public function test_graph_untouched_when_kind_has_no_image(): void {
+		// Matrix case 5, wiring half: no artwork → no node, no refs.
+		$post_id = $this->make_listen_post( [ 'trackTitle' => 'American Obituary', 'artistName' => 'U2' ] );
+		wp_set_object_terms( $post_id, 'listen', 'kind' );
+		$permalink = get_permalink( $post_id );
+		$this->go_to( $permalink );
+
+		$graph  = $this->make_graph( $permalink );
+		$result = ( new Yoast_SEO() )->filter_schema_graph( $graph, $this->make_context( $permalink ) );
+
+		$this->assertSame( $graph, $result );
+	}
+
+	// --- Micropub / editor consistency (matrix case 7) ----------------------
+
+	public function test_micropub_and_editor_posts_resolve_identically(): void {
+		// Micropub path: real builder output from a real property bag.
+		$micropub_content = \PKIW\Micropub_Content_Builder::fill_empty_content(
+			'',
+			[
+				'properties' => [
+					'listen-of' => [ 'https://musicbrainz.org/recording/one' ],
+					'name'      => [ 'One' ],
+					'author'    => [ 'U2' ],
+					'photo'     => [ self::COVER ],
+				],
+			]
+		);
+		$micropub_id = self::factory()->post->create( [ 'post_content' => $micropub_content ] );
+		wp_set_object_terms( $micropub_id, 'listen', 'kind' );
+
+		// Editor path: the same normalized data as card attributes.
+		$editor_id = $this->make_listen_post( [
+			'listenUrl'  => 'https://musicbrainz.org/recording/one',
+			'trackTitle' => 'One',
+			'artistName' => 'U2',
+			'coverImage' => self::COVER,
+		] );
+		wp_set_object_terms( $editor_id, 'listen', 'kind' );
+
+		// Both origins must normalize the same core meta…
+		$this->assertSame( 'One', get_post_meta( $micropub_id, '_pkiw_listen_track', true ) );
+		$this->assertSame(
+			get_post_meta( $editor_id, '_pkiw_listen_track', true ),
+			get_post_meta( $micropub_id, '_pkiw_listen_track', true )
+		);
+		$this->assertSame(
+			get_post_meta( $editor_id, '_pkiw_listen_artist', true ),
+			get_post_meta( $micropub_id, '_pkiw_listen_artist', true )
+		);
+
+		// …and the same representative-image outcome. The Micropub builder
+		// intentionally renders `photo` as a visible image block (which
+		// Yoast's own first-content-image scan resolves), while editor
+		// artwork rides the card attr — so the *schema image* both posts
+		// end up with is the same URL, arriving via the two documented
+		// lanes.
+		$this->assertSame( self::COVER, Yoast_SEO::get_representative_image_url( $editor_id ) );
+	}
+}

--- a/tests/phpunit/integration/YoastSeoIntegrationTest.php
+++ b/tests/phpunit/integration/YoastSeoIntegrationTest.php
@@ -16,6 +16,7 @@
 declare(strict_types=1);
 
 use PKIW\Integrations\Yoast_SEO;
+use PKIW\Kind_Artwork;
 
 /**
  * @group integration
@@ -88,7 +89,7 @@ final class YoastSeoIntegrationTest extends WP_UnitTestCase {
 		wp_set_object_terms( $post_id, 'listen', 'kind' );
 		update_post_meta( $post_id, '_pkiw_listen_cover', self::COVER );
 
-		$this->assertSame( self::COVER, Yoast_SEO::get_representative_image_url( $post_id ) );
+		$this->assertSame( self::COVER, Kind_Artwork::get_representative_image_url( $post_id ) );
 	}
 
 	public function test_block_attr_fallback_covers_posts_saved_before_sync(): void {
@@ -98,7 +99,7 @@ final class YoastSeoIntegrationTest extends WP_UnitTestCase {
 		delete_post_meta( $post_id, '_pkiw_listen_cover' ); // Simulate the pre-change save.
 		wp_set_object_terms( $post_id, 'listen', 'kind' );
 
-		$this->assertSame( self::COVER, Yoast_SEO::get_representative_image_url( $post_id ) );
+		$this->assertSame( self::COVER, Kind_Artwork::get_representative_image_url( $post_id ) );
 	}
 
 	public function test_listen_without_artwork_resolves_null(): void {
@@ -106,14 +107,14 @@ final class YoastSeoIntegrationTest extends WP_UnitTestCase {
 		$post_id = $this->make_listen_post( [ 'trackTitle' => 'American Obituary', 'artistName' => 'U2' ] );
 		wp_set_object_terms( $post_id, 'listen', 'kind' );
 
-		$this->assertNull( Yoast_SEO::get_representative_image_url( $post_id ) );
+		$this->assertNull( Kind_Artwork::get_representative_image_url( $post_id ) );
 	}
 
 	public function test_ordinary_post_resolves_null(): void {
 		// Matrix case 2: no kind media, no card — nothing to expose.
 		$post_id = self::factory()->post->create( [ 'post_content' => 'Just words.' ] );
 
-		$this->assertNull( Yoast_SEO::get_representative_image_url( $post_id ) );
+		$this->assertNull( Kind_Artwork::get_representative_image_url( $post_id ) );
 	}
 
 	public function test_watch_poster_resolves_from_meta(): void {
@@ -125,7 +126,7 @@ final class YoastSeoIntegrationTest extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'https://image.tmdb.org/t/p/w500/dune.jpg',
-			Yoast_SEO::get_representative_image_url( $post_id ),
+			Kind_Artwork::get_representative_image_url( $post_id ),
 			'watch poster must resolve (via the meta Card_Meta_Sync mirrored on create)'
 		);
 	}
@@ -143,7 +144,7 @@ final class YoastSeoIntegrationTest extends WP_UnitTestCase {
 		// hostile or corrupted stored data reaching the resolver.
 		update_metadata( 'post', $post_id, '_pkiw_listen_cover', $bad_url );
 
-		$this->assertNull( Yoast_SEO::get_representative_image_url( $post_id ) );
+		$this->assertNull( Kind_Artwork::get_representative_image_url( $post_id ) );
 	}
 
 	public function bad_url_provider(): array {
@@ -164,7 +165,7 @@ final class YoastSeoIntegrationTest extends WP_UnitTestCase {
 		wp_set_object_terms( $post_id, 'listen', 'kind' );
 		update_metadata( 'post', $post_id, '_pkiw_listen_cover', 'http://example.com/cover.jpg' );
 
-		$this->assertSame( 'http://example.com/cover.jpg', Yoast_SEO::get_representative_image_url( $post_id ) );
+		$this->assertSame( 'http://example.com/cover.jpg', Kind_Artwork::get_representative_image_url( $post_id ) );
 	}
 
 	// --- Graph wiring -------------------------------------------------------
@@ -296,6 +297,6 @@ final class YoastSeoIntegrationTest extends WP_UnitTestCase {
 		// artwork rides the card attr — so the *schema image* both posts
 		// end up with is the same URL, arriving via the two documented
 		// lanes.
-		$this->assertSame( self::COVER, Yoast_SEO::get_representative_image_url( $editor_id ) );
+		$this->assertSame( self::COVER, Kind_Artwork::get_representative_image_url( $editor_id ) );
 	}
 }

--- a/tests/phpunit/unit/TaxonomyTest.php
+++ b/tests/phpunit/unit/TaxonomyTest.php
@@ -203,6 +203,24 @@ class TaxonomyTest extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_first_block_kind_descends_into_wrapper_blocks() {
+		// The Micropub bridge wraps its card in an h-entry core/group —
+		// the card is still the first thing a person sees.
+		$this->assertSame(
+			'listen',
+			Taxonomy::get_first_block_kind(
+				'<!-- wp:group {"className":"h-entry"} --><div class="wp-block-group h-entry"><!-- wp:post-kinds-indieweb/listen-card {"trackTitle":"One"} /--></div><!-- /wp:group -->'
+			)
+		);
+		// A wrapper whose first visible child is not a card behaves like
+		// a paragraph-first post.
+		$this->assertNull(
+			Taxonomy::get_first_block_kind(
+				'<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph --><!-- wp:post-kinds-indieweb/eat-card /--></div><!-- /wp:group -->'
+			)
+		);
+	}
+
 	public function test_save_assigns_kind_from_first_card_block() {
 		$this->ensure_kind_terms( 'eat' );
 


### PR DESCRIPTION
## Summary

Kind micro-posts (a listen post is two words and a card) had no featured image and their artwork lives in dynamic-block attributes, so it was invisible twice over: Yoast's schema graph shipped Article with no `image` (flagged by site audits), and nothing showed where featured images live — archive grids, related-post cards, feeds.

Two commits:

**`20711c1` — schema.** New `Integrations\Yoast_SEO` on Yoast's documented `wpseo_schema_graph` filter. Fills the primary image only when Yoast itself found none (featured image and first-content-image always win), resolves from normalized `_pkiw_*` meta with a block-attribute fallback for posts saved before the sync covered their kind, validates to absolute http(s) URLs, and wires the node in Yoast's native shape (`#primaryimage`, `Article.image`/`thumbnailUrl`, `WebPage.primaryImageOfPage`). Hooks nothing when Yoast is inactive. `wordCount` stays truthful — a two-word post reports 2.

**`5dcca99` — featured images.** New `Featured_Artwork` (save_post:35) sideloads artwork once per URL (reuses local attachments with no fetch, post title as alt when empty) and sets it as the featured image. Ownership markers keep editorial choice in charge: a user-picked image is never replaced, removing the auto-set image sticks, a failed fetch isn't retried until the URL changes, and `pkiw_set_featured_from_artwork` disables the whole behavior. `wp postkind featured-artwork backfill [--dry-run]` covers existing posts. Shared resolution lives in `Kind_Artwork`, so schema and featured image can't disagree.

Two real bugs fixed en route, both caused by top-level-only block walks that never saw the h-entry `core/group` the Micropub bridge wraps around every card: `Card_Meta_Sync` wrote no `_pkiw_*` meta at all for Micropub posts, and `Taxonomy::get_first_block_kind()` left them with no kind term. Both now descend into `innerBlocks`; paragraph-first posts still get no auto-kind. The sync map also grew listen/watch/jam/play entries (previously read/checkin only).

## Reviewer notes

- Verified end-to-end in wp-env (WP 7.0, Yoast 28.2) with posts created through the real Micropub endpoint, and against an 11-case behavior matrix (featured-image precedence, invalid/unsafe URLs, drafts, Yoast absent, pre-existing posts). Also already deployed to courtneyr.dev staging and live and verified there (Yoast Premium/News stack, `@type: ["Article","BlogPosting"]`).
- `FeaturedArtworkTest` stubs `pre_http_request` — no network in CI.
- Existing posts gain both behaviors without migration (block-attr fallback); re-saving or the backfill command additionally normalizes meta.
- Yoast is not a dependency; without it the integration registers nothing.

## Documentation checklist

- [x] User-facing behavior changes are documented in `docs/src/content/docs/` — new [Schema and featured images] page; getting-started/common-tasks/works-together updated for the 33-kind roster (`34314cf`)
- [x] Settings and labels in the docs match the current UI (no UI changes)
- [x] Screenshots remain current (no UI changes)
- [x] Accessibility implications were reviewed (sideloaded artwork gets alt text; no UI changes)
- [x] `README.md` remains accurate
- [ ] `readme.txt` remains accurate — **changelog entry for the next release still to be written** (CHANGELOG.md is updated; readme.txt is maintained by hand at release time)
- [x] Links and metadata were validated (`docs npm run build` + `check:links` — only expected pre-merge canonical 404 and a transient microformats.org 502)
- [ ] Release notes describe the user impact — deferred to release prep
