### PR TITLE
🚀 RELEASE: prepare 1.5.2 — editor crash fixes, save guards, slim download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-08-21
+
 ### Fixed
 
 - Saving can no longer be blocked by an unparseable date. The same unguarded `toISOString()` fixed in the editor renders survived in three live save serializers (wish, favorite, acquisition), the play-card front-end save, four deprecated saves, and the check-in card editor — a throw during save serialization blocks the whole post from saving, which is worse than a crashed preview. Every date site in the plugin now goes through `parseDate()`. No block deprecations needed: with a valid date the output is byte-identical, and an invalid date could never have produced saved markup because the old serializer threw.
@@ -339,7 +341,8 @@ This project uses Semantic Versioning:
 - [Issues](https://github.com/courtneyr-dev/post-kinds-for-indieweb/issues)
 - [IndieWeb Wiki](https://indieweb.org/)
 
-[Unreleased]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.2...HEAD
+[1.5.2]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/1.0.0...v1.5.0
 [1.2.0]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.1.0...v1.2.0

--- a/docs/src/site-meta.mjs
+++ b/docs/src/site-meta.mjs
@@ -9,7 +9,7 @@ export default {
 		'User documentation for Post Kinds for IndieWeb in Block Themes: log what you listen to, watch, read, play, and visit on your own WordPress site.',
 	github: 'https://github.com/courtneyr-dev/post-kinds-for-indieweb',
 	wporg: 'https://wordpress.org/plugins/post-kinds-for-indieweb-in-block-themes/',
-	version: '1.5.0',
+	version: '1.5.2',
 	requiresWP: '7.0',
 	requiresPHP: '8.2',
 	author: 'Courtney Robertson',

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb in Block Themes
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.5.1
+ * Version:           1.5.2
  * Requires at least: 7.0
  * Tested up to:      7.1
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'PKIW_VERSION', '1.5.1' );
+define( 'PKIW_VERSION', '1.5.2' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 7.0
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.5.1
+Stable tag: 1.5.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -158,6 +158,14 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 9. Standard.site record panel on a Bookmark Card, showing the cited page's own title, publication, description, and tags read from AT Protocol
 
 == Changelog ==
+
+= 1.5.2 =
+* Fixed: the Check-in Dashboard block crashed in the editor for everyone who inserted it, with any settings. It read its data feed in the wrong shape.
+* Fixed: the Play Card crashed in the editor whenever its status differed from the default — pasted, imported, or pattern-inserted cards hit this every time.
+* Fixed: Event and RSVP cards crashed in the editor on a date they couldn't parse, and a similar problem in several cards' saving code could block a post from saving at all. Every date now degrades gracefully instead.
+* Fixed: the Check-in Dashboard's "Check-ins" and "Countries" stats always showed 0 regardless of your data.
+* Fixed: the cover image's remove control was a button nested inside another button in all eleven card blocks — invalid HTML that confuses screen readers, and it was invisible to keyboard users. It's now a proper sibling control that appears on keyboard focus too.
+* Changed: the plugin download shrinks from 4.8M to 0.6M — a folder of marketing imagery that the plugin never loads no longer ships.
 
 = 1.5.1 =
 * Fixed: the /firehose feed added in 1.5.0 returned 404 on any site that updated rather than installed fresh, and stayed that way. Rewrite rules were only rebuilt on activation, which WordPress doesn't run on update, so the feed's address was never registered. Updating now rebuilds them.


### PR DESCRIPTION
Version bump + changelogs for shipping the #149–#155 sweep (PRs #152, #156) to WordPress.org: three editor crashes (Check-in Dashboard crashed for every user on insertion), the `parseDate()` guard across all eleven date sites including save serializers that could block saving, dashboard stats keys, the nested-button fix in all eleven card blocks, and the 4.8M → 0.6M download cut.

SVN trunk + tag follow merge, then verification against the published artifact including 1.0.0→1.5.2 and 1.5.1→1.5.2 upgrade smokes.