### PR TITLE
🐛 FIX: mood posts read as "emoji text" in feeds, not a flattened card

### DIFF
--- a/includes/functions-feed-mood.php
+++ b/includes/functions-feed-mood.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Mood posts in syndication feeds.
+ *
+ * The mood card renders a badge SVG, a "Mood" kind label, and the emoji as
+ * block-level markup. A feed reader strips the styling and flattens that
+ * into a stack of stray lines ("Mood", the emoji, then the text). In feeds
+ * the card collapses to its essence instead: the emoji inline at the head
+ * of the post text ("🥳 Testing out …"), or "emoji note" as a single
+ * paragraph when the card is the whole post.
+ *
+ * @package PKIW
+ */
+
+namespace PKIW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Suppress the mood card's markup in feed content.
+ *
+ * Runs on the mood-card block's render filter; feed_mood_content() re-adds
+ * the mood as an inline emoji afterwards.
+ *
+ * @param string $content Rendered block HTML.
+ * @return string Empty string in feeds, untouched HTML elsewhere.
+ */
+function suppress_mood_card_in_feeds( $content ) {
+	return is_feed() ? '' : $content;
+}
+add_filter( 'render_block_post-kinds-indieweb/mood-card', __NAMESPACE__ . '\\suppress_mood_card_in_feeds' );
+
+/**
+ * The first mood-card block in a post body, as its emoji and note.
+ *
+ * Attributes come straight from the stored block comment. Mirroring the
+ * block's own render (block.json defaults emoji to ''), an absent emoji
+ * stays absent rather than gaining a default.
+ *
+ * @param string $post_content Raw post content.
+ * @return array{emoji: string, note: string}|null Card data, or null when the body has no mood-card block.
+ */
+function first_mood_card( string $post_content ): ?array {
+	if ( ! str_contains( $post_content, 'post-kinds-indieweb/mood-card' ) ) {
+		return null;
+	}
+
+	$stack = parse_blocks( $post_content );
+	while ( $stack ) {
+		$block = array_shift( $stack );
+
+		if ( 'post-kinds-indieweb/mood-card' === ( $block['blockName'] ?? '' ) ) {
+			return [
+				'emoji' => trim( (string) ( $block['attrs']['emoji'] ?? '' ) ),
+				'note'  => trim( (string) ( $block['attrs']['note'] ?? '' ) ),
+			];
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			$stack = array_merge( $stack, $block['innerBlocks'] );
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Lead a mood post's feed content with its emoji, inline.
+ *
+ * The card itself is suppressed in feeds; here the emoji is planted inside
+ * the first paragraph so it reads on the same line as the text. A post
+ * that was nothing but the card becomes a single "emoji note" paragraph.
+ *
+ * @param string $content Feed item content, blocks already rendered.
+ * @return string Content led by the mood emoji.
+ */
+function feed_mood_content( $content ) {
+	if ( ! is_feed() ) {
+		return $content;
+	}
+
+	$post = get_post();
+	if ( ! $post instanceof \WP_Post ) {
+		return $content;
+	}
+
+	$card = first_mood_card( (string) $post->post_content );
+	if ( null === $card ) {
+		return $content;
+	}
+
+	$content = trim( (string) $content );
+
+	if ( '' === $content ) {
+		$line = trim( $card['emoji'] . ' ' . wp_strip_all_tags( $card['note'] ) );
+
+		return '' === $line ? '' : '<p>' . esc_html( $line ) . '</p>';
+	}
+
+	if ( '' === $card['emoji'] ) {
+		return $content;
+	}
+
+	$count   = 0;
+	$content = preg_replace_callback(
+		'/<p\b[^>]*>/',
+		static function ( $matches ) use ( $card ) {
+			return $matches[0] . esc_html( $card['emoji'] ) . ' ';
+		},
+		$content,
+		1,
+		$count
+	);
+
+	return ( 0 === $count ) ? esc_html( $card['emoji'] ) . ' ' . $content : $content;
+}
+add_filter( 'the_content_feed', __NAMESPACE__ . '\\feed_mood_content' );
+
+/**
+ * Lead a mood post's feed excerpt with its emoji.
+ *
+ * Covers the "For each post in a feed, include: Excerpt" reading setting,
+ * where the item body is the excerpt rather than the rendered content.
+ *
+ * @param string $excerpt Feed item excerpt.
+ * @return string Excerpt led by the mood emoji.
+ */
+function feed_mood_excerpt( $excerpt ) {
+	if ( ! is_feed() ) {
+		return $excerpt;
+	}
+
+	$post = get_post();
+	if ( ! $post instanceof \WP_Post ) {
+		return $excerpt;
+	}
+
+	$card = first_mood_card( (string) $post->post_content );
+	if ( null === $card || '' === $card['emoji'] ) {
+		return $excerpt;
+	}
+
+	$excerpt = trim( (string) $excerpt );
+	if ( '' === $excerpt ) {
+		$excerpt = wp_strip_all_tags( $card['note'] );
+	}
+
+	return trim( $card['emoji'] . ' ' . $excerpt );
+}
+add_filter( 'the_excerpt_rss', __NAMESPACE__ . '\\feed_mood_excerpt' );

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -342,6 +342,7 @@ require_once PKIW_PATH . 'includes/functions-embeds.php';
 require_once PKIW_PATH . 'includes/functions-card-icons.php';
 require_once PKIW_PATH . 'includes/functions-card-labels.php';
 require_once PKIW_PATH . 'includes/functions-stream-card.php';
+require_once PKIW_PATH . 'includes/functions-feed-mood.php';
 
 // Hook into WordPress init (priority 0 so component registrations land
 // before the priority-10 callbacks they depend on).

--- a/tests/phpunit/integration/FeedMoodRenderTest.php
+++ b/tests/phpunit/integration/FeedMoodRenderTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Integration tests for mood rendering in syndication feeds.
+ *
+ * A mood post's card block renders badge SVG, a "Mood" kind label, and the
+ * emoji as block-level markup — a feed reader flattens that into stray
+ * lines. In feeds the mood should collapse to its essence: the emoji
+ * inline at the head of the post text.
+ *
+ * @package PKIW
+ */
+
+/**
+ * @covers \PKIW\suppress_mood_card_in_feeds
+ * @covers \PKIW\feed_mood_content
+ * @covers \PKIW\feed_mood_excerpt
+ */
+class FeedMoodRenderTest extends WP_UnitTestCase {
+
+	const MOOD_CARD = '<!-- wp:post-kinds-indieweb/mood-card {"mood":"Excited","emoji":"🥳","note":"Excited","moodAt":"2026-08-23"} /-->';
+
+	public function test_long_form_mood_feed_content_leads_with_inline_emoji(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_title'   => 'Demo.RSS.Chat',
+				'post_content' => self::MOOD_CARD . "\n\n" .
+					'<!-- wp:paragraph --><p>Testing out connecting my site to Demo.RSS.Chat.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$content = $this->feed_content_for( $post_id );
+
+		$this->assertMatchesRegularExpression( '/<p\b[^>]*>🥳 Testing out connecting my site to Demo\.RSS\.Chat\.<\/p>/', $content );
+		$this->assertStringNotContainsString( 'Mood', $content );
+		$this->assertStringNotContainsString( 'pk-card', $content );
+		$this->assertStringNotContainsString( 'pk-kindlabel', $content );
+	}
+
+	public function test_micro_mood_feed_content_is_emoji_and_note(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_title'   => 'Recharged',
+				'post_content' => '<!-- wp:post-kinds-indieweb/mood-card {"mood":"Recharged","emoji":"😌","note":"Recharged","moodAt":"2026-08-10"} /-->',
+			]
+		);
+
+		$content = $this->feed_content_for( $post_id );
+
+		$this->assertSame( '<p>😌 Recharged</p>', trim( $content ) );
+	}
+
+	public function test_mood_card_without_emoji_leaves_content_bare(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_content' => '<!-- wp:post-kinds-indieweb/mood-card {"mood":"Quiet","note":"Quiet"} /-->' . "\n\n" .
+					'<!-- wp:paragraph --><p>Just words today.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$content = $this->feed_content_for( $post_id );
+
+		$this->assertMatchesRegularExpression( '/<p\b[^>]*>Just words today\.<\/p>/', $content );
+		$this->assertStringNotContainsString( 'pk-card', $content );
+	}
+
+	public function test_non_mood_post_feed_content_is_untouched(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_content' => '<!-- wp:paragraph --><p>An ordinary post.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$content = $this->feed_content_for( $post_id );
+
+		$this->assertMatchesRegularExpression( '/<p\b[^>]*>An ordinary post\.<\/p>/', $content );
+		$this->assertStringNotContainsString( '🥳', $content );
+	}
+
+	public function test_feed_excerpt_leads_with_emoji(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_excerpt' => '',
+				'post_content' => self::MOOD_CARD . "\n\n" .
+					'<!-- wp:paragraph --><p>Testing out connecting my site to Demo.RSS.Chat.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$this->go_to( '/?feed=rss2' );
+
+		$excerpt = null;
+		while ( have_posts() ) {
+			the_post();
+			if ( get_the_ID() === $post_id ) {
+				$excerpt = apply_filters( 'the_excerpt_rss', get_the_excerpt() );
+				break;
+			}
+		}
+
+		$this->assertNotNull( $excerpt, 'Post never appeared in the feed loop.' );
+		$this->assertStringStartsWith( '🥳 Testing out connecting my site', $excerpt );
+	}
+
+	public function test_web_rendering_still_shows_the_full_card(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_content' => self::MOOD_CARD . "\n\n" .
+					'<!-- wp:paragraph --><p>Testing out connecting my site to Demo.RSS.Chat.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+		$post = get_post( $post_id );
+
+		$this->assertFalse( is_feed() );
+
+		$content = do_blocks( $post->post_content );
+
+		$this->assertStringContainsString( 'pk-card', $content );
+		$this->assertStringContainsString( 'pk-mood__emoji', $content );
+	}
+
+	/**
+	 * Render a post's feed content the way the RSS2 template does.
+	 *
+	 * @param int $post_id Post to render.
+	 * @return string Feed item content.
+	 */
+	private function feed_content_for( int $post_id ): string {
+		$this->go_to( '/?feed=rss2' );
+
+		$this->assertTrue( is_feed(), 'Feed context did not take.' );
+
+		while ( have_posts() ) {
+			the_post();
+			if ( get_the_ID() === $post_id ) {
+				return get_the_content_feed( 'rss2' );
+			}
+		}
+
+		$this->fail( sprintf( 'Post %d never appeared in the feed loop.', $post_id ) );
+	}
+}


### PR DESCRIPTION
A mood post in the RSS/Atom feed currently arrives as the card flattened to its text nodes:

```
Mood

🥳
Testing out connecting my site to Demo.RSS.Chat. Dave has a lot of ideas for RSS that I can't wait to see happen.
```

The card markup (badge SVG, kind label, block-level emoji) is built for a styled page; a feed reader has none of that styling, so every block element becomes its own stray line.

In feeds the mood-card block now renders as nothing, and a `the_content_feed` filter plants the emoji inside the first paragraph so the item body reads inline:

```
🥳 Testing out connecting my site to Demo.RSS.Chat. Dave has a lot of ideas for RSS that I can't wait to see happen.
```

A post that is nothing but the card becomes a single "emoji note" paragraph (`🥳 Recharged`-style), and `the_excerpt_rss` gets the same treatment for sites whose feeds carry excerpts. Web rendering is untouched. A card whose emoji attribute was never set stays emoji-less in the feed too, mirroring the block's own render (block.json defaults `emoji` to an empty string).

Six integration tests in `FeedMoodRenderTest`: the long-form and card-only shapes, the no-emoji card, a non-mood control, the excerpt path, and the unchanged web render. Written failing first against ae96863; full suite locally is 1466 tests green (the two risky `SyndicationPageAuthorizationTest` warnings are present on clean main).