### PR TITLE
📖 DOC: list the companion plugins both readmes were missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ Then activate the plugin in WordPress admin.
 - [Post Formats for Block Themes](https://wordpress.org/plugins/post-formats-for-block-themes/) — post format support in block themes
 - [Link Extension for XFN](https://wordpress.org/plugins/link-extension-for-xfn/) — XFN relationship options
 
+**Integrated** (detected at runtime; each stays optional):
+
+- [ATmosphere](https://wordpress.org/plugins/atmosphere/) — Standard.site publishing on AT Protocol (2.1.0+). It owns the connection and records; this plugin supplies kind eligibility, derived titles, and check-in privacy rules.
+- [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/) / [My Calendar](https://wordpress.org/plugins/my-calendar/) — either one feeds the Event card's name, start, end, location, and URL. Neither installed, and the card uses its own fields.
+- [WP Recipe Maker](https://wordpress.org/plugins/wp-recipe-maker/) — detects a WPRM recipe in a post and suggests the recipe kind.
+
 **Optional:**
 
 - [ActivityPub](https://wordpress.org/plugins/activitypub/) — federate with Mastodon and the Fediverse

--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,10 @@ Each kind gets its own archive page (for example `/kind/listen/`), and the kind 
 * [IndieBlocks](https://wordpress.org/plugins/indieblocks/) — detected and recommended, not required. It provides companion blocks (Facepile, Location, Syndication, Link Preview); this plugin doesn't implement those features itself.
 * [Webmention](https://wordpress.org/plugins/webmention/) — detected on the Integrations settings tab. Cross-site conversations come from that plugin, not this one.
 * [Syndication Links](https://wordpress.org/plugins/syndication-links/), [Post Formats for Block Themes](https://wordpress.org/plugins/post-formats-for-block-themes/), [Bookmark Card](https://wordpress.org/plugins/bookmark-card/) — detected and enhanced when present.
+* [ATmosphere](https://wordpress.org/plugins/atmosphere/) — optional companion (2.1.0+) for Standard.site publishing on AT Protocol. ATmosphere owns the connection and the records; this plugin decides which kinds publish, derives readable titles for untitled posts, and applies check-in privacy rules. Everything else works without it.
+* [Link Extension for XFN](https://wordpress.org/plugins/link-extension-for-xfn/) — detected on the Integrations settings tab. Adds XFN relationship options to the block editor's link popover, so a reply or mention can say how you know the person.
+* [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/) and [My Calendar](https://wordpress.org/plugins/my-calendar/) — either one feeds the Event card. Event name, start, end, location, and URL are read from whichever is installed; with neither, the card falls back to its own fields.
+* [WP Recipe Maker](https://wordpress.org/plugins/wp-recipe-maker/) — a post containing a WPRM recipe is detected, and the recipe kind is suggested for it.
 * [ActivityPub](https://wordpress.org/plugins/activitypub/) — a recommendation only; this plugin contains no ActivityPub integration.
 
 = Conflicts =


### PR DESCRIPTION
Five plugins this one actually integrates with weren't listed where people look for them.

`readme.txt`'s **Works with** section had no entry for ATmosphere (it appeared only as a feature bullet further up) or Link Extension for XFN, and neither readme mentioned the calendar or recipe integrations at all — despite all of them living in `includes/integrations/` and being feature-detected at runtime. Link Extension for XFN even has its own card on the Integrations settings tab with an Active / Not Installed badge, so the plugin was already telling users about a relationship the docs didn't.

Added to both readmes:

- **ATmosphere** — Standard.site publishing; it owns the connection and records, this plugin supplies kind eligibility, derived titles, and check-in privacy.
- **Link Extension for XFN** — detected on the Integrations tab; XFN options in the link popover.
- **The Events Calendar** / **My Calendar** — either feeds the Event card; with neither, the card falls back to its own fields.
- **WP Recipe Maker** — detects a WPRM recipe and suggests the recipe kind.

Each entry states what happens *without* the plugin, matching how the existing entries separate required (Micropub) from detected (IndieBlocks, Webmention) from recommendation-only (ActivityPub). README.md gets an "Integrated" group so runtime detections aren't conflated with the plugins that are merely nice alongside.

Docs only — no code change. `DistributionManifestTest` and the readme tests pass (3 tests, 9 assertions).