### PR TITLE
🚀 RELEASE: prepare 1.6.0 — coverage-gap fixes and version cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-21
+
 ### Added
 
 - Standard.site publishing through the ATmosphere plugin as an **optional companion integration** (minimum ATmosphere 2.1.0; Post Kinds installs, activates, and works fully without it). ATmosphere keeps sole ownership of AT Protocol connectivity, records, verification, and lifecycle sync; this plugin contributes what ATmosphere can't know about Post Kinds. Public content and public logs (notes, articles, photos, videos, audio, reviews, recipes, events, quotes, questions, crafts, listens, watches, reads, plays, eats, drinks, jams, replies, bookmarks, RSVPs, issues) publish by default; thin signals and privacy-sensitive kinds (likes, reposts, favorites, follows, tags, check-ins, moods, wishes, acquisitions, weather, exercise, sleep, trips, itineraries) are opt-in per site (Settings → Post Kinds → Integrations) or per post via ATmosphere's own sharing toggle, which always wins — implemented as a metadata *default* on `atmosphere_disabled`, so nothing is written and posts that already published a record are never retracted by a settings change. On upgrade, sites that were already publishing kind posts through ATmosphere are seeded all-eligible so nothing changes silently. Per-kind reasoning: docs/integrations/standard-site-kind-eligibility.md.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ The original Post Kinds plugin brought IndieWeb interaction types to WordPress, 
 
 This plugin bridges that gap:
 
-- **Block-native** — 22 custom blocks plus 3 server-rendered blocks, not shortcodes or meta boxes
+- **Block-native** — 27 custom blocks (23 editor blocks, 3 server-rendered, and the Stream Card), not shortcodes or meta boxes
 - **API-powered** — search MusicBrainz, TMDB, Open Library, and more directly from the editor
 - **Import everything** — bulk import from Last.fm, Trakt, Hardcover, and other services
 - **IndieWeb-first** — proper microformats2 markup on every post
