### PR TITLE
📦 NEW: classify every kind in the Micropub bridge, with a pkiw-kind hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The Micropub bridge now classifies **every registered kind**, not just the original 16. New property inference: `jam-of`, `favorite-of`, `wish-of` (plus `wishlist-of` compat alias), `quotation-of`, `tag-of`, `issue-of` (compat alias), `craft-of`, `acquisition-of`, `exercise`, `sleep`, `trip`, `itinerary`, `question`, `start` (event), `item` (review), `ingredient` (recipe), `video`, and `audio` — video/audio detect ahead of `photo` so a poster image can't demote them, and `start` detects ahead of `location` so events with venues don't read as check-ins.
+- New `pkiw-kind` vendor property (mirrors `pkiw-promote`): a Micropub client that knows its kind names it explicitly, overriding inference. This is the only route to kinds whose property shape is ambiguous — issue (which reuses `in-reply-to`) and content-only quotes. Invalid values fall back to inference.
+- Kinds without a card block now generate a typed one-line paragraph (the follow/weather pattern) carrying the canonical microformats2 class, which also prevents title-less posts of those kinds from dying in `wp_insert_post()` with `empty_content`.
+
 ## [1.6.0] - 2026-08-21
 
 ### Added

--- a/docs/micropub-field-gaps.md
+++ b/docs/micropub-field-gaps.md
@@ -151,6 +151,30 @@ a plain `core/paragraph` carrying a microformats2 class (`u-follow-of`,
 is no card attribute schema to reconcile against, so these kinds are outside
 the scope of the wire-matrix completeness assertion.
 
+## Paragraph-only kinds and the `pkiw-kind` hint
+
+The bridge now classifies every registered kind. Kinds without a card
+builder follow the follow/weather pattern — `paragraph_for_kind()` emits a
+one-line `core/paragraph` carrying the canonical microformats2 class:
+
+- URL-shaped: `jam-of` (`u-jam-of`), `favorite-of` (`u-favorite-of`),
+  `wish-of` (`u-wish-of`; `wishlist-of` accepted as a compat alias),
+  `tag-of` (`u-tag-of`), `issue-of` (`u-in-reply-to` — an issue is a reply
+  to a repository), `craft-of` (`u-craft-of`), `acquisition-of`
+  (`u-acquisition-of`), `video` (`u-video`), `audio` (`u-audio`).
+- Text-shaped: `exercise`, `sleep`, `trip`, `itinerary`, `question`
+  (each `p-<property>`).
+- Detected for kind assignment only (no generated content; these shapes
+  carry a `name` that becomes the post title): `start` → event, `item` →
+  review, `ingredient` → recipe.
+
+Clients can also send an explicit **`pkiw-kind`** vendor property (mirrors
+`pkiw-promote`). A valid kind slug there overrides property inference — the
+only way to reach kinds whose property shape is ambiguous (issue vs. reply,
+quote with content only). Invalid values fall back to inference. Like the
+follow/weather trio, none of these are card blocks, so they're outside the
+wire-matrix completeness assertion.
+
 ## Follow-on work
 
 Every "proposed property" above is a **sender-side** change: Outpost (the

--- a/includes/class-micropub-content-builder.php
+++ b/includes/class-micropub-content-builder.php
@@ -197,17 +197,49 @@ final class Micropub_Content_Builder {
 	 * @return void
 	 */
 	private static function assign_kind_term( int $post_id, array $properties ): void {
-		$kind = self::detect_kind( $properties ) ?? self::detect_term_only_kind( $properties );
-		if ( null === $kind ) {
+		$taxonomy = Plugin::get_instance()->get_taxonomy();
+		if ( null === $taxonomy ) {
 			return;
 		}
 
-		$taxonomy = Plugin::get_instance()->get_taxonomy();
-		if ( null === $taxonomy || ! $taxonomy->is_valid_kind( $kind ) ) {
+		// An explicit `pkiw-kind` hint from the client (e.g. Outpost) wins
+		// over property inference — it's the only way to reach kinds whose
+		// property shape is ambiguous (issue reuses in-reply-to; quote posts
+		// may carry content only). Invalid hints fall through to inference
+		// rather than dropping the post's kind entirely.
+		$explicit = self::explicit_kind( $properties );
+		if ( null !== $explicit && $taxonomy->is_valid_kind( $explicit ) ) {
+			$taxonomy->set_post_kind( $post_id, $explicit );
+			return;
+		}
+
+		$kind = self::detect_kind( $properties ) ?? self::detect_term_only_kind( $properties );
+		if ( null === $kind || ! $taxonomy->is_valid_kind( $kind ) ) {
 			return;
 		}
 
 		$taxonomy->set_post_kind( $post_id, $kind );
+	}
+
+	/**
+	 * Read the explicit `pkiw-kind` vendor property from the request.
+	 *
+	 * Mirrors the `pkiw-promote` vendor-property pattern: a Micropub client
+	 * that knows exactly which kind it's posting (Outpost's composer
+	 * variants) names it directly instead of relying on inference. The
+	 * value is sanitized to a slug; validation against registered terms
+	 * happens in assign_kind_term().
+	 *
+	 * @param array<string, mixed> $properties h-entry properties bag.
+	 * @return string|null Sanitized kind slug, or null when absent.
+	 */
+	private static function explicit_kind( array $properties ): ?string {
+		$raw = self::flatten_scalar( $properties, 'pkiw-kind' );
+		if ( '' === $raw ) {
+			return null;
+		}
+		$slug = sanitize_key( $raw );
+		return '' === $slug ? null : $slug;
 	}
 
 	/**
@@ -303,59 +335,62 @@ final class Micropub_Content_Builder {
 	 * @return string|null Kind slug ('eat'|'drink'|'listen'|...) or null when no kind matches.
 	 */
 	private static function detect_kind( array $properties ): ?string {
-		if ( self::has_property( $properties, 'eat-of' ) ) {
-			return 'eat';
-		}
-		if ( self::has_property( $properties, 'drink-of' ) ) {
-			return 'drink';
-		}
-		if ( self::has_property( $properties, 'listen-of' ) ) {
-			return 'listen';
-		}
-		if ( self::has_property( $properties, 'watch-of' ) ) {
-			return 'watch';
-		}
-		if ( self::has_property( $properties, 'read-of' ) ) {
-			return 'read';
-		}
-		if ( self::has_property( $properties, 'play-of' ) ) {
-			return 'play';
-		}
-		if ( self::has_property( $properties, 'rsvp' ) ) {
-			return 'rsvp';
-		}
-		if ( self::has_property( $properties, 'like-of' ) ) {
-			return 'like';
-		}
-		if ( self::has_property( $properties, 'repost-of' ) ) {
-			return 'repost';
-		}
-		if ( self::has_property( $properties, 'bookmark-of' ) ) {
-			return 'bookmark';
-		}
-		// Reply must be checked AFTER rsvp — RSVP posts carry `in-reply-to`
-		// as the event URL, so a reply match here means no rsvp was present.
-		if ( self::has_property( $properties, 'in-reply-to' ) ) {
-			return 'reply';
-		}
-		if ( self::has_property( $properties, 'follow-of' ) ) {
-			return 'follow';
-		}
-		if ( self::has_property( $properties, 'mood' ) ) {
-			return 'mood';
-		}
-		if ( self::has_property( $properties, 'weather' ) ) {
-			return 'weather';
-		}
-		// Checkin = location property without one of the food/drink/media of-kinds.
-		if ( self::has_property( $properties, 'location' ) ) {
-			return 'checkin';
-		}
-		// Photo / gallery = `photo` property without any of the of-kinds above.
-		// Single-photo and multi-photo posts both route here; photo_card()
-		// emits a single core/image or a core/gallery accordingly.
-		if ( self::has_property( $properties, 'photo' ) ) {
-			return 'photo';
+		/*
+		 * Ordered property → kind map; the first present property wins,
+		 * so array order IS the precedence order. Notable orderings:
+		 *   - eat-of/drink-of before location (those posts carry a venue).
+		 *   - jam-of before listen-of (a jam is a deliberate highlight).
+		 *   - rsvp, issue-of, quotation-of, tag-of before in-reply-to
+		 *     (all of those shapes may also carry a reply target).
+		 *   - wishlist-of is a compat alias for wish-of (older senders).
+		 *   - start (h-event) and exercise before location — an event or
+		 *     workout with a venue must not read as a checkin.
+		 *   - item = flattened h-review; ingredient = h-recipe signature.
+		 *   - video/audio before photo — a poster image must not demote
+		 *     a video/audio post to a photo post.
+		 */
+		$property_kind_map = [
+			'eat-of'         => 'eat',
+			'drink-of'       => 'drink',
+			'jam-of'         => 'jam',
+			'listen-of'      => 'listen',
+			'watch-of'       => 'watch',
+			'read-of'        => 'read',
+			'play-of'        => 'play',
+			'rsvp'           => 'rsvp',
+			'favorite-of'    => 'favorite',
+			'like-of'        => 'like',
+			'repost-of'      => 'repost',
+			'wish-of'        => 'wish',
+			'wishlist-of'    => 'wish',
+			'bookmark-of'    => 'bookmark',
+			'quotation-of'   => 'quote',
+			'tag-of'         => 'tag',
+			'issue-of'       => 'issue',
+			'in-reply-to'    => 'reply',
+			'follow-of'      => 'follow',
+			'craft-of'       => 'craft',
+			'acquisition-of' => 'acquisition',
+			'exercise'       => 'exercise',
+			'sleep'          => 'sleep',
+			'trip'           => 'trip',
+			'itinerary'      => 'itinerary',
+			'question'       => 'question',
+			'mood'           => 'mood',
+			'weather'        => 'weather',
+			'start'          => 'event',
+			'item'           => 'review',
+			'ingredient'     => 'recipe',
+			'location'       => 'checkin',
+			'video'          => 'video',
+			'audio'          => 'audio',
+			'photo'          => 'photo',
+		];
+
+		foreach ( $property_kind_map as $property => $kind ) {
+			if ( self::has_property( $properties, $property ) ) {
+				return $kind;
+			}
 		}
 		return null;
 	}
@@ -402,6 +437,61 @@ final class Micropub_Content_Builder {
 				return self::weather_paragraph( $properties );
 			case 'photo':
 				return self::photo_card( $properties );
+		}
+		return self::paragraph_for_kind( $kind, $properties );
+	}
+
+	/**
+	 * Build a typed paragraph for kinds without a dedicated card block.
+	 *
+	 * These kinds emit a one-line paragraph carrying the canonical
+	 * microformats2 property (the follow/weather pattern) so the property
+	 * still lands in content AND the post is never empty. Without this, a
+	 * title-less/content-less post of these kinds dies in wp_insert_post()
+	 * with empty_content (the "phantom post" failure fill_empty_content()
+	 * exists to prevent).
+	 *
+	 * @param string               $kind       Post-kind slug as returned by detect_kind().
+	 * @param array<string, mixed> $properties h-entry properties bag.
+	 * @return string|null Block-comment markup, or null when the kind has no paragraph shape.
+	 */
+	private static function paragraph_for_kind( string $kind, array $properties ): ?string {
+		switch ( $kind ) {
+			case 'jam':
+				return self::typed_paragraph( $properties, 'jam-of', 'u-jam-of', __( 'Jamming to', 'post-kinds-for-indieweb-in-block-themes' ) );
+			case 'favorite':
+				return self::typed_paragraph( $properties, 'favorite-of', 'u-favorite-of', __( 'Favorited', 'post-kinds-for-indieweb-in-block-themes' ) );
+			case 'wish':
+				return self::typed_paragraph(
+					$properties,
+					self::has_property( $properties, 'wish-of' ) ? 'wish-of' : 'wishlist-of',
+					'u-wish-of',
+					__( 'Wishing for', 'post-kinds-for-indieweb-in-block-themes' )
+				);
+			case 'tag':
+				return self::typed_paragraph( $properties, 'tag-of', 'u-tag-of', __( 'Tagged', 'post-kinds-for-indieweb-in-block-themes' ) );
+			case 'issue':
+				// Legacy issue-of senders; canonical class stays u-in-reply-to
+				// (an issue is a reply to a repository — see class-microformats.php).
+				return self::typed_paragraph( $properties, 'issue-of', 'u-in-reply-to', __( 'Issue for', 'post-kinds-for-indieweb-in-block-themes' ) );
+			case 'craft':
+				return self::typed_paragraph( $properties, 'craft-of', 'u-craft-of', __( 'Crafted', 'post-kinds-for-indieweb-in-block-themes' ) );
+			case 'acquisition':
+				return self::typed_paragraph( $properties, 'acquisition-of', 'u-acquisition-of', __( 'Acquired', 'post-kinds-for-indieweb-in-block-themes' ) );
+			case 'exercise':
+				return self::typed_paragraph( $properties, 'exercise', 'p-exercise', '' );
+			case 'sleep':
+				return self::typed_paragraph( $properties, 'sleep', 'p-sleep', '' );
+			case 'trip':
+				return self::typed_paragraph( $properties, 'trip', 'p-trip', '' );
+			case 'itinerary':
+				return self::typed_paragraph( $properties, 'itinerary', 'p-itinerary', '' );
+			case 'question':
+				return self::typed_paragraph( $properties, 'question', 'p-question', '' );
+			case 'video':
+				return self::typed_paragraph( $properties, 'video', 'u-video', '' );
+			case 'audio':
+				return self::typed_paragraph( $properties, 'audio', 'u-audio', '' );
 		}
 		return null;
 	}
@@ -846,6 +936,37 @@ final class Micropub_Content_Builder {
 		}
 		return '<!-- wp:paragraph -->' . "\n"
 			. '<p><span class="p-weather">' . esc_html( $reading ) . '</span></p>' . "\n"
+			. '<!-- /wp:paragraph -->';
+	}
+
+	/**
+	 * Build a one-line typed paragraph carrying a microformats2 class.
+	 *
+	 * Generalizes the follow/weather paragraph pattern for kinds without a
+	 * dedicated card block. URL values render as a link (so u-* classes
+	 * resolve for parsers); plain-text values render as a span (p-* kinds
+	 * like exercise/sleep, and name-shaped u-* values like a crafted item).
+	 *
+	 * @param array<string, mixed> $properties h-entry properties bag.
+	 * @param string               $key        Property to read the value from.
+	 * @param string               $mf2_class  Microformats2 class for the value element.
+	 * @param string               $prefix     Translated lead-in text ('' for none).
+	 * @return string Block-comment markup, or '' when the property is empty.
+	 */
+	private static function typed_paragraph( array $properties, string $key, string $mf2_class, string $prefix ): string {
+		$value = self::flatten_scalar( $properties, $key );
+		if ( '' === $value ) {
+			return '';
+		}
+		$is_url = 0 === strpos( $value, 'http://' ) || 0 === strpos( $value, 'https://' );
+		if ( $is_url ) {
+			$inner = '<a class="' . esc_attr( $mf2_class ) . '" href="' . esc_url( $value ) . '">' . esc_html( $value ) . '</a>';
+		} else {
+			$inner = '<span class="' . esc_attr( $mf2_class ) . '">' . esc_html( $value ) . '</span>';
+		}
+		$lead = '' === $prefix ? '' : esc_html( $prefix ) . ' ';
+		return '<!-- wp:paragraph -->' . "\n"
+			. '<p>' . $lead . $inner . '</p>' . "\n"
 			. '<!-- /wp:paragraph -->';
 	}
 

--- a/tests/phpunit/unit/MicropubContentBuilderTest.php
+++ b/tests/phpunit/unit/MicropubContentBuilderTest.php
@@ -30,7 +30,7 @@ class MicropubContentBuilderTest extends WP_UnitTestCase {
 	 */
 	public function set_up(): void {
 		parent::set_up();
-		foreach ( array( 'note', 'checkin', 'eat', 'drink', 'like', 'rsvp' ) as $slug ) {
+		foreach ( array( 'note', 'checkin', 'eat', 'drink', 'like', 'rsvp', 'jam', 'favorite', 'wish', 'exercise', 'event', 'video', 'quote', 'issue', 'listen' ) as $slug ) {
 			if ( ! term_exists( $slug, 'kind' ) ) {
 				wp_insert_term( ucfirst( $slug ), 'kind', array( 'slug' => $slug ) );
 			}
@@ -99,6 +99,243 @@ class MicropubContentBuilderTest extends WP_UnitTestCase {
 			array( array( 'mood' => 'focused' ) )
 		);
 		$this->assertSame( 'mood', $kind );
+	}
+
+	// --- detect_kind — extended kind coverage ------------------------------
+
+	public function test_detect_kind_jam_takes_precedence_over_listen(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array(
+				array(
+					'jam-of'    => 'https://example.test/track/9',
+					'listen-of' => 'https://example.test/track/9',
+				),
+			)
+		);
+		$this->assertSame( 'jam', $kind );
+	}
+
+	public function test_detect_kind_favorite_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'favorite-of' => 'https://example.test/post/1' ) )
+		);
+		$this->assertSame( 'favorite', $kind );
+	}
+
+	public function test_detect_kind_wish_recognized_via_canonical_property(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'wish-of' => 'https://example.test/item/1' ) )
+		);
+		$this->assertSame( 'wish', $kind );
+	}
+
+	public function test_detect_kind_wish_recognized_via_wishlist_alias(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'wishlist-of' => 'https://example.test/item/1' ) )
+		);
+		$this->assertSame( 'wish', $kind );
+	}
+
+	public function test_detect_kind_quote_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'quotation-of' => 'https://example.test/essay' ) )
+		);
+		$this->assertSame( 'quote', $kind );
+	}
+
+	public function test_detect_kind_tag_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'tag-of' => 'https://example.test/page' ) )
+		);
+		$this->assertSame( 'tag', $kind );
+	}
+
+	public function test_detect_kind_issue_alias_takes_precedence_over_reply(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array(
+				array(
+					'issue-of'    => 'https://example.test/repo',
+					'in-reply-to' => 'https://example.test/repo',
+				),
+			)
+		);
+		$this->assertSame( 'issue', $kind );
+	}
+
+	public function test_detect_kind_craft_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'craft-of' => 'hand-knit scarf' ) )
+		);
+		$this->assertSame( 'craft', $kind );
+	}
+
+	public function test_detect_kind_acquisition_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'acquisition-of' => 'https://example.test/product' ) )
+		);
+		$this->assertSame( 'acquisition', $kind );
+	}
+
+	public function test_detect_kind_exercise_takes_precedence_over_location(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array(
+				array(
+					'exercise' => '5k run',
+					'location' => 'geo:29.12,-103.24',
+				),
+			)
+		);
+		$this->assertSame( 'exercise', $kind );
+	}
+
+	public function test_detect_kind_sleep_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'sleep' => '7h 40m' ) )
+		);
+		$this->assertSame( 'sleep', $kind );
+	}
+
+	public function test_detect_kind_trip_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'trip' => 'Chicago to Detroit' ) )
+		);
+		$this->assertSame( 'trip', $kind );
+	}
+
+	public function test_detect_kind_itinerary_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'itinerary' => 'ORD → DTW → YYZ' ) )
+		);
+		$this->assertSame( 'itinerary', $kind );
+	}
+
+	public function test_detect_kind_question_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'question' => 'Best static site host in 2026?' ) )
+		);
+		$this->assertSame( 'question', $kind );
+	}
+
+	public function test_detect_kind_event_takes_precedence_over_checkin(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array(
+				array(
+					'name'     => 'WordCamp',
+					'start'    => '2026-09-01T10:00:00-04:00',
+					'location' => 'geo:29.12,-103.24',
+				),
+			)
+		);
+		$this->assertSame( 'event', $kind );
+	}
+
+	public function test_detect_kind_review_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'item' => 'https://example.test/gadget' ) )
+		);
+		$this->assertSame( 'review', $kind );
+	}
+
+	public function test_detect_kind_recipe_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'ingredient' => array( '2 eggs', '1 cup flour' ) ) )
+		);
+		$this->assertSame( 'recipe', $kind );
+	}
+
+	public function test_detect_kind_video_takes_precedence_over_photo(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array(
+				array(
+					'video' => 'https://example.test/clip.mp4',
+					'photo' => 'https://example.test/poster.jpg',
+				),
+			)
+		);
+		$this->assertSame( 'video', $kind );
+	}
+
+	public function test_detect_kind_audio_recognized(): void {
+		$kind = $this->invoke_private(
+			'detect_kind',
+			array( array( 'audio' => 'https://example.test/memo.mp3' ) )
+		);
+		$this->assertSame( 'audio', $kind );
+	}
+
+	// --- explicit_kind ------------------------------------------------------
+
+	public function test_explicit_kind_reads_and_sanitizes_hint(): void {
+		$slug = $this->invoke_private(
+			'explicit_kind',
+			array( array( 'pkiw-kind' => array( 'Jam' ) ) )
+		);
+		$this->assertSame( 'jam', $slug );
+	}
+
+	public function test_explicit_kind_null_when_absent(): void {
+		$slug = $this->invoke_private(
+			'explicit_kind',
+			array( array( 'content' => 'plain note' ) )
+		);
+		$this->assertNull( $slug );
+	}
+
+	// --- typed_paragraph ----------------------------------------------------
+
+	public function test_typed_paragraph_renders_url_as_link_with_mf2_class(): void {
+		$markup = $this->invoke_private(
+			'typed_paragraph',
+			array(
+				array( 'favorite-of' => 'https://example.test/post/1' ),
+				'favorite-of',
+				'u-favorite-of',
+				'Favorited',
+			)
+		);
+		$this->assertStringContainsString( '<a class="u-favorite-of" href="https://example.test/post/1">', $markup );
+		$this->assertStringContainsString( 'Favorited', $markup );
+		$this->assertStringContainsString( '<!-- wp:paragraph -->', $markup );
+	}
+
+	public function test_typed_paragraph_renders_text_as_span(): void {
+		$markup = $this->invoke_private(
+			'typed_paragraph',
+			array(
+				array( 'exercise' => '5k run' ),
+				'exercise',
+				'p-exercise',
+				'',
+			)
+		);
+		$this->assertStringContainsString( '<span class="p-exercise">5k run</span>', $markup );
+		$this->assertStringNotContainsString( '<a ', $markup );
+	}
+
+	public function test_typed_paragraph_empty_when_property_missing(): void {
+		$markup = $this->invoke_private(
+			'typed_paragraph',
+			array( array(), 'favorite-of', 'u-favorite-of', 'Favorited' )
+		);
+		$this->assertSame( '', $markup );
 	}
 
 	// --- parse_geo_from_location -------------------------------------------
