### PR TITLE
🐛 FIX: the quote post format maps to the quote kind, not repost

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -490,7 +490,10 @@ class Admin {
 				'gallery'  => 'photo',
 				'image'    => 'photo',
 				'link'     => 'bookmark',
-				'quote'    => 'repost',
+				// The quote format is a quotation of someone else, which is
+				// the quote kind (u-quotation-of). This defaulted to repost
+				// before the quote kind existed.
+				'quote'    => 'quote',
 				'status'   => 'note',
 				'video'    => 'watch',
 			],

--- a/tests/phpunit/unit/AdminTest.php
+++ b/tests/phpunit/unit/AdminTest.php
@@ -87,6 +87,27 @@ class AdminTest extends WP_UnitTestCase {
 		$this->assertIsArray( $defaults['format_kind_mappings'] );
 	}
 
+	/**
+	 * Each post format maps to the kind that means the same thing.
+	 *
+	 * The quote format defaulted to the repost kind before the quote kind
+	 * existed; a quotation of someone else is a quote (u-quotation-of),
+	 * not a reshare.
+	 */
+	public function test_format_kind_mappings_pair_equivalent_meanings(): void {
+		$map = $this->admin->get_default_settings()['format_kind_mappings'];
+
+		$this->assertSame( 'quote', $map['quote'] );
+		$this->assertSame( 'article', $map['standard'] );
+		$this->assertSame( 'note', $map['aside'] );
+		$this->assertSame( 'listen', $map['audio'] );
+		$this->assertSame( 'photo', $map['image'] );
+		$this->assertSame( 'photo', $map['gallery'] );
+		$this->assertSame( 'bookmark', $map['link'] );
+		$this->assertSame( 'watch', $map['video'] );
+		$this->assertSame( 'note', $map['status'] );
+	}
+
 	// ─── get_post_kinds ───
 
 	/**


### PR DESCRIPTION
`format_kind_mappings` has paired the quote post format with the **repost** kind since the defaults were written — before the quote kind existed. A quote post is a quotation of someone else (`u-quotation-of`); a repost is a reshare of it. Any site with `sync_formats_to_kinds` on (the default) has been getting the wrong kind assigned to quote-format posts.

Found while consolidating a duplicate `quotation` term on courtneyr.dev — both that site and its staging had `quote => repost` saved.

Existing installs keep whatever mapping they've saved, so this only corrects the default for fresh installs and anyone who resets settings. Sites that already have the wrong value need it changed in Settings → Post Kinds, which is what I did on mine.

Adds a test asserting each format maps to the kind that means the same thing, so the next stale pairing shows up as a failure rather than as posts filed under the wrong kind. `AdminTest` passes locally (29 tests, 184 assertions).

Not in 1.7.0 — this landed after the tag.