### PR TITLE
🐛 FIX: wrap singular kind content in an h-entry when the theme supplies none

### DIFF
--- a/includes/class-microformats.php
+++ b/includes/class-microformats.php
@@ -35,6 +35,16 @@ class Microformats {
 	private array $kind_formats = [];
 
 	/**
+	 * Post IDs whose wrapper already went through the post_class filter
+	 * during this request. A theme wrapper renders before its inner
+	 * content, so by the time the_content runs for a post, its presence
+	 * here means the theme supplied the h-entry root itself.
+	 *
+	 * @var array<int, true>
+	 */
+	private array $post_class_seen = [];
+
+	/**
 	 * IndieBlocks block names to skip (they already have mf2).
 	 *
 	 * @var array<string>
@@ -361,6 +371,9 @@ class Microformats {
 
 		// Add hidden mf2 data elements.
 		add_filter( 'the_content', [ $this, 'add_hidden_mf2_data' ], 99 );
+
+		// After the hidden data (99) so it lands inside the wrapper.
+		add_filter( 'the_content', [ $this, 'wrap_singular_content' ], 100 );
 	}
 
 	/**
@@ -372,6 +385,8 @@ class Microformats {
 	 * @return array<string> Modified classes.
 	 */
 	public function add_post_classes( array $classes, array $class, int $post_id ): array {
+		$this->post_class_seen[ $post_id ] = true;
+
 		$kind = $this->get_post_kind( $post_id );
 
 		if ( ! $kind || ! isset( $this->kind_formats[ $kind ] ) ) {
@@ -541,6 +556,79 @@ class Microformats {
 			},
 			$html,
 			1
+		);
+	}
+
+	/**
+	 * Wrap singular content in an h-entry when the theme supplied none.
+	 *
+	 * The kind properties ride markup inside the content (the card's
+	 * h-cite, the hidden mf2 data), and they only reach a consuming
+	 * parser if an h-entry root wraps them. That root normally comes
+	 * from the post_class filter — but a block theme whose single
+	 * template wraps the post in a plain Group (Twenty Twenty-Five,
+	 * Twenty Twenty-Four) never calls post_class(), the card parses as
+	 * a top-level orphan h-cite, and a webmention receiver fetching the
+	 * permalink cannot tell what kind of post it is. See GH issue 142.
+	 *
+	 * Wraps only the queried post on singular requests, only for posts
+	 * with a kind, and only when post_class() has not already run for
+	 * that post this request.
+	 *
+	 * @param string $content Post content.
+	 * @return string Content, wrapped when the theme supplied no h-entry.
+	 */
+	public function wrap_singular_content( string $content ): string {
+		$post_id = get_the_ID();
+
+		if ( ! $post_id || ! is_singular() || get_queried_object_id() !== $post_id ) {
+			return $content;
+		}
+
+		// The theme already produced an h-entry wrapper via post_class().
+		if ( isset( $this->post_class_seen[ $post_id ] ) ) {
+			return $content;
+		}
+
+		// the_content can be applied more than once per request.
+		if ( str_contains( $content, 'pkiw-singular-entry' ) ) {
+			return $content;
+		}
+
+		$kind = $this->get_post_kind( $post_id );
+
+		if ( ! $kind || ! isset( $this->kind_formats[ $kind ] ) ) {
+			return $content;
+		}
+
+		$root_classes = $this->kind_formats[ $kind ]['root'] ?? [ 'h-entry' ];
+		$classes      = array_merge( $root_classes, [ 'kind-' . $kind, 'pkiw-singular-entry' ] );
+
+		// Entry-level essentials so the h-entry stands alone for parsers.
+		$entry_meta = sprintf(
+			'<a class="u-url" href="%s" hidden></a><time class="dt-published" datetime="%s" hidden></time>',
+			esc_url( get_permalink( $post_id ) ),
+			esc_attr( (string) get_the_date( 'c', $post_id ) )
+		);
+
+		// Only name the entry where the kind's vocabulary has a name —
+		// notes and responses are intentionally title-less in mf2.
+		$properties = $this->kind_formats[ $kind ]['properties'] ?? [];
+		if ( in_array( 'p-name', $properties, true ) ) {
+			$title = get_the_title( $post_id );
+			if ( '' !== $title ) {
+				$entry_meta .= sprintf(
+					'<span class="p-name" hidden>%s</span>',
+					esc_html( $title )
+				);
+			}
+		}
+
+		return sprintf(
+			'<div class="%s">%s%s</div>',
+			esc_attr( implode( ' ', $classes ) ),
+			$content,
+			$entry_meta
 		);
 	}
 

--- a/tests/phpunit/integration/SingularEntryWrapperTest.php
+++ b/tests/phpunit/integration/SingularEntryWrapperTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Entry-attachment coverage for singular permalinks.
+ *
+ * @package PKIW
+ */
+
+declare(strict_types=1);
+
+/**
+ * Verifies a kind post's canonical property attaches to an h-entry at the
+ * permalink — the URL webmention receivers actually fetch.
+ *
+ * MicroformatsRenderTest wraps do_blocks() output in an h-entry it injects
+ * itself, so it can only prove property/root co-location on the card. These
+ * tests render the real block template for a singular request (Twenty
+ * Twenty-Five's single template does not call post_class(), so no theme
+ * wrapper exists) and parse what a consumer would see.
+ *
+ * @group integration
+ */
+final class SingularEntryWrapperTest extends WP_UnitTestCase {
+
+	/**
+	 * Create a published like post carrying only a like card.
+	 */
+	private function make_like_post(): int {
+		$post_id = self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_title'   => 'Entry wrapper probe',
+				'post_content' => '<!-- wp:post-kinds-indieweb/like-card {"title":"Target","url":"https://example.com/target"} /-->',
+			]
+		);
+
+		$term_result = wp_set_object_terms( $post_id, 'like', 'kind' );
+		$this->assertNotWPError( $term_result );
+
+		return $post_id;
+	}
+
+	/**
+	 * Recursively search parsed mf2 items for an h-entry carrying a property.
+	 *
+	 * @param array<int, array<string, mixed>> $items    Parsed mf2 items.
+	 * @param string                           $property Canonical property name.
+	 * @return array<string, mixed>|null The matching h-entry, or null.
+	 */
+	private function find_entry_with_property( array $items, string $property ): ?array {
+		foreach ( $items as $item ) {
+			$types = $item['type'] ?? [];
+			if ( in_array( 'h-entry', $types, true ) && isset( $item['properties'][ $property ] ) ) {
+				return $item;
+			}
+			if ( ! empty( $item['children'] ) ) {
+				$found = $this->find_entry_with_property( $item['children'], $property );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Render the current request's block template exactly as template-canvas does.
+	 */
+	private function render_block_template(): string {
+		$template = resolve_block_template(
+			'single',
+			[ 'single-post.php', 'single.php', 'singular.php', 'index.php' ],
+			''
+		);
+		$this->assertNotNull( $template, 'No block template resolved for the singular request.' );
+
+		global $_wp_current_template_id, $_wp_current_template_content;
+		$_wp_current_template_id      = $template->id;
+		$_wp_current_template_content = $template->content;
+
+		return get_the_block_template_html();
+	}
+
+	/**
+	 * The full Twenty Twenty-Five single template attaches like-of to an h-entry.
+	 */
+	public function test_singular_template_attaches_property_to_h_entry(): void {
+		switch_theme( 'twentytwentyfive' );
+		$post_id = $this->make_like_post();
+
+		$this->go_to( get_permalink( $post_id ) );
+		$this->assertTrue( is_singular(), 'Request did not resolve as singular.' );
+
+		$html  = $this->render_block_template();
+		$entry = $this->find_entry_with_property( \Mf2\parse( $html )['items'] ?? [], 'like-of' );
+
+		$this->assertNotNull(
+			$entry,
+			'like-of did not attach to any h-entry in the rendered singular template.'
+		);
+		$this->assertPropertyContainsTarget(
+			$entry['properties']['like-of'],
+			'https://example.com/target'
+		);
+	}
+
+	/**
+	 * The content filter alone produces a complete h-entry when no theme wrapper exists.
+	 */
+	public function test_content_filter_wraps_orphan_singular_content(): void {
+		$post_id = $this->make_like_post();
+
+		$this->go_to( get_permalink( $post_id ) );
+		$this->assertTrue( is_singular() );
+
+		$content = apply_filters( 'the_content', get_post_field( 'post_content', $post_id ) );
+		$parsed  = \Mf2\parse( $content, get_permalink( $post_id ) );
+		$entry   = $this->find_entry_with_property( $parsed['items'] ?? [], 'like-of' );
+
+		$this->assertNotNull( $entry, 'Filtered content did not carry an h-entry with like-of.' );
+		$this->assertContains(
+			get_permalink( $post_id ),
+			$entry['properties']['url'] ?? [],
+			'The injected h-entry does not declare the permalink as u-url.'
+		);
+	}
+
+	/**
+	 * A theme that wraps the post via post_class() must not get a second h-entry.
+	 */
+	public function test_no_double_wrap_when_theme_applies_post_class(): void {
+		$post_id = $this->make_like_post();
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		// A post_class()-based wrapper renders before its inner content, so the
+		// filter fires first — exactly what core/post-template does per item.
+		get_post_class( '', $post_id );
+
+		$content = apply_filters( 'the_content', get_post_field( 'post_content', $post_id ) );
+
+		$this->assertStringNotContainsString(
+			'pkiw-singular-entry',
+			$content,
+			'Content was wrapped even though the theme already applied post_class().'
+		);
+	}
+
+	/**
+	 * Posts without a kind keep their content untouched.
+	 */
+	public function test_kindless_post_content_is_untouched(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>Plain post.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+		$content = apply_filters( 'the_content', get_post_field( 'post_content', $post_id ) );
+
+		$this->assertStringNotContainsString( 'pkiw-singular-entry', $content );
+	}
+
+	/**
+	 * Non-singular contexts are never wrapped.
+	 */
+	public function test_archive_context_is_never_wrapped(): void {
+		$post_id = $this->make_like_post();
+
+		$this->go_to( home_url( '/' ) );
+		$this->assertFalse( is_singular() );
+
+		$content = apply_filters( 'the_content', get_post_field( 'post_content', $post_id ) );
+
+		$this->assertStringNotContainsString( 'pkiw-singular-entry', $content );
+	}
+
+	/**
+	 * Assert a parsed property contains a target URL, as a plain value or
+	 * inside an embedded microformat (a u- property on an h-cite parses to
+	 * an embedded object whose url property carries the target).
+	 *
+	 * @param array<int, mixed> $values     Parsed property values.
+	 * @param string            $target_url Expected URL.
+	 */
+	private function assertPropertyContainsTarget( array $values, string $target_url ): void {
+		foreach ( $values as $value ) {
+			if ( $target_url === $value ) {
+				$this->addToAssertionCount( 1 );
+				return;
+			}
+
+			if ( ! is_array( $value ) ) {
+				continue;
+			}
+
+			if ( $target_url === ( $value['value'] ?? null ) ) {
+				$this->addToAssertionCount( 1 );
+				return;
+			}
+
+			foreach ( $value['properties']['url'] ?? [] as $url ) {
+				if ( $target_url === $url ) {
+					$this->addToAssertionCount( 1 );
+					return;
+				}
+			}
+		}
+
+		$this->fail( 'No parsed value carries ' . $target_url );
+	}
+}


### PR DESCRIPTION
Fixes #142. Fixes #143.

## The bug

At a kind post's permalink — the URL webmention receivers fetch — the card's canonical property (`u-like-of`, `u-listen-of`, …) parsed as a top-level orphan `h-cite` with no parent `h-entry`. The plugin's `h-entry` root came exclusively from the `post_class` filter, and TT5's / TT4's single templates never call `post_class()`. On TT4 the property attached nowhere on the entire site (archives render excerpts without the card).

## The fix

`wrap_singular_content()` on `the_content` at priority 100 (after the hidden mf2 data at 99, so it lands inside the wrapper). It wraps only when all of these hold:

- singular request, and the filtered post is the queried post
- the post has a kind with a defined format
- `post_class()` has **not** fired for this post this request — a theme wrapper renders before its inner content, so if the filter ran, the theme brought its own `h-entry` and wrapping again would double-root
- the content isn't already wrapped (the_content can be applied more than once)

The wrapper carries the kind's root classes plus hidden `u-url` and `dt-published`, and `p-name` only for kinds whose format maps a name — notes and responses stay intentionally title-less in mf2.

## Why the old test never caught it (#143)

`MicroformatsRenderTest` wraps `do_blocks()` output in an `h-entry` it injects itself, asserting markup the singular template doesn't supply. The new `SingularEntryWrapperTest` renders the **real** TT5 single template (`resolve_block_template()` + `get_the_block_template_html()`, entering the main loop exactly as template-canvas does) and parses what a consumer sees. It failed before the fix with the same signature as the live site; the old test stays for fast property/root co-location checks.

## Verification

- New test failing-first, then 5/5 green
- Full suites on WP 7.1: integration 186/497, unit 1159/3042
- Live HTTP parse on TT5 permalinks (like/listen/reply/read): all attach with target URL and `u-url`; archive control still attaches; TT4 permalink now attaches too
- PHPCS 0 errors on changed files, `composer analyze` clean

Docs note: #141's common-tasks section documents the pre-fix behavior and stays accurate for released versions; once this ships in a release I'll trim that section to a short "older versions" note.