### PR TITLE
🐛 FIX: exclude .wordpress-org from the distribution

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -43,6 +43,11 @@ phpstan-baseline.neon
 # the single largest thing in the download.
 /img
 
+# Banners, icons, and screenshots for the plugin directory listing. These
+# belong in the SVN repo's own assets/ directory, never in trunk — shipping
+# them would add ~6M to every download.
+/.wordpress-org
+
 # Development documentation
 CLAUDE.md
 CODE_OF_CONDUCT.md

--- a/tests/phpunit/unit/DistributionManifestTest.php
+++ b/tests/phpunit/unit/DistributionManifestTest.php
@@ -103,6 +103,32 @@ class DistributionManifestTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Heavy dot-directories are excluded by name.
+	 *
+	 * `expected_shipped()` skips every dot-entry, so a dot-directory missing
+	 * from `.distignore` is invisible to the manifest comparison — but
+	 * `wp dist-archive` reads `.distignore` alone and would package it.
+	 * `.wordpress-org/` (banners and screenshots for the directory listing,
+	 * ~6M) belongs in the SVN repo's assets/, never in trunk, and shipped
+	 * that way only because the 1.7.0 build excluded it by hand.
+	 */
+	public function test_distignore_excludes_directory_listing_assets(): void {
+		$ignored = $this->ignored_entries();
+
+		foreach ( [ '.wordpress-org', '.git', '.github' ] as $entry ) {
+			if ( ! is_dir( $this->repo_root() . '/' . $entry ) ) {
+				continue;
+			}
+
+			$this->assertContains(
+				$entry,
+				$ignored,
+				"$entry exists in the repo but .distignore does not exclude it, so wp dist-archive would ship it"
+			);
+		}
+	}
+
+	/**
 	 * The manifest ships exactly what `.distignore` does not exclude.
 	 */
 	public function test_manifest_matches_distignore_contract(): void {


### PR DESCRIPTION
`.wordpress-org/` holds the banners, icons, and screenshots that feed the plugin directory listing — ~6M. Those belong in the SVN repo's own `assets/` directory, never in `trunk/`, and `.distignore` never excluded them. `wp dist-archive` reads `.distignore` alone, so a build from it would package the whole directory: the same shape as #150 (`img/`), and about the same size.

1.7.0 isn't affected — I caught it while building that release and excluded the directory by hand, which is exactly the kind of manual step that doesn't survive the next release.

**Why the existing test missed it.** `DistributionManifestTest::expected_shipped()` skips every entry starting with `.`, so dot-directories never enter the manifest comparison at all. Added `test_distignore_excludes_directory_listing_assets()`, which checks the exclusion list by name for the heavy dot-directories that actually exist in the repo.

Negative control run before committing: with the new `.distignore` line removed the test fails ("Failed asserting that an array contains '.wordpress-org'"); restored, it passes. `DistributionManifestTest` is 3 tests / 9 assertions green.