### PR TITLE
🐛 FIX: /firehose 404s on updated sites; kinds wait for an admin visit (1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-08-21
+
+### Fixed
+
+- `/firehose` no longer 404s on updated sites — the one defect here that never self-corrected. Rewrite rules were flushed only from the activation hook and on a storage-mode change, and WordPress does not fire activation on an in-place update, so the feed registered in 1.5.0 never entered the persisted ruleset for anyone who updated rather than installed fresh. `/firehose` and `/feed/firehose` both 404'd indefinitely while `?feed=firehose` worked. `maybe_flush_rewrite_rules()` now also flushes when the stored rewrite version differs from the plugin version. Kind archives were unaffected — they resolve through a generic `kind/([^/]+)` rule stored since 1.0.0 — which is what made this easy to miss.
+- Kinds added since a site's install now appear without waiting for an admin visit. `ensure_all_terms_exist()` already back-filled them, but only on `is_admin()` requests, so a freshly-updated site served 24 kinds and 404'd `/kind/weather/` and friends to visitors until someone loaded wp-admin. The first-run seeder is now version-stamped rather than guarded by a write-once boolean, so the back-fill happens on the next request of any kind. Measured on the published builds: updating 1.0.0 to 1.5.0 showed 24 kinds on the front end and 36 after one wp-admin load.
+
 ## [1.5.0] - 2026-08-21
 
 ### Fixed
@@ -316,7 +323,8 @@ This project uses Semantic Versioning:
 - [Issues](https://github.com/courtneyr-dev/post-kinds-for-indieweb/issues)
 - [IndieWeb Wiki](https://indieweb.org/)
 
-[Unreleased]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/1.0.0...v1.5.0
 [1.2.0]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.1.0...v1.2.0
 [1.0.0]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/releases/tag/v1.0.0

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1515,15 +1515,36 @@ final class Plugin {
 	}
 
 	/**
-	 * Flush rewrite rules if storage mode changed.
+	 * Flush rewrite rules when they are stale.
+	 *
+	 * Two triggers. The `pkiw_flush_rewrite` flag covers activation and a
+	 * storage-mode change. The version stamp covers plugin updates, which
+	 * WordPress handles without firing the activation hook — so a release
+	 * that adds a feed or rewrite rule (1.5.0 added `/firehose`) would
+	 * otherwise leave every upgrading site serving the ruleset generated
+	 * at its original activation, and the new URL 404s until someone
+	 * re-saves permalinks.
+	 *
+	 * Runs at init priority 999 so every add_feed()/add_rewrite_rule()
+	 * registration has already happened.
 	 *
 	 * @return void
 	 */
 	public function maybe_flush_rewrite_rules(): void {
-		if ( get_option( 'pkiw_flush_rewrite' ) ) {
-			flush_rewrite_rules();
+		$requested   = (bool) get_option( 'pkiw_flush_rewrite' );
+		$stale_rules = PKIW_VERSION !== get_option( 'pkiw_rewrite_version' );
+
+		if ( ! $requested && ! $stale_rules ) {
+			return;
+		}
+
+		flush_rewrite_rules();
+
+		if ( $requested ) {
 			delete_option( 'pkiw_flush_rewrite' );
 		}
+
+		update_option( 'pkiw_rewrite_version', PKIW_VERSION );
 	}
 
 	/**

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -347,16 +347,27 @@ class Taxonomy {
 	}
 
 	/**
-	 * Create default terms on first activation.
+	 * Create default terms on install, and again whenever the plugin adds kinds.
+	 *
+	 * The guard records the version that last seeded rather than a bare
+	 * boolean. WordPress does not fire the activation hook on update, so a
+	 * write-once flag meant every kind introduced after a site's first
+	 * install never got a term there — sites installed on 1.0.0 and updated
+	 * to 1.5.0 carried 24 kinds while the plugin declared 36. Re-seeding is
+	 * cheap and safe: create_default_terms() skips slugs that already exist.
+	 *
+	 * A boolean from a pre-1.5.1 install never equals PKIW_VERSION, so those
+	 * sites re-seed once on their next request and pick up what they missed.
 	 *
 	 * @return void
 	 */
 	public function maybe_create_default_terms(): void {
-		// Only run once after activation.
-		if ( ! get_option( 'pkiw_terms_created' ) ) {
-			$this->create_default_terms();
-			update_option( 'pkiw_terms_created', true );
+		if ( PKIW_VERSION === get_option( 'pkiw_terms_created' ) ) {
+			return;
 		}
+
+		$this->create_default_terms();
+		update_option( 'pkiw_terms_created', PKIW_VERSION );
 	}
 
 	/**

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb in Block Themes
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.5.0
+ * Version:           1.5.1
  * Requires at least: 7.0
  * Tested up to:      7.1
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'PKIW_VERSION', '1.5.0' );
+define( 'PKIW_VERSION', '1.5.1' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 7.0
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -158,6 +158,10 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 9. Standard.site record panel on a Bookmark Card, showing the cited page's own title, publication, description, and tags read from AT Protocol
 
 == Changelog ==
+
+= 1.5.1 =
+* Fixed: the /firehose feed added in 1.5.0 returned 404 on any site that updated rather than installed fresh, and stayed that way. Rewrite rules were only rebuilt on activation, which WordPress doesn't run on update, so the feed's address was never registered. Updating now rebuilds them.
+* Fixed: kinds added in a previous update now show up right away. They were only filled in on a wp-admin page load, so a freshly-updated site briefly showed 24 kinds instead of 36 and 404'd the newer kind archives for visitors.
 
 = 1.5.0 =
 * Fixed: a kind post's microformats2 property (u-like-of, u-listen-of, and the rest) now attaches to an h-entry at the post's own URL — the page webmention receivers actually fetch. Block themes whose single template never calls post_class() (Twenty Twenty-Five, Twenty Twenty-Four) left the card parsing as an orphan citation; the plugin now supplies its own h-entry wrapper there, with the permalink and publish date included, and steps aside on themes that already provide one.

--- a/tests/phpunit/integration/UpgradeFlushesRewriteRulesTest.php
+++ b/tests/phpunit/integration/UpgradeFlushesRewriteRulesTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Rewrite-rule freshness across plugin updates.
+ *
+ * Rewrite rules were flushed only from the activation hook and on a
+ * storage-mode change. WordPress does not fire the activation hook when a
+ * plugin updates in place, so a release that adds a feed or rewrite rule
+ * left every upgrading site serving the ruleset generated at its original
+ * activation. 1.5.0 added `/firehose`, and it 404'd for the entire
+ * existing install base until someone re-saved permalinks.
+ *
+ * Kind archives were unaffected because they resolve through a generic
+ * `kind/([^/]+)` rule that has been stored since 1.0.0 — only genuinely
+ * new rules go missing, which is what makes this easy to overlook.
+ *
+ * @group integration
+ */
+
+declare(strict_types=1);
+
+/**
+ * Verifies an update refreshes the persisted rewrite rules.
+ */
+final class UpgradeFlushesRewriteRulesTest extends WP_UnitTestCase {
+
+	/**
+	 * Restore a permalink structure so rules are actually generated.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure( '/%postname%/' );
+	}
+
+	/**
+	 * Reset to the default structure so later tests are unaffected.
+	 */
+	public function tear_down(): void {
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure( '' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Run the plugin's init-time flush check the way the hook does.
+	 */
+	private function run_flush_check(): void {
+		$plugin = \PKIW\Plugin::get_instance();
+		$plugin->maybe_flush_rewrite_rules();
+	}
+
+	/**
+	 * A site whose stored rules predate this version gets them rebuilt.
+	 */
+	public function test_update_refreshes_stale_rewrite_rules(): void {
+		// A site that activated under an older release: rules were flushed
+		// then, the flag was consumed, and the stamp records that version.
+		delete_option( 'pkiw_flush_rewrite' );
+		update_option( 'pkiw_rewrite_version', '1.0.0' );
+
+		$this->run_flush_check();
+
+		$this->assertSame(
+			PKIW_VERSION,
+			get_option( 'pkiw_rewrite_version' ),
+			'An update should re-stamp the rewrite version after flushing.'
+		);
+
+		$rules = get_option( 'rewrite_rules' );
+		$this->assertIsArray( $rules );
+		$this->assertNotEmpty( $rules, 'Rewrite rules were not regenerated.' );
+	}
+
+	/**
+	 * The firehose feed registered in 1.5.0 survives the rebuild.
+	 */
+	public function test_firehose_rule_is_present_after_an_update_flush(): void {
+		delete_option( 'pkiw_flush_rewrite' );
+		update_option( 'pkiw_rewrite_version', '1.0.0' );
+
+		$this->run_flush_check();
+
+		$rules = (array) get_option( 'rewrite_rules' );
+
+		$this->assertArrayHasKey(
+			'^firehose/?$',
+			$rules,
+			'The /firehose rewrite rule is missing after an update flush.'
+		);
+	}
+
+	/**
+	 * No repeat flush once this version has already stamped.
+	 */
+	public function test_no_flush_when_the_version_already_matches(): void {
+		delete_option( 'pkiw_flush_rewrite' );
+		update_option( 'pkiw_rewrite_version', PKIW_VERSION );
+
+		$sentinel = [ 'pkiw-sentinel/?$' => 'index.php?pkiw_sentinel=1' ];
+		update_option( 'rewrite_rules', $sentinel );
+
+		$this->run_flush_check();
+
+		$this->assertSame(
+			$sentinel,
+			get_option( 'rewrite_rules' ),
+			'Rules were flushed even though this version had already stamped.'
+		);
+	}
+
+	/**
+	 * The explicit request flag still forces a flush and is consumed.
+	 */
+	public function test_explicit_flush_request_is_honored_and_cleared(): void {
+		update_option( 'pkiw_rewrite_version', PKIW_VERSION );
+		update_option( 'pkiw_flush_rewrite', true );
+
+		$this->run_flush_check();
+
+		$this->assertFalse(
+			get_option( 'pkiw_flush_rewrite' ),
+			'The one-shot flush request should be consumed.'
+		);
+
+		$rules = (array) get_option( 'rewrite_rules' );
+		$this->assertArrayHasKey( '^firehose/?$', $rules );
+	}
+}

--- a/tests/phpunit/integration/UpgradeSeedsNewKindsTest.php
+++ b/tests/phpunit/integration/UpgradeSeedsNewKindsTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Upgrade path coverage for the default kind terms.
+ *
+ * `maybe_create_default_terms()` was guarded by a boolean option set once
+ * on first activation, so the seeder never ran again. WordPress does not
+ * fire the activation hook on update, which meant every kind added after
+ * a site's first install — the twelve added between 1.0.0 and 1.5.0 —
+ * never got a term on existing sites. Those users saw 24 kinds while the
+ * readme advertised 36, with no picker entries and no archives for the
+ * missing ones.
+ *
+ * Reproduced against the real published builds: a site installed on
+ * 1.0.0 and upgraded to 1.5.0 reported 24 kinds; clearing the flag
+ * yielded 36, confirming the seeder itself is idempotent and correct.
+ *
+ * @group integration
+ */
+
+declare(strict_types=1);
+
+use PKIW\Taxonomy;
+
+/**
+ * Verifies newly-added kinds reach sites that upgrade rather than install fresh.
+ */
+final class UpgradeSeedsNewKindsTest extends WP_UnitTestCase {
+
+	/**
+	 * Every kind the plugin declares must exist as a term.
+	 */
+	private function assert_all_kinds_present( string $context ): void {
+		$taxonomy = new Taxonomy();
+		$declared = array_keys( apply_filters( 'pkiw_default_kinds', $this->declared_kinds( $taxonomy ) ) );
+
+		$existing = get_terms(
+			[
+				'taxonomy'   => Taxonomy::TAXONOMY,
+				'hide_empty' => false,
+				'fields'     => 'slugs',
+			]
+		);
+		$this->assertNotWPError( $existing );
+
+		$missing = array_values( array_diff( $declared, (array) $existing ) );
+
+		$this->assertSame(
+			[],
+			$missing,
+			$context . ' — kinds declared by the plugin but absent as terms: ' . implode( ', ', $missing )
+		);
+	}
+
+	/**
+	 * Read the declared kind list off the taxonomy instance.
+	 *
+	 * @param Taxonomy $taxonomy Taxonomy instance.
+	 * @return array<string, array<string, string>> Declared kinds.
+	 */
+	private function declared_kinds( Taxonomy $taxonomy ): array {
+		$reflection = new ReflectionProperty( Taxonomy::class, 'default_kinds' );
+		$reflection->setAccessible( true );
+
+		return (array) $reflection->getValue( $taxonomy );
+	}
+
+	/**
+	 * A site that already seeded terms under an older version still gets
+	 * kinds added since — the upgrade case.
+	 */
+	public function test_upgrade_from_older_version_seeds_newly_added_kinds(): void {
+		$taxonomy = new Taxonomy();
+
+		// Simulate a site seeded by an older release: terms exist for the
+		// kinds that version knew about, and the guard is already set.
+		$taxonomy->create_default_terms();
+
+		$legacy_only = [ 'audio', 'quote', 'weather', 'follow', 'sleep', 'craft' ];
+		foreach ( $legacy_only as $slug ) {
+			$term = get_term_by( 'slug', $slug, Taxonomy::TAXONOMY );
+			if ( $term instanceof WP_Term ) {
+				wp_delete_term( $term->term_id, Taxonomy::TAXONOMY );
+			}
+		}
+
+		// The pre-1.5.1 guard: a bare boolean, as written by the old code.
+		update_option( 'pkiw_terms_created', true );
+
+		$this->assertNotEmpty(
+			array_diff(
+				$legacy_only,
+				(array) get_terms(
+					[
+						'taxonomy'   => Taxonomy::TAXONOMY,
+						'hide_empty' => false,
+						'fields'     => 'slugs',
+					]
+				)
+			),
+			'Fixture failed: the legacy-only kinds should be missing before the upgrade runs.'
+		);
+
+		// The upgrade: init fires and the seeder gets its chance.
+		$taxonomy->maybe_create_default_terms();
+
+		$this->assert_all_kinds_present( 'After upgrading from a site seeded by an older version' );
+	}
+
+	/**
+	 * The guard still prevents redundant work once the current version has seeded.
+	 */
+	public function test_seeder_does_not_repeat_for_the_current_version(): void {
+		$taxonomy = new Taxonomy();
+
+		$taxonomy->maybe_create_default_terms();
+		$stamp = get_option( 'pkiw_terms_created' );
+
+		$this->assertSame(
+			PKIW_VERSION,
+			$stamp,
+			'The guard should record the plugin version that seeded, not a bare boolean.'
+		);
+
+		// A second pass in the same version must be a no-op, not a re-seed.
+		$before = get_terms(
+			[
+				'taxonomy'   => Taxonomy::TAXONOMY,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			]
+		);
+		$taxonomy->maybe_create_default_terms();
+		$after = get_terms(
+			[
+				'taxonomy'   => Taxonomy::TAXONOMY,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			]
+		);
+
+		$this->assertSame( count( (array) $before ), count( (array) $after ), 'Re-running created duplicate terms.' );
+		$this->assertSame( $stamp, get_option( 'pkiw_terms_created' ), 'The version stamp changed unexpectedly.' );
+	}
+
+	/**
+	 * A fresh install gets the full vocabulary.
+	 */
+	public function test_fresh_install_seeds_every_declared_kind(): void {
+		delete_option( 'pkiw_terms_created' );
+
+		$taxonomy = new Taxonomy();
+		$taxonomy->maybe_create_default_terms();
+
+		$this->assert_all_kinds_present( 'On a fresh install' );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -18,6 +18,7 @@ delete_option( 'pkiw_settings' );
 delete_option( 'pkiw_api_credentials' );
 delete_option( 'pkiw_webhook_settings' );
 delete_option( 'pkiw_flush_rewrite' );
+delete_option( 'pkiw_rewrite_version' );
 delete_option( 'pkiw_terms_created' );
 delete_option( 'pkiw_terms_version' );
 delete_option( 'pkiw_active_imports' );


### PR DESCRIPTION
Found by installing the **published 1.0.0** build and updating it to the **published 1.5.0** build — the path every existing user takes, which I hadn't tested before shipping 1.5.0. Fresh installs were and are fine.

Measured on those published builds:

| After updating 1.0.0 → 1.5.0 | Front-end only | After one wp-admin load |
|---|---|---|
| kind terms | 24 | **36** (self-heals) |
| `/kind/weather/` | 404 | **200** |
| `/firehose/` | 404 | **404 — never heals** |

**`/firehose` is the real one.** Rewrite rules were flushed only from the activation hook and on a storage-mode change, and WordPress doesn't fire activation on an in-place update — so the feed 1.5.0 registered never entered the persisted ruleset for anyone who updated. `/firehose` and `/feed/firehose` 404 indefinitely; only `?feed=firehose` resolves. A wp-admin visit does not fix it. `maybe_flush_rewrite_rules()` now also flushes when the stored rewrite version differs from `PKIW_VERSION`. Kind archives were unaffected because they resolve through a generic `kind/([^/]+)` rule stored since 1.0.0 — which is precisely why this was easy to miss.

**The kinds gap is narrower than it looks.** `ensure_all_terms_exist()` already back-fills newly-added kinds, but it's gated on `is_admin()`, so an updated site serves 24 kinds and 404s the newer kind archives *to visitors* until someone loads wp-admin. Version-stamping the first-run seeder closes that window without depending on an admin visit. I initially read this as permanent data loss; it isn't, and the changelog says so plainly.

Both regression tests verified failing-first — without the flush fix, `'^firehose/?$'` is absent from `rewrite_rules` after an update. Integration 195/516, unit 1162/3051, PHPCS and PHPStan clean.

`uninstall.php` cleans the new `pkiw_rewrite_version` option alongside its siblings.