@@ -313,6 +550,100 @@ class MicropubContentBuilderTest extends WP_UnitTestCase {
 		$content = (string) get_post_field( 'post_content', $post_id );
 		$this->assertSame( 'just a note, no card kind', $content );
 		$this->assertSame( '', (string) get_post_meta( $post_id, '_pkiw_block_content_generated', true ) );
+	}
+
+	// --- pkiw-kind explicit hint --------------------------------------------
+
+	public function test_apply_explicit_hint_overrides_property_inference(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'current jam',
+			)
+		);
+
+		// listen-of would infer 'listen'; the explicit hint says jam.
+		Micropub_Content_Builder::apply(
+			array(
+				'h'         => 'entry',
+				'listen-of' => 'https://example.test/track/9',
+				'pkiw-kind' => 'jam',
+				'content'   => 'current jam',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'jam' ), $this->kind_slugs( $post_id ) );
+	}
+
+	public function test_apply_invalid_hint_falls_back_to_inference(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'listening',
+			)
+		);
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'         => 'entry',
+				'listen-of' => 'https://example.test/track/9',
+				'pkiw-kind' => 'definitely-not-a-kind',
+				'content'   => 'listening',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'listen' ), $this->kind_slugs( $post_id ) );
+	}
+
+	public function test_apply_hint_reaches_kinds_with_ambiguous_properties(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'the linked repo mislabels its license',
+			)
+		);
+
+		// An issue is property-identical to a reply (in-reply-to); only the
+		// hint can classify it.
+		Micropub_Content_Builder::apply(
+			array(
+				'h'           => 'entry',
+				'in-reply-to' => 'https://example.test/repo',
+				'pkiw-kind'   => 'issue',
+				'content'     => 'the linked repo mislabels its license',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'issue' ), $this->kind_slugs( $post_id ) );
+	}
+
+	public function test_apply_favorite_generates_typed_paragraph_content(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => 'placeholder',
+			)
+		);
+
+		Micropub_Content_Builder::apply(
+			array(
+				'h'           => 'entry',
+				'favorite-of' => 'https://example.test/post/1',
+			),
+			array( 'ID' => $post_id )
+		);
+
+		$this->assertSame( array( 'favorite' ), $this->kind_slugs( $post_id ) );
+		$content = (string) get_post_field( 'post_content', $post_id );
+		$this->assertStringContainsString( 'u-favorite-of', $content );
+		$this->assertStringContainsString( 'https://example.test/post/1', $content );
 	}
 
 	// --- photo / gallery ----------------------------------------------------
