### PR TITLE
🐛 FIX: don't remember an empty lookup for a full day

### DIFF
--- a/includes/apis/class-api-base.php
+++ b/includes/apis/class-api-base.php
@@ -428,7 +428,23 @@ abstract class API_Base {
 	}
 
 	/**
+	 * How long an empty result is remembered, in seconds.
+	 *
+	 * Short on purpose — see set_cache().
+	 */
+	protected const EMPTY_CACHE_DURATION = 300;
+
+	/**
 	 * Set cached data.
+	 *
+	 * An empty result is cached for EMPTY_CACHE_DURATION rather than the
+	 * full duration. A lookup can come back empty for reasons that have
+	 * nothing to do with the query — a rate limit, a transient upstream
+	 * failure, a service returning 200 with no rows — and at the normal
+	 * duration that answer is then repeated for a day, so the same search
+	 * keeps reporting "no results found" long after the service recovered
+	 * and no request is ever made to notice. Keeping a short window still
+	 * protects the service from a user retrying in frustration.
 	 *
 	 * @param string $key      Cache key.
 	 * @param mixed  $data     Data to cache.
@@ -438,6 +454,10 @@ abstract class API_Base {
 	protected function set_cache( string $key, $data, ?int $duration = null ): bool {
 		$cache_key = $this->get_cache_key( $key );
 		$duration  = $duration ?? $this->cache_duration;
+
+		if ( empty( $data ) ) {
+			$duration = min( $duration, static::EMPTY_CACHE_DURATION );
+		}
 
 		return set_transient( $cache_key, $data, $duration );
 	}

--- a/tests/phpunit/unit/ApiBaseTest.php
+++ b/tests/phpunit/unit/ApiBaseTest.php
@@ -282,4 +282,54 @@ class ApiBaseTest extends ApiTestCase {
 
 		$this->assertSame( [], $results );
 	}
+
+	/**
+	 * An empty result is remembered briefly, not for a full day.
+	 *
+	 * A lookup can return empty because of a rate limit or a transient
+	 * upstream failure. At the normal duration that answer is repeated for
+	 * a day and the same search keeps reporting "no results found" with no
+	 * request ever made to notice the service recovered.
+	 */
+	public function test_empty_results_get_a_short_ttl(): void {
+		$this->api->exposed_set_cache( 'empty_search', [] );
+
+		$key     = $this->api->exposed_get_cache_key( 'empty_search' );
+		$timeout = (int) get_option( '_transient_timeout_' . $key );
+
+		$this->assertGreaterThan( time(), $timeout, 'empty result should still be cached' );
+		$this->assertLessThanOrEqual(
+			time() + 300,
+			$timeout,
+			'empty result should expire within the short window, not the full cache duration'
+		);
+	}
+
+	/**
+	 * A real result still gets the full cache duration.
+	 */
+	public function test_non_empty_results_keep_the_full_ttl(): void {
+		$this->api->exposed_set_cache( 'real_search', [ [ 'title' => 'A Day of Fallen Night' ] ] );
+
+		$key     = $this->api->exposed_get_cache_key( 'real_search' );
+		$timeout = (int) get_option( '_transient_timeout_' . $key );
+
+		$this->assertGreaterThan(
+			time() + 300,
+			$timeout,
+			'a real result should outlive the short empty-result window'
+		);
+	}
+
+	/**
+	 * Both cases round-trip through get_cache unchanged.
+	 */
+	public function test_cached_values_round_trip(): void {
+		$this->api->exposed_set_cache( 'roundtrip_empty', [] );
+		$this->assertSame( [], $this->api->exposed_get_cache( 'roundtrip_empty' ) );
+
+		$rows = [ [ 'title' => 'Tomorrow, and Tomorrow, and Tomorrow' ] ];
+		$this->api->exposed_set_cache( 'roundtrip_rows', $rows );
+		$this->assertSame( $rows, $this->api->exposed_get_cache( 'roundtrip_rows' ) );
+	}
 }


### PR DESCRIPTION
A lookup can come back empty for reasons that have nothing to do with the query — a rate limit, a transient upstream failure, a service answering 200 with no rows. `set_cache()` stored that empty answer for the full cache duration (`DAY_IN_SECONDS`), so the same search kept reporting "no results found" for a day, and because the cached value was served every time, no request was ever made to notice the service had recovered.

Seen on a live site: an OpenLibrary title search returned nothing on every attempt, then started working immediately after the object cache was flushed for an unrelated reason. Sites running a persistent object cache (Redis, Memcached) feel this hardest, since transients live there rather than in the options table.

Empty results now expire after five minutes — short enough to self-heal, long enough to absorb someone retrying in frustration. Real results keep the full duration.

Fixed in `set_cache()` rather than at the ~130 `set_cache` call sites across the API clients, so every service is covered and a new client can't reintroduce it.

Three tests on `API_Base`: empty results get the short TTL, non-empty keep the full one, and both round-trip through `get_cache()` unchanged. Negative control run before committing — with the guard removed, the empty-TTL test fails on the day-long timeout; restored, it passes. `ApiBaseTest` is 20 tests / 32 assertions green.