### PR TITLE
🐛 FIX: keep the mood emoji on long-form mood posts' stream cards

### DIFF
--- a/includes/functions-stream-card.php
+++ b/includes/functions-stream-card.php
@@ -138,6 +138,16 @@ function render_generic_stream_card( \WP_Post $post ): string {
 	$out .= '<div class="pk-badge">' . get_kind_icon_svg( $badge_kind ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	$out .= '<div class="pk-body">';
 	$out .= '<p class="pk-kindlabel">' . esc_html( get_kind_label( $kind_label, $badge_kind, 'stream-card' ) ) . '</p>';
+
+	// A long-form mood post falls through to this card, which would otherwise
+	// drop the mood-card block's emoji — carry it over as the mood pin.
+	if ( 'mood' === $kind_slug ) {
+		$emoji = extract_mood_card_emoji( (string) $post->post_content );
+		if ( '' !== $emoji ) {
+			$out .= '<span class="pk-mood__emoji" aria-hidden="true">' . esc_html( $emoji ) . '</span>';
+		}
+	}
+
 	$out .= '<div class="pk-caption">';
 	$out .= '<h2 class="' . esc_attr( $title_class ) . '"><a href="' . $permalink . '">' . esc_html( $title ) . '</a></h2>';
 
@@ -360,6 +370,35 @@ function extract_first_video_url( string $content ): string {
 
 	if ( preg_match( '#https?://(?:www\.)?(?:youtube\.com/watch\?[^\s"<]+|youtu\.be/[A-Za-z0-9_-]{6,})#i', $content, $matches ) ) {
 		return $matches[0];
+	}
+
+	return '';
+}
+
+/**
+ * The emoji attribute of the first mood-card block in a post body.
+ *
+ * Saved block comments carry raw attributes — parse_blocks() applies no
+ * block.json defaults — so a mood-card saved without an explicit emoji has
+ * no `emoji` key at all. Mirror the block renderer's own 😊 fallback in
+ * that case; a body with no mood-card block yields '' so the card renders
+ * without a pin rather than inventing one.
+ *
+ * @param string $content Post content.
+ * @return string The emoji, or '' when the body has no mood-card block.
+ */
+function extract_mood_card_emoji( string $content ): string {
+	if ( ! str_contains( $content, 'post-kinds-indieweb/mood-card' ) ) {
+		return '';
+	}
+
+	foreach ( flatten_blocks( parse_blocks( $content ) ) as $block ) {
+		if ( 'post-kinds-indieweb/mood-card' !== ( $block['blockName'] ?? '' ) ) {
+			continue;
+		}
+
+		$emoji = trim( (string) ( $block['attrs']['emoji'] ?? '' ) );
+		return '' !== $emoji ? $emoji : '😊';
 	}
 
 	return '';

--- a/tests/phpunit/integration/StreamCardTest.php
+++ b/tests/phpunit/integration/StreamCardTest.php
@@ -333,6 +333,70 @@ final class StreamCardTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A long-form mood post keeps its mood-card emoji on the generic card,
+	 * ahead of the caption so the theme can paint it as the enamel pin.
+	 */
+	public function test_long_form_mood_renders_mood_card_emoji(): void {
+		$this->ensure_kind_term( 'mood' );
+		$post_id = self::factory()->post->create(
+			[
+				'post_title'   => 'A rainy-day reflection',
+				'post_content' => '<!-- wp:post-kinds-indieweb/mood-card {"mood":"Melancholy","emoji":"🌧️"} /-->' .
+					"\n\n<!-- wp:paragraph -->\n<p>Long thoughts about the rain.</p>\n<!-- /wp:paragraph -->",
+			]
+		);
+		wp_set_object_terms( $post_id, 'mood', 'kind' );
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$html = \PKIW\render_stream_card();
+
+		$this->assertStringContainsString( 'pk-card--stream', $html );
+		$this->assertStringContainsString( '<span class="pk-mood__emoji" aria-hidden="true">🌧️</span>', $html );
+		$this->assertLessThan( strpos( $html, 'pk-caption' ), strpos( $html, 'pk-mood__emoji' ) );
+	}
+
+	/**
+	 * A mood-card block with no explicit emoji still pins the block's 😊
+	 * default to the card.
+	 */
+	public function test_long_form_mood_without_explicit_emoji_uses_block_default(): void {
+		$this->ensure_kind_term( 'mood' );
+		$post_id = self::factory()->post->create(
+			[
+				'post_title'   => 'Feeling fine',
+				'post_content' => '<!-- wp:post-kinds-indieweb/mood-card {"mood":"Content"} /-->' .
+					"\n\n<!-- wp:paragraph -->\n<p>Nothing much to add.</p>\n<!-- /wp:paragraph -->",
+			]
+		);
+		wp_set_object_terms( $post_id, 'mood', 'kind' );
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$html = \PKIW\render_stream_card();
+
+		$this->assertStringContainsString( '<span class="pk-mood__emoji" aria-hidden="true">😊</span>', $html );
+	}
+
+	/**
+	 * A mood post with no mood-card block in the body gets no invented pin.
+	 */
+	public function test_long_form_mood_without_mood_card_block_has_no_emoji(): void {
+		$this->ensure_kind_term( 'mood' );
+		$post_id = self::factory()->post->create(
+			[
+				'post_title'   => 'Mood, in prose only',
+				'post_content' => "<!-- wp:paragraph -->\n<p>Words about a feeling.</p>\n<!-- /wp:paragraph -->",
+			]
+		);
+		wp_set_object_terms( $post_id, 'mood', 'kind' );
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$html = \PKIW\render_stream_card();
+
+		$this->assertStringContainsString( 'k-mood', $html );
+		$this->assertStringNotContainsString( 'pk-mood__emoji', $html );
+	}
+
+	/**
 	 * Make sure a `kind` term exists so it can be assigned to a post.
 	 *
 	 * @param string $slug Kind slug.


### PR DESCRIPTION
A mood post whose body is a mood-card block plus real paragraphs falls through `content_is_kind_card_only()` to `render_generic_stream_card()`, which builds its markup from post metadata alone. The emoji only exists in the mood-card block's saved attributes, so it vanished from the Stream. courtneyr.dev has been patching this site-side with a `render_block_post-kinds-indieweb/stream-card` filter in the child theme (`stream_card_mood_emoji` in `inc/post-kinds.php`); this upstreams that behavior into the renderer.

For kind=mood posts the generic card now extracts the emoji from the first mood-card block in the body and renders the same `<span class="pk-mood__emoji" aria-hidden="true">` the block itself emits, just before the caption, so the theme's existing enamel-pin CSS picks it up unchanged. A block saved without an explicit emoji gets the block renderer's own 😊 fallback — `parse_blocks()` applies no block.json defaults, so the attribute is simply absent from saved markup. A body with no mood-card block gets no span rather than an invented one.

The extraction reuses the file's existing `flatten_blocks()` walk rather than the theme filter's hand-rolled stack, and the kind check rides the `$kind_slug` the function already computes.

Three new StreamCardTest cases — explicit emoji, block-default, no-block — written first and watched fail against the unpatched renderer (both injection tests fail; the no-block test passes before and after, guarding against over-injection). StreamCardTest is 23 tests / 51 assertions green, MicroformatsRenderTest 8/8 (the span is aria-hidden and carries no mf2 class), full suite 1463 tests with no failures beyond the two pre-existing SyndicationPageAuthorizationTest output-buffer risky flags, PHPCS clean on the touched file, PHPStan level 5 clean.

Once this ships, the theme filter's `pk-mood__emoji` guard (`str_contains` early return) makes the site-side patch a no-op; removing it from the child theme can follow separately.
