### PR TITLE
📖 DOC: name RSS Chat in the companion lists, with what it does not do

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Then activate the plugin in WordPress admin.
 **Optional:**
 
 - [ActivityPub](https://wordpress.org/plugins/activitypub/) — federate with Mastodon and the Fediverse
+- [RSS Chat](https://github.com/pfefferle/wordpress-rss-chat) — publish to the rss.chat network. Recommendation only; there is no integration here. RSS Chat routes on the core `chat` post format, which is independent of kinds, so kinds do not drive rss.chat syndication today — see [issue #6](https://github.com/pfefferle/wordpress-rss-chat/issues/6). GitHub only, not on WordPress.org.
 
 **Conflicts:**
 

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,7 @@ Each kind gets its own archive page (for example `/kind/listen/`), and the kind 
 * [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/) and [My Calendar](https://wordpress.org/plugins/my-calendar/) — either one feeds the Event card. Event name, start, end, location, and URL are read from whichever is installed; with neither, the card falls back to its own fields.
 * [WP Recipe Maker](https://wordpress.org/plugins/wp-recipe-maker/) — a post containing a WPRM recipe is detected, and the recipe kind is suggested for it.
 * [ActivityPub](https://wordpress.org/plugins/activitypub/) — a recommendation only; this plugin contains no ActivityPub integration.
+* [RSS Chat](https://github.com/pfefferle/wordpress-rss-chat) — a recommendation only; this plugin contains no rss.chat integration, and RSS Chat is on GitHub rather than WordPress.org. It syndicates posts carrying the core **chat** post format, which is separate from kinds, so a note or a reply is not sent to rss.chat unless you also set that format on it. Whether that check could become filterable, so a kind could decide instead, is open upstream: [issue #6](https://github.com/pfefferle/wordpress-rss-chat/issues/6).
 
 = Conflicts =
 


### PR DESCRIPTION
Follows #185, which filled in the companion lists. rss.chat was still missing from both, even though the question that started this — can a Post Kind reach rss.chat — is one people will actually ask.

It goes in the recommendation-only tier next to ActivityPub, because that is honestly where it sits. RSS Chat gates syndication on the core `chat` post format:

```php
if ( 'chat' !== \get_post_format( $post ) ) {
	return;
}
```

Kinds have no say in that, and nothing in this plugin talks to RSS Chat. The entry says so instead of implying a pairing that does not exist, notes that RSS Chat lives on GitHub rather than WordPress.org, and links pfefferle/wordpress-rss-chat#6, which asks whether that check could become filterable so a kind could decide.

Docs only, no version bump. The wordpress.org listing picks it up at the next release.