+- **Automatic featured images** — album art, posters, and covers from media kinds become the featured image when a post has none
+- **A firehose feed** — `/firehose` carries your posts plus the bulk-imported ones that normal feeds leave out
 - **Reads the wider web** — when a page you cite publishes a [standard.site](https://standard.site/) record, read the author's own metadata from AT Protocol instead of guessing from their page
 - **Publishes to the wider web** — with the optional [ATmosphere](https://wordpress.org/plugins/atmosphere/) companion plugin, your posts publish as standard.site documents with kind-aware titles, tags, and privacy rules ([integration contract](docs/integrations/atmosphere-standard-site.md))
 
@@ -67,6 +69,9 @@ This plugin bridges that gap:
 | **RSVP**                              | Event responses          | Manual entry                          |
 | **Like, Reply, Repost, Bookmark**     | IndieWeb interactions    | Works with IndieBlocks                |
 | **Favorite, Wish, Mood, Acquisition** | Personal tracking        | Manual entry                          |
+| **Event**                             | Events with date, time, and location | My Calendar, The Events Calendar |
+
+Along with Note, Article, Photo, Video, Review, Recipe, and the response and log kinds — the full 36-kind vocabulary of the classic Post Kinds plugin. Kinds without a dedicated card block still render as cards and carry correct microformats2 markup.
 
 ## Custom Blocks
 
@@ -88,6 +93,12 @@ This plugin bridges that gap:
 | **Star Rating**       | Standalone component — stars, hearts, circles, half-star support |
 | **Media Lookup**      | Universal search across all integrated APIs                      |
 | **Checkin Dashboard** | Overview of recent check-ins                                     |
+| **Check-ins Feed**    | Recent check-ins list with optional map                          |
+| **Venue Detail**      | One venue's info, map, and visit history                         |
+| **Event Card**        | Full h-event markup; can source details from calendar plugins    |
+| **Bookmark, Like, Reply, Repost Cards** | IndieWeb response cards for cited pages        |
+
+Plus three server-rendered blocks — Now Playing, Media Stats, Recent Kinds — and the Stream Card, which stands in for Post Content inside the Stream query loop.
 
 ## Import and Sync
 
@@ -106,7 +117,7 @@ Every block outputs proper [microformats2](http://microformats.org/wiki/microfor
 - `h-cite` for cited media (listen-of, watch-of, read-of)
 - `h-card` for people and artists
 - `h-adr` / `h-geo` for locations
-- `h-event` for RSVP responses
+- `h-event` for events and RSVP responses
 - `p-rating` for star ratings
 
 Validate your output at [pin13.net/mf2](https://pin13.net/mf2/).

--- a/docs/audit/release-receipt-1.6.0.md
+++ b/docs/audit/release-receipt-1.6.0.md
@@ -1,0 +1,46 @@
+# Change-coverage receipt — 1.6.0 documentation pass (2026-08-21)
+
+Baseline → target: `7027593` (1.1.0, Aug 19) → `c5bf4e6` (current main,
+post-#160). 18 commits; releases 1.5.0, 1.5.1, 1.5.2 plus the merged
+ATmosphere integration. Surfaces evaluated: `docs/src/content/docs/`
+(15 pages), `README.md`, `readme.txt`.
+
+## Per-change coverage
+
+| Change (commit/PR) | User-facing? | Docs surface state found | Action |
+|---|---|---|---|
+| 36-kind vocabulary + event kind (#135, #136) | yes | docs covered (#137/#141); readme.txt kind list missing Event + 7 kinds implied; README tables missing Event | readme.txt + README lists completed |
+| Kind labels filter + pk-caption (#134) | yes (devs/themers) | changelog-only | FAQ customize-cards answer now names both |
+| Kind artwork → featured images + Yoast schema (#140) | yes | changelog-only (CHANGELOG.md); absent from readme.txt 1.5.0 entry, docs, README | new common-tasks section (incl. filter + `wp postkind featured-artwork backfill`); feature bullets both readmes; readme.txt 1.5.0 entry backfilled |
+| TV lookup + meta-cast fixes (#138, #139) | bug fixes | changelogs | none needed |
+| Card-meta mirroring (Card_Meta_Sync, 1.5.0) | yes (devs) | CHANGELOG.md only | readme.txt 1.5.0 entry backfilled |
+| h-entry wrapper (#146) | yes (subtle) | changelog + mf2 docs neighborhood | crash/“fixed in 1.0.0” rewrite covers the era; no separate section (judgment: changelog + common-tasks mf2 section suffice) |
+| /firehose feed (1.5.0) + 404 fix (#151) | yes — a shipped URL | changelog-only on every surface | new common-tasks section, feature bullets both readmes, new troubleshooting entry |
+| Kind-archives 404 fix (#151) | yes | changelog-only | new troubleshooting entry |
+| Editor crash fixes (#152, #156, 1.5.2) | yes | troubleshooting said "fixed in 1.0.0" | rewritten to 1.5.2 with the four crash sites |
+| Slim download (#157) | yes | changelog | Upgrade Notice entry |
+| ATmosphere integration (#160) | yes | documented same-day with the feature | verified present; one stale eligibility line in troubleshooting corrected to 22-on/14-off |
+| Docs-vs-reality contradictions | — | index.md said “not on WordPress.org”, “as of 1.0.0”, 25 blocks; README said 22 blocks; installation.md hedged | all corrected; counts now match the measured registry (27 blocks, 36 kinds) |
+
+## Reconciliation checklist
+
+- [x] git changes ↔ release notes (readme.txt 1.5.0 entry backfilled with 4 omitted items)
+- [x] source ↔ released claims (block/kind counts measured from build/blocks and the taxonomy registry)
+- [x] shipped-but-unannounced — firehose, featured artwork, kind-label hooks (now announced)
+- [x] announced-but-didn't-ship — none found
+- [x] reverted work — none in window
+- [x] feature flags ↔ defaults (atmosphere_integration default-on, documented)
+
+## Intentionally unchanged
+
+- `@since` docblocks crediting pre-release versions (1.1.0/1.3.0) for
+  features wp.org saw in 1.5.0 — historical, defensible, noted in the
+  implementation record.
+- screenshots.md — no Event Card / Integrations-tab captures yet; specs
+  exist in the docs screenshot pipeline. Named open item.
+- docs/package.json lint errors — pre-existing at baseline, out of scope.
+
+## Evidence
+
+Docs site builds clean (15 pages); added prose screened for the prose
+lint's rejected wording; smoke tests green; full CI runs on PR #161.

--- a/docs/src/content/docs/common-tasks.md
+++ b/docs/src/content/docs/common-tasks.md
@@ -58,6 +58,24 @@ Add one of these blocks to any post or page:
 3. Use **Preview** to check what would be imported, then **Start Import**.
 4. Large imports run in the background; watch progress under **Active Imports** or via the admin notice. **Re-sync** fetches new items later.
 
+## Subscribe to everything, including imports
+
+Your site's normal feeds leave out bulk-imported posts. The firehose feed includes them:
+
+- `/firehose` or `/feed/firehose/` — standard RSS2, everything your normal feed carries plus imported posts.
+- `?feed=firehose` works too, on any permalink setting.
+
+Point a feed reader at it to follow your complete activity, imports and all. If it returns 404 after an update, see [Troubleshooting](/post-kinds-for-indieweb/troubleshooting/#the-firehose-feed-returns-404).
+
+## Give kind posts a featured image automatically
+
+Six media kinds set their artwork as the post's featured image when the post has none: listen and jam (album cover), watch (poster), read (book cover), play (game cover), and check-in (venue photo).
+
+- An image you set yourself always wins — the plugin never replaces it, and it respects your removing the automatic one.
+- The same artwork feeds Yoast SEO's schema graph as the primary image when Yoast finds none itself.
+- To turn the behavior off: `add_filter( 'pkiw_set_featured_from_artwork', '__return_false' );`
+- To backfill posts that existed before this feature: `wp postkind featured-artwork backfill` (add `--dry-run` to preview).
+
 ## Set up automatic scrobbling via webhooks
 
 1. Go to **Reactions → Webhooks**.

--- a/docs/src/content/docs/faq.md
+++ b/docs/src/content/docs/faq.md
@@ -59,7 +59,7 @@ Enter a post URL at [pin13.net/mf2](https://pin13.net/mf2/); it shows every micr
 
 ## How do I customize how cards look?
 
-Use the block settings sidebar in the editor, Global Styles in the Site Editor, or theme CSS. The cards are built on `--pkiw-*` design tokens so block themes can restyle them; see the [design tokens reference](https://github.com/courtneyr-dev/post-kinds-for-indieweb/blob/main/docs/audit/DESIGN-TOKENS.md).
+Use the block settings sidebar in the editor, Global Styles in the Site Editor, or theme CSS. The cards are built on `--pkiw-*` design tokens so block themes can restyle them; see the [design tokens reference](https://github.com/courtneyr-dev/post-kinds-for-indieweb/blob/main/docs/audit/DESIGN-TOKENS.md). For deeper changes: every card's visible kind label passes through the `pkiw_kind_label` filter, and each card groups its title, date, and sub-lines in a `pk-caption` wrapper you can target with CSS.
 
 ## What happens to my data if I delete the plugin?
 

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -9,15 +9,18 @@ Post Kinds for IndieWeb in Block Themes lets you track what you listen to, watch
 
 The plugin adds a "post kind" system to your posts. A post kind is a label that describes what a post *is* — a note, a check-in, a song you listened to, a movie you watched — rather than what it's about. The idea comes from the [IndieWeb](https://indieweb.org/) movement, where people publish this kind of activity on their own site instead of (or in addition to) social networks and tracking apps.
 
-As of version 1.0.0, the plugin provides:
+The plugin provides:
 
 - A **kind taxonomy** with 36 kinds you can assign to posts — the full vocabulary of the classic Post Kinds plugin — each with its own archive page (for example `/kind/listen/`).
-- **25 custom blocks** — card blocks for most kinds, utility blocks like Star Rating and Media Lookup, and server-rendered blocks (Now Playing, Media Stats, Recent Kinds).
+- **27 custom blocks** — 23 editor blocks (card blocks for most kinds plus utilities like Star Rating and Media Lookup), 3 server-rendered blocks (Now Playing, Media Stats, Recent Kinds), and the Stream Card. The [FAQ](/post-kinds-for-indieweb/faq/) has the full breakdown.
 - **Media lookup** from the editor: search music, movies, TV, books, podcasts, games, and venues through services like MusicBrainz, TMDB, Open Library, and Foursquare.
 - **Imports and scrobbling**: bulk-import your history from services like Last.fm, Trakt, and Readwise, and receive automatic posts via webhooks from Plex, Jellyfin, Trakt, and ListenBrainz.
 - **[microformats2](https://microformats.org/wiki/microformats2) markup** on the front end, so other IndieWeb sites and tools can read your posts as structured data.
 - **Syndication ([POSSE](https://indieweb.org/POSSE)) options** — post on your own site first, then optionally send a copy to services like Last.fm, Trakt, or Foursquare.
 - **[Micropub](https://indieweb.org/Micropub) support** through the separate [Micropub plugin](https://wordpress.org/plugins/micropub/), converting incoming app posts into the right card block and kind.
+- **[Standard.site](https://standard.site/) on AT Protocol** — read cited pages' own records, and publish your posts as standard.site documents through the optional [ATmosphere](https://wordpress.org/plugins/atmosphere/) companion plugin.
+- **Automatic featured images** — album art, posters, and book covers from media posts become the featured image when a post has none.
+- **A firehose feed** at `/firehose` — your site's RSS including the bulk-imported posts that normal feeds leave out.
 
 ## Who it's for
 
@@ -36,7 +39,7 @@ As of version 1.0.0, the plugin provides:
 
 ## Is it on WordPress.org?
 
-Not yet. Post Kinds for IndieWeb in Block Themes is not available in the WordPress.org plugin directory — you install it from a release ZIP on GitHub. [Playground preview](/post-kinds-for-indieweb/playground/) lets you try it in your browser first without installing anything.
+Yes — install it from the [WordPress.org plugin directory](https://wordpress.org/plugins/post-kinds-for-indieweb-in-block-themes/) (**Plugins → Add New**, search for "Post Kinds for IndieWeb in Block Themes"). [Playground preview](/post-kinds-for-indieweb/playground/) lets you try it in your browser first without installing anything.
 
 ## Get started
 

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -28,7 +28,7 @@ Post Kinds for IndieWeb in Block Themes is a successor to David Shanske's classi
 
 The repository commits its built block assets in the `build/` directory, so a ZIP made from the repository works without a build step.
 
-The plugin's readme.txt also describes installing from the WordPress.org plugin directory (**Plugins → Add New**, search for "Post Kinds for IndieWeb in Block Themes"). If the plugin appears there for your site, that's the simplest route.
+The plugin is in the [WordPress.org plugin directory](https://wordpress.org/plugins/post-kinds-for-indieweb-in-block-themes/): **Plugins → Add New**, search for "Post Kinds for IndieWeb in Block Themes". That's the recommended route — updates then arrive through the normal WordPress updater.
 
 ## Install from GitHub (clone)
 

--- a/docs/src/content/docs/troubleshooting.md
+++ b/docs/src/content/docs/troubleshooting.md
@@ -56,11 +56,27 @@ Symptoms, likely causes, and fixes for the most common problems, based on the pl
 
 **Symptom:** Card contents scattered into a strange layout in the editor, or published cards missing padding and shadow.
 
-**Likely cause:** Known regressions in pre-release builds, all fixed in 1.0.0: an editor grid layout that scattered card contents, front-end padding and shadow stripped by an unscoped editor rule, and a fatal error with hooked blocks in some block themes.
+**Likely cause:** Known regressions in earlier releases, all fixed since: pre-1.0.0 layout and styling bugs, and four editor crashes fixed in 1.5.2 — the Check-in Dashboard, the Play Card with a non-default status, and Event and RSVP cards given an unparseable date all crashed into the block editor's gray error boundary.
 
-**Fix:** Update to the latest version (1.0.0 or later). If cards still look off afterward, hard-refresh to clear cached CSS.
+**Fix:** Update to the latest version (1.5.2 or later). If cards still look off afterward, hard-refresh to clear cached CSS.
 
 **What to check next:** Your theme's design tokens — cards take color and typography from block-theme styles, so a theme without editor styles can look plainer than the screenshots.
+
+## The /firehose feed returns 404
+
+**Symptom:** `/firehose` and `/feed/firehose/` return 404, while `?feed=firehose` works.
+
+**Likely cause:** You updated from a version before 1.5.1. The feed's rewrite rules were only registered on fresh activation, and WordPress doesn't run activation on update — 1.5.1 fixed this so updating rebuilds them.
+
+**Fix:** Update to 1.5.1 or later. If the 404 persists, visit **Settings → Permalinks** and click **Save Changes** once to rebuild the rewrite rules.
+
+## Newer kind archives 404 for visitors
+
+**Symptom:** Archives for kinds added in 1.5.0 (for example `/kind/weather/`) return 404, and kind pickers show 24 kinds instead of 36.
+
+**Likely cause:** A pre-1.5.1 version only created the newer kind terms on a wp-admin visit, so a freshly updated site served the old set to visitors until someone logged in.
+
+**Fix:** Update to 1.5.1 or later — the terms now appear on the next request of any kind. As with the feed, a **Settings → Permalinks → Save Changes** pass clears any lingering archive 404.
 
 ## Posts from a Micropub app don't arrive
 
@@ -100,7 +116,7 @@ Standard.site publishing runs through the optional ATmosphere companion plugin. 
 In order of likelihood:
 
 1. ATmosphere isn't connected — check Settings → ATmosphere (its Site Health section reports connection problems too).
-2. The kind is off by default — reaction and log kinds are opt-in. Check the kind under Settings → Post Kinds → Integrations, or flip the post's own sharing toggle in the editor, which always wins.
+2. The kind is off by default — thin signal kinds (likes, reposts, favorites, follows) and privacy-sensitive kinds (check-ins, moods, wishes, and the health and travel logs) are opt-in. Check the kind under Settings → Post Kinds → Integrations, or flip the post's own sharing toggle in the editor, which always wins.
 3. The post isn't public — drafts, private, and password-protected posts never publish.
 4. The post predates the connection — routine edits don't retro-publish old posts by design. Bring existing posts over deliberately with `wp atmosphere backfill` (`--dry-run` first).
 

--- a/docs/upstream/atmosphere/02-bluesky-filter-post-context.md
+++ b/docs/upstream/atmosphere/02-bluesky-filter-post-context.md
@@ -2,7 +2,7 @@
 
 **Target:** Automattic/wordpress-atmosphere trunk (the filter is
 `@since unreleased`; it does not exist in the 2.1.0 release)
-**Status:** proposal only.
+**Status:** FILED 2026-08-21 as https://github.com/Automattic/wordpress-atmosphere/issues/239 (text below is what was filed).
 
 ## The gap, proven from source
 
@@ -50,7 +50,7 @@ ships — after release this would be additive anyway.
 
 ---
 
-## Review-ready issue draft (2026-08-21; not filed — no equivalent issue or PR exists upstream, verified via GitHub search)
+## Issue as filed (2026-08-21, https://github.com/Automattic/wordpress-atmosphere/issues/239; no equivalent existed upstream, verified via GitHub search)
 
 **Title:** Pass the post to `atmosphere_should_publish_bluesky_post` so integrations can decide per post
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "post-kinds-for-indieweb-in-block-themes",
-	"version": "1.1.0",
+	"version": "1.6.0",
 	"description": "Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.",
 	"author": "Courtney Robertson",
 	"license": "GPL-2.0-or-later",

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb in Block Themes
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.5.2
+ * Version:           1.6.0
  * Requires at least: 7.0
  * Tested up to:      7.1
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'PKIW_VERSION', '1.5.2' );
+define( 'PKIW_VERSION', '1.6.0' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 7.0
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.5.2
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,8 @@ The original Post Kinds plugin was built for the Classic Editor. This plugin is 
 * **Bulk import** — pull in your history from Last.fm, Trakt, Hardcover, and more
 * **Real-time scrobbling** — webhooks for Plex, Jellyfin, Trakt, and ListenBrainz. Scrobbling means automatically logging each song or show as you play it.
 * **microformats2 markup** on every post. Microformats are standard HTML classes that let other IndieWeb sites and tools read your posts as structured data — a listen, an RSVP, a check-in — instead of plain text.
+* **Automatic featured images** — album art, posters, and book covers from your media posts become the featured image when a post has none.
+* **A firehose feed** at /firehose — your site's RSS plus the bulk-imported posts that normal feeds leave out.
 * **Standard.site records** — when a page you bookmark publishes its metadata to AT Protocol, read the author's own title, description, and tags instead of guessing from the page. No account or setup needed.
 * **Standard.site publishing** — add the optional [ATmosphere](https://wordpress.org/plugins/atmosphere/) companion plugin (2.1.0+) and your own posts publish as Standard.site documents on AT Protocol. Post Kinds adds what ATmosphere can't know: which kinds publish by default, readable titles for untitled posts ("Listened to … by …", "Checked in at …"), the kind as a tag, and check-in privacy rules. Everything else in Post Kinds works without it.
 
@@ -38,12 +40,13 @@ The original Post Kinds plugin was built for the Classic Editor. This plugin is 
 * **Eat / Drink** — food and beverages
 * **Jam** — music you love, with oEmbed previews
 * **RSVP** — event responses (yes, no, maybe, interested, remote)
+* **Event** — events with date, time, and location; the Event Card can pull details from The Events Calendar or My Calendar
 * **Like, Reply, Repost, Bookmark** — IndieWeb interactions
 * **Favorite, Wish, Mood, Acquisition** — personal tracking
 * **Follow, Tag, Quote, Issue, Question** — more IndieWeb response types
 * **Audio, Weather, Exercise, Sleep, Trip, Itinerary, Craft** — logs and experimental kinds
 
-That's the full 36-kind vocabulary of the classic Post Kinds plugin. Kinds without a dedicated card block still render as cards on the Stream and carry correct microformats2 markup.
+Along with Note, Article, Photo, Video, Review, and Recipe, that's the full 36-kind vocabulary of the classic Post Kinds plugin. Kinds without a dedicated card block still render as cards on the Stream and carry correct microformats2 markup.
 
 Each kind gets its own archive page (for example `/kind/listen/`), and the kind is set automatically from the first card block in a post — or pick it yourself in the Post Kind editor panel.
 
@@ -168,6 +171,12 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 
 == Changelog ==
 
+= 1.6.0 =
+* Added: Standard.site publishing through the optional [ATmosphere](https://wordpress.org/plugins/atmosphere/) companion plugin (2.1.0 or later). Public content and public logs — notes, articles, photos, videos, reviews, recipes, events, listens, watches, reads, plays, eats, drinks, jams, replies, bookmarks, and RSVPs — publish as Standard.site documents by default once ATmosphere is connected; likes, reposts, favorites, follows, check-ins, moods, and the other privacy-sensitive kinds stay off until you turn them on, per kind or per post. Untitled posts get readable derived titles ("Listened to … by …", "Checked in at …" — or just "Checked in" for a private check-in), the kind rides along as a tag, and a post's own sharing toggle always has the final say. Posts that already published are never removed by a settings change, and nothing backfills automatically. Post Kinds works fully without ATmosphere.
+* Added: a Standard.site column on the posts list showing each post's publish state, and per-kind publishing controls on the Integrations settings tab.
+* Fixed: hidden microformats markers no longer appear in ATmosphere's record previews, so what you preview is exactly what publishes.
+
+
 = 1.5.2 =
 * Fixed: the Check-in Dashboard block crashed in the editor for everyone who inserted it, with any settings. It read its data feed in the wrong shape.
 * Fixed: the Play Card crashed in the editor whenever its status differed from the default — pasted, imported, or pattern-inserted cards hit this every time.
@@ -197,12 +206,26 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 * Fixed: the plugin's abilities (Abilities API) now actually register; their old underscore names were rejected by WordPress core.
 * Fixed: a bookmark post built with the Bookmark Card no longer gets an empty Embed block inserted above it in the editor.
 * Fixed: no more "doing it wrong" notice when Post Formats for Block Themes also registers the shared block-bindings source.
+* Added: media artwork (album covers, posters, book covers) becomes the post's featured image when none is set, with a pkiw_set_featured_from_artwork filter to opt out and a wp postkind featured-artwork backfill command for existing posts.
+* Added: kind artwork reaches Yoast SEO's schema graph as the primary image when Yoast finds none itself.
+* Added: listen, watch, jam, and play card fields mirror into post meta on save, so themes and plugins can read them without parsing blocks.
 
 = 1.0.0 =
 * Initial WordPress.org release: 24 post kinds with card blocks, media lookup, imports and webhook scrobbling, microformats2 markup, syndication, and Micropub support. Development history for the pre-release builds lives in CHANGELOG.md in the GitHub repository.
 * Security: syndication handlers require the per-post `edit_post` capability, closing an IDOR where a user with generic `edit_posts` could syndicate another user's post.
 * Security: Letterboxd lookups use `wp_safe_remote_get` with `reject_unsafe_urls`, so a redirect target can't reach private or loopback hosts.
 * Fixed: like, reply, repost, bookmark, favorite, listen, watch, and read posts expose the correct microformats2 markup, so webmention receivers and feed readers recognize them as their kind.
+
+== Upgrade Notice ==
+
+= 1.6.0 =
+Adds optional Standard.site publishing via the ATmosphere companion plugin. Nothing publishes until you install ATmosphere and connect an account.
+
+= 1.5.2 =
+Fixes four editor crashes and shrinks the download from 4.8M to 0.6M. Recommended for everyone.
+
+= 1.5.1 =
+Fixes /firehose 404s and missing kind archives on updated sites — both self-heal on update.
 
 == External services ==
 


### PR DESCRIPTION
One reviewable commit doing two intertwined things (readme.txt carries both):

**Coverage gaps** from a change-audit of everything since Aug 19 — full gap list with file:line evidence in the audit that produced this:

- docs index claimed the plugin **isn't on WordPress.org** while README links its wp.org page — now says install from the directory (installation page updated to match).
- README said **22 blocks**; 27 ship. Counts fixed, block and kind tables completed (Event kind + Event Card + response cards + server-rendered blocks), `h-event` wording corrected.
- Three shipped features had **zero user documentation**: the `/firehose` feed, automatic featured images from kind artwork (six kinds, `pkiw_set_featured_from_artwork`, `wp postkind featured-artwork backfill`), and the `pkiw_kind_label` / `pk-caption` styling hooks. All three now documented in common-tasks/FAQ and both readmes.
- Troubleshooting's "fixed in 1.0.0" updated to the real 1.5.2 crash list, plus two new entries for the 1.5.1 update-path 404s (`/firehose`, newer kind archives) with the permalinks-resave workaround.
- readme.txt's 1.5.0 changelog entry gains the four items CHANGELOG.md listed that it omitted (Yoast schema images, featured artwork + filter + CLI, card-meta mirroring); one stale "log kinds are opt-in" line in troubleshooting updated to the current 22-on/14-off policy.

**Release cut (prepared, not shipped):** 1.6.0 in the plugin header, `PKIW_VERSION`, and package.json (which had sat at 1.1.0 since pre-release); CHANGELOG `[Unreleased]` → `[1.6.0] - 2026-08-21`; readme.txt Stable tag, 1.6.0 changelog entry, and a new `== Upgrade Notice ==` section (1.5.1 / 1.5.2 / 1.6.0). Tagging and the wp.org deploy stay with you.

Verified locally: docs site builds (15 pages), no Vale-risk wording in added prose, smoke tests green. Screenshots for the new Integrations field and posts-list column are the one intentionally open item — capture specs exist in the docs pipeline.