@@ -734,9 +1065,15 @@ class MicropubContentBuilderTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'rsvp' ), $this->kind_slugs( $post_id ) );
 	}
 
-	public function test_apply_leaves_default_note_for_termless_follow_kind(): void {
-		// follow/weather are builder-only kinds with no taxonomy term —
-		// they keep core's `note` default (but still get their content).
+	public function test_apply_leaves_default_note_for_termless_kind(): void {
+		// A kind whose taxonomy term is missing (e.g. a site deleted it)
+		// keeps core's `note` default — but still gets its typed content.
+		// (follow used to lack a term by default; now that every kind ships
+		// a default term, the termless state must be created explicitly.)
+		$follow = get_term_by( 'slug', 'follow', 'kind' );
+		if ( $follow instanceof \WP_Term ) {
+			wp_delete_term( $follow->term_id, 'kind' );
+		}
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'author' ) ) );
 		$post_id = self::factory()->post->create(
 			array(


### PR DESCRIPTION
## What

Micropub-created posts could only reach 16 of the 36 registered kinds. Everything else — jam, favorite, wish, tag, issue, craft, acquisition, exercise, sleep, trip, itinerary, question, event, review, recipe, video, audio — silently landed as `note` (the taxonomy default), because `detect_kind()` never learned their properties.

Three changes in `class-micropub-content-builder.php`:

1. **Full property inference.** `detect_kind()` is now an ordered property → kind map covering every kind with a canonical property, mirroring what `class-microformats.php` emits per kind: `jam-of`, `favorite-of`, `wish-of` (+ `wishlist-of` compat alias), `quotation-of`, `tag-of`, `issue-of` (compat alias), `craft-of`, `acquisition-of`, `exercise`, `sleep`, `trip`, `itinerary`, `question`, `start` → event, `item` → review, `ingredient` → recipe, `video`, `audio`. Ordering matters and is documented in place: `start` detects before `location` (an event with a venue isn't a checkin), `video`/`audio` before `photo` (a poster image can't demote them), `jam-of` before `listen-of`.

2. **Explicit `pkiw-kind` hint.** A vendor property mirroring `pkiw-promote`: a client that knows its kind (Outpost's composer variants) names it directly, overriding inference. This is the only route to property-ambiguous kinds — issue reuses `in-reply-to` per the mf2 map, and a quote may carry content only. Invalid slugs fall back to inference rather than dropping classification.

3. **Typed paragraphs for card-less kinds.** `paragraph_for_kind()` generalizes the follow/weather pattern: a one-line `core/paragraph` carrying the canonical mf2 class (`u-jam-of`, `p-exercise`, …). Besides parser visibility, this stops title-less/content-less posts of these kinds from dying inside `wp_insert_post()` with `empty_content` — the same phantom-post failure `fill_empty_content()` was added for.

## Test updates

- 28 new unit tests: inference for each new kind (including the precedence cases), `explicit_kind` sanitization, `typed_paragraph` URL/span/empty behavior, and apply-level tests proving the hint overrides inference, invalid hints fall back, `in-reply-to` + `pkiw-kind=issue` classifies as issue, and a bare `favorite-of` generates paragraph content.
- Fixed the stale `test_apply_leaves_default_note_for_termless_follow_kind`: it asserted behavior from when `follow` had no default term, and **fails on current main** (follow is a default kind now, so the term exists and assignment correctly happens). The test now deletes the term first, preserving its real intent — a termless kind keeps the `note` default but still gets content.

Doc ledger (`docs/micropub-field-gaps.md`) gains a section for the paragraph-only kinds and the hint; none of the new kinds are card blocks, so the wire-matrix completeness assertion is unaffected.

Sender side (Outpost posting the canonical properties + hint) lands separately in courtneyr-dev/outpost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)