### PR TITLE
📖 DOC: describe full-kind Micropub classification in both readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ Pull in your existing data:
 - **Background processing** via WP-Cron for large imports
 - **Duplicate prevention** on re-imports
 
+## Micropub
+
+With the [Micropub](https://wordpress.org/plugins/micropub/) plugin handling the endpoint, this plugin classifies every incoming Micropub post as its kind and builds the matching content:
+
+- **Every registered kind is reachable.** Classification reads the kind's canonical property — `listen-of`, `watch-of`, `read-of`, `jam-of`, `favorite-of`, `wish-of`, `tag-of`, `craft-of`, `acquisition-of`, `quotation-of`, `exercise`, `sleep`, `trip`, `itinerary`, `question`, `mood`, `weather`, `start` (event), `item` (review), `ingredient` (recipe), `video`, `audio`, `photo`, `location` (checkin), and the response properties (`in-reply-to`, `like-of`, `repost-of`, `bookmark-of`, `rsvp`, `follow-of`). Ordering handles the overlaps: an event with a venue is an event, not a checkin; a video with a poster image is a video, not a photo.
+- **Clients can name the kind outright.** A `pkiw-kind` property (a vendor extension, like `pkiw-promote`) overrides inference — the only way to reach kinds whose properties are ambiguous, such as issue, which shares `in-reply-to` with reply. Unknown values fall back to inference. [Outpost](https://github.com/courtneyr-dev/outpost) sends this for every composer mode.
+- **Content is generated per kind.** Kinds with card blocks get the card; kinds without one get a one-line paragraph carrying the canonical microformats2 class, so parsers see the property and the post is never empty.
+
+The receiving side's property-by-property contract lives in [docs/micropub-field-gaps.md](docs/micropub-field-gaps.md).
+
 ## Microformats
 
 Every block outputs proper [microformats2](http://microformats.org/wiki/microformats2) markup:

--- a/readme.txt
+++ b/readme.txt
@@ -59,7 +59,7 @@ Each kind gets its own archive page (for example `/kind/listen/`), and the kind 
 
 = Works with =
 
-* [Micropub](https://wordpress.org/plugins/micropub/) — **required for posting from Micropub apps.** This plugin doesn't implement the Micropub endpoint itself; install the Micropub plugin (plus [IndieAuth](https://wordpress.org/plugins/indieauth/) for authentication), and this plugin converts incoming posts into the right card block and kind.
+* [Micropub](https://wordpress.org/plugins/micropub/) — **required for posting from Micropub apps.** This plugin doesn't implement the Micropub endpoint itself; install the Micropub plugin (plus [IndieAuth](https://wordpress.org/plugins/indieauth/) for authentication), and this plugin classifies every incoming post as its kind — all registered kinds, not just the common ones — and converts it into the right card block or microformats paragraph. Clients that know their kind can name it outright with a `pkiw-kind` property; [Outpost](https://github.com/courtneyr-dev/outpost) does.
 * [IndieBlocks](https://wordpress.org/plugins/indieblocks/) — detected and recommended, not required. It provides companion blocks (Facepile, Location, Syndication, Link Preview); this plugin doesn't implement those features itself.
 * [Webmention](https://wordpress.org/plugins/webmention/) — detected on the Integrations settings tab. Cross-site conversations come from that plugin, not this one.
 * [Syndication Links](https://wordpress.org/plugins/syndication-links/), [Post Formats for Block Themes](https://wordpress.org/plugins/post-formats-for-block-themes/), [Bookmark Card](https://wordpress.org/plugins/bookmark-card/) — detected and enhanced when present.
@@ -125,7 +125,7 @@ That's ATmosphere's choice, not this plugin's: Bluesky cross-posting follows ATm
 
 = How do I post from my phone or a Micropub app? =
 
-Install the separate [Micropub](https://wordpress.org/plugins/micropub/) plugin and an IndieAuth setup (for example the [IndieAuth](https://wordpress.org/plugins/indieauth/) plugin). Micropub is a standard API that lets mobile and third-party apps publish to your site. Once it's active, this plugin converts incoming Micropub posts into the right card block and assigns the kind.
+Install the separate [Micropub](https://wordpress.org/plugins/micropub/) plugin and an IndieAuth setup (for example the [IndieAuth](https://wordpress.org/plugins/indieauth/) plugin). Micropub is a standard API that lets mobile and third-party apps publish to your site. Once it's active, this plugin assigns the kind and builds the content for every incoming Micropub post — each registered kind is reachable, whether the client sends the kind's canonical property or names the kind directly with the `pkiw-kind` property.
 
 For one-tap posting and bookmarklet-style sharing from any page or your phone's share sheet, [Outpost](https://github.com/courtneyr-dev/outpost) is a companion progressive web app that posts to your site over Micropub. This plugin doesn't ship its own bookmarklet — Micropub and Outpost cover that.
 


### PR DESCRIPTION
Documentation for #164, which merged without its reader-facing docs.

- **README.md** gains a Micropub section between Import/Sync and Microformats: the full canonical-property list the bridge classifies, the precedence notes readers actually need (event-with-venue is not a checkin; video-with-poster is not a photo), the `pkiw-kind` vendor property with its Outpost pointer, and the typed-paragraph behavior for card-less kinds. Links to the property-by-property contract in `docs/micropub-field-gaps.md`.
- **readme.txt**: the Works-with Micropub bullet and the "How do I post from my phone or a Micropub app?" FAQ now describe all-kinds classification and the explicit kind property instead of the old convert-the-common-ones wording.

Deliberately unchanged: the readme.txt changelog (release-time, per the prepare-vs-ship convention — CHANGELOG.md already carries the Unreleased entry from #164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)