### PR TITLE
👌 IMPROVE: register stream-card with apiVersion 3

### DIFF
--- a/includes/functions-stream-card.php
+++ b/includes/functions-stream-card.php
@@ -397,6 +397,9 @@ function register_stream_card_block(): void {
 	register_block_type(
 		'post-kinds-indieweb/stream-card',
 		[
+			// No block.json for this block, so declare the API version here —
+			// register_block_type() otherwise defaults it to 1.
+			'api_version'     => 3,
 			'render_callback' => __NAMESPACE__ . '\\render_stream_card',
 			'uses_context'    => [ 'postId', 'postType' ],
 			'supports'        => [ 'inserter' => false ],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -319,6 +319,12 @@ parameters:
 			path: includes/class-webhook-handler.php
 
 		-
+			message: '#^Parameter \#2 \$args of function register_block_type expects array\{api_version\?\: string, title\?\: string, category\?\: string\|null, parent\?\: array\<string\>\|null, ancestor\?\: array\<string\>\|null, allowed_blocks\?\: array\<string\>\|null, icon\?\: string\|null, description\?\: string, \.\.\.\}, array\{api_version\: 3, render_callback\: ''PKIW\\\\render_stream…'', uses_context\: array\{''postId'', ''postType''\}, supports\: array\{inserter\: false\}\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/functions-stream-card.php
+
+		-
 			message: '#^Call to function method_exists\(\) with ''WPRM_Recipe_Manager'' and ''get_recipe'' will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1

--- a/tests/phpunit/integration/BlockApiVersionTest.php
+++ b/tests/phpunit/integration/BlockApiVersionTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Block API version coverage for every registered plugin block.
+ *
+ * @package PKIW
+ */
+
+declare(strict_types=1);
+
+/**
+ * Asserts every plugin block registers with apiVersion 3.
+ *
+ * The block.json files all declare apiVersion 3, but blocks registered in
+ * PHP with a settings array (stream-card) silently default to 1 when the
+ * key is omitted — a drift no file-based check can see. This enumerates
+ * the live registry across both plugin namespaces so the next omission
+ * fails here instead of shipping.
+ *
+ * @group integration
+ */
+final class BlockApiVersionTest extends WP_UnitTestCase {
+
+	/**
+	 * Every registered plugin block carries API version 3.
+	 */
+	public function test_all_plugin_blocks_register_api_version_3(): void {
+		$registered = WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+		$plugin_blocks = array_filter(
+			$registered,
+			static function ( string $name ): bool {
+				return str_starts_with( $name, 'post-kinds-indieweb/' )
+					|| str_starts_with( $name, 'post-kinds/' );
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+
+		// Guard the guard: an empty list would vacuously pass.
+		$this->assertGreaterThanOrEqual(
+			24,
+			count( $plugin_blocks ),
+			'Expected the full plugin block roster to be registered.'
+		);
+
+		$stragglers = [];
+		foreach ( $plugin_blocks as $name => $block_type ) {
+			if ( 3 !== (int) $block_type->api_version ) {
+				$stragglers[] = $name . ' (v' . $block_type->api_version . ')';
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$stragglers,
+			'Blocks registered without apiVersion 3: ' . implode( ', ', $stragglers )
+		);
+	}
+}


### PR DESCRIPTION
Fixes #144.

One-line fix plus the regression test that would have caught it: stream-card was the only plugin block registered without `api_version`, silently defaulting to 1 while every block.json declares 3. `BlockApiVersionTest` now enumerates the live registry across both namespaces (`post-kinds-indieweb/`, `post-kinds/`) and fails on any straggler — verified failing-first against the unfixed code, green after. StreamCardTest (20 tests) unaffected, `composer analyze` and PHPCS clean; the one new baseline entry is the same wordpress-stubs `api_version?: string` false positive already baselined for the three `post-kinds/*` blocks.