### PR TITLE
📖 DOC: correct mf2 permalink claims, block count, and gate WP 7.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
       fail-fast: false
       matrix:
         php: ["8.2", "8.3", "8.4"]
-        wp: ["7.0"]
+        # 7.0 is the declared minimum and 7.1 the declared "Tested up to".
+        # Gate both so neither header claim goes unverified.
+        wp: ["7.0", "7.1"]
         include:
           - php: "8.4"
             wp: "trunk"

--- a/docs/src/content/docs/common-tasks.md
+++ b/docs/src/content/docs/common-tasks.md
@@ -93,7 +93,25 @@ POSSE = Publish on your Own Site, Syndicate Elsewhere. Nothing is sent until you
 
 1. Publish a kind post.
 2. Visit [pin13.net/mf2](https://pin13.net/mf2/) and enter the post URL.
-3. The parser shows the detected microformats (for example `h-entry` with `u-listen-of`, or `p-rsvp` for RSVPs).
+3. The parser shows the detected microformats. What you want is the kind's property
+   (`u-listen-of`, `u-like-of`, `u-in-reply-to`, `p-rsvp`, and so on) nested **inside** the
+   post's `h-entry` — not sitting beside it.
+
+### If the property parses outside the `h-entry`
+
+Some block themes render the single-post template without passing the post wrapper through
+`post_class()`. That filter is where this plugin adds the `h-entry` root, so when a theme
+skips it the card parses as a standalone top-level `h-cite` and the property never attaches
+to the entry. Twenty Twenty-Five behaves this way.
+
+To tell the two apart, parse the post's archive URL as well (`/kind/listen/`, for example).
+If the property attaches there but not at the permalink, the theme's single template is the
+cause, not the plugin's markup.
+
+This is worth fixing in your theme, because webmention receivers and feed readers fetch the
+**permalink**. In a block theme, make sure the single template's post wrapper renders through
+`post_class()` — a Post Template block does; a plain Group wrapping Post Title and Post
+Content does not.
 
 ## Clear cached API data
 

--- a/docs/src/content/docs/faq.md
+++ b/docs/src/content/docs/faq.md
@@ -11,7 +11,7 @@ A label describing what a post *is* — a note, a listen, a check-in, a book you
 
 ## How many blocks does the plugin include?
 
-26: 23 blocks registered from the editor source (18 kind cards plus Star Rating, Media Lookup, Check-in Dashboard, Check-ins Feed, and Venue Detail) and 3 server-rendered blocks (Now Playing, Media Stats, Recent Kinds). Older plugin copy said "16 custom blocks" — that figure was outdated.
+27: 23 blocks registered from the editor source (18 kind cards plus Star Rating, Media Lookup, Check-in Dashboard, Check-ins Feed, and Venue Detail), 3 server-rendered blocks (Now Playing, Media Stats, Recent Kinds), and Stream Card, which is registered in PHP and hidden from the inserter — it replaces Post Content inside the Stream query loop, so you never place it by hand. Older plugin copy said "16 custom blocks" — that figure was outdated.
 
 ## Do all 36 kinds have their own block?
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -29,7 +29,7 @@ Eighteen kinds have a matching **card block** (Listen Card, Watch Card, Read Car
 **Expected results at each stage:**
 
 - After inserting the card, the editor sidebar's **Post Kind** panel shows a notice that the kind was auto-detected from the block. On save, the post's kind is set to **listen** automatically — you don't have to pick it by hand. If you do pick a kind manually, your choice is never overridden.
-- After publishing, the post appears at `/kind/listen/` and its HTML carries microformats2 markup (an `h-entry` with `u-listen-of`), which IndieWeb readers and parsers can understand.
+- After publishing, the post appears at `/kind/listen/` and its HTML carries microformats2 markup (`u-listen-of` on an `h-cite`), which IndieWeb readers and parsers can understand. On the archive that property attaches to the post's `h-entry`; at the permalink it depends on whether your theme's single template runs `post_class()`. See [Confirm your microformats are valid](/post-kinds-for-indieweb/common-tasks/#confirm-your-microformats-are-valid).
 
 The same flow works for movies (Watch Card), books (Read Card), places (Checkin Card), games (Play Card), and the rest.
 


### PR DESCRIPTION
Tested the plugin against WordPress 7.1 GA the day after release: runtime sweep with a calibrated debug.log detector, mf2 parses of really-rendered pages, and full PHPUnit in wp-env (integration 181 tests / 482 assertions, unit 1159 / 3042, all green). Three documentation claims didn't survive contact with the running site.

**Permalink microformats claim was wrong on TT5.** getting-started and common-tasks promised "an h-entry with u-listen-of" at the post URL. On Twenty Twenty-Five singles the property actually parses on an orphan top-level h-cite — our h-entry root rides the `post_class` filter (class-microformats.php:357), and TT5's single template never calls it. Archives attach correctly, which is the diagnostic the docs now teach: parse the archive and the permalink, and if they disagree it's the theme's single template. Both pages now describe real behavior and how to fix a theme. (Fixing the *plugin* side is a separate issue — this PR only stops the docs from overpromising.)

**faq.md counted 26 blocks; the registry has 27.** The uncounted one is stream-card, registered in PHP with no block.json and hidden from the inserter. Verified by enumerating `WP_Block_Type_Registry` at runtime — 24 under `post-kinds-indieweb/` plus 3 under `post-kinds/`.

**CI never tested what the header claims.** The plugin says "Tested up to: 7.1" but the matrix only ran WP 7.0 (plus a PHP 8.4 trunk cell). The matrix now gates 7.0 and 7.1 both; the codecov upload condition still matches exactly one cell.

Docs build is clean after the edits: markdownlint 0 errors, 104 internal links 0 broken, 15 pages built.