### PR TITLE
🚀 RELEASE: 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-21
+
 ### Added
 
+- Four more kinds from the IndieWeb posts vocabulary: **chicken**, **comics**, **collection**, and **presentation**, bringing the registry to 40. Each gets its taxonomy term, admin picker entry, editor icon, badge glyph, and microformats2 mapping.
+- Kind icons in the editor picker are filterable — `postKindsIndieweb.kindIcons` lets a site register an icon component for a custom kind term, or override a built-in. Custom terms previously always fell back to the note icon with no way to change it.
+- Six block style variations for the Play Card — board game, console game, computer game, card game, dice game, and tabletop RPG — selectable from the editor's Styles panel. The style is suggested automatically from what's known about the game (platform first, then title keywords, then lookup source: BoardGameGeek implies board game, Steam implies computer, RAWG implies console), and never overrides a style you picked yourself.
 - The Micropub bridge now classifies **every registered kind**, not just the original 16. New property inference: `jam-of`, `favorite-of`, `wish-of` (plus `wishlist-of` compat alias), `quotation-of`, `tag-of`, `issue-of` (compat alias), `craft-of`, `acquisition-of`, `exercise`, `sleep`, `trip`, `itinerary`, `question`, `start` (event), `item` (review), `ingredient` (recipe), `video`, and `audio` — video/audio detect ahead of `photo` so a poster image can't demote them, and `start` detects ahead of `location` so events with venues don't read as check-ins.
 - New `pkiw-kind` vendor property (mirrors `pkiw-promote`): a Micropub client that knows its kind names it explicitly, overriding inference. This is the only route to kinds whose property shape is ambiguous — issue (which reuses `in-reply-to`) and content-only quotes. Invalid values fall back to inference.
 - Kinds without a card block now generate a typed one-line paragraph (the follow/weather pattern) carrying the canonical microformats2 class, which also prevents title-less posts of those kinds from dying in `wp_insert_post()` with `empty_content`.
+
+### Fixed
+
+- Publishing failed with "meta._pkiw_read_isbn is not of type string" after a book lookup. External APIs return numbers where the meta is registered as a string — OpenLibrary ISBNs, TMDB and Trakt ids, release years — and REST rejects the whole post update. Values are now coerced to the registered type at the single point where kind meta is written, rather than cast per call site, so the ~20 other lookup fields with the same exposure (check-in address, listen track and album, play title and ids) are covered too. The type map comes from the PHP registry itself, so JS and PHP can't drift apart.
 
 ## [1.6.0] - 2026-08-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "post-kinds-for-indieweb-in-block-themes",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "post-kinds-for-indieweb-in-block-themes",
-			"version": "1.6.0",
+			"version": "1.7.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "post-kinds-for-indieweb-in-block-themes",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.",
 	"author": "Courtney Robertson",
 	"license": "GPL-2.0-or-later",

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb in Block Themes
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.6.0
+ * Version:           1.7.0
  * Requires at least: 7.0
  * Tested up to:      7.1
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'PKIW_VERSION', '1.6.0' );
+define( 'PKIW_VERSION', '1.7.0' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 7.0
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.6.0
+Stable tag: 1.7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -170,6 +170,13 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 9. Standard.site record panel on a Bookmark Card, showing the cited page's own title, publication, description, and tags read from AT Protocol
 
 == Changelog ==
+
+= 1.7.0 =
+* Added: four more kinds — chicken, comics, collection, and presentation — bringing the total to 40.
+* Added: the Play Card has six looks to choose from in the editor's Styles panel — board game, console game, computer game, card game, dice game, and tabletop RPG. It picks one for you based on what it knows about the game, and leaves your choice alone if you've made one.
+* Added: sites can now give their own custom kinds an icon in the kind picker, instead of every custom kind showing the generic note icon. Developers: the new `postKindsIndieweb.kindIcons` JavaScript filter.
+* Added: the Micropub bridge understands every registered kind, not just the original 16, and clients can name a kind outright with the new `pkiw-kind` property.
+* Fixed: publishing a book post after a lookup failed with "meta._pkiw_read_isbn is not of type string". Lookup services return ISBNs, IDs, and years as numbers where the plugin stores text, which made WordPress reject the whole save. Values are now converted where they're stored, so every lookup field is covered rather than just the ones reported.
 
 = 1.6.0 =
 * Added: Standard.site publishing through the optional [ATmosphere](https://wordpress.org/plugins/atmosphere/) companion plugin (2.1.0 or later). Public content and public logs — notes, articles, photos, videos, reviews, recipes, events, listens, watches, reads, plays, eats, drinks, jams, replies, bookmarks, and RSVPs — publish as Standard.site documents by default once ATmosphere is connected; likes, reposts, favorites, follows, check-ins, moods, and the other privacy-sensitive kinds stay off until you turn them on, per kind or per post. Untitled posts get readable derived titles ("Listened to … by …", "Checked in at …" — or just "Checked in" for a private check-in), the kind rides along as a tag, and a post's own sharing toggle always has the final say. Posts that already published are never removed by a settings change, and nothing backfills automatically. Post Kinds works fully without ATmosphere.


### PR DESCRIPTION
Version bumps, CHANGELOG, and readme.txt changelog for 1.7.0.

Everything merged since the v1.6.0 tag: #162 (Play Card block styles), #163 (filterable kind icons), #164 (full-kind Micropub classification, already in Unreleased), #165 (chicken, comics, collection, presentation), #166 (meta type coercion — the ISBN publish failure).

**Minor, not patch.** The release adds kinds, block styles, and a public JS filter; the project declares semver adherence.

`PKIW_VERSION` is bumped alongside the header, readme stable tag, package.json, and lock. That constant gates `ensure_all_terms_exist()` — leaving it at 1.6.0 would ship the four new kinds without ever creating their terms on existing sites.

Local run before tagging: PHPUnit 1455 tests OK (11 skipped, 2 risky — both pre-existing), Jest 51/51, production build regenerated and unchanged against the committed `build/`.