### PR TITLE
🚀 RELEASE: 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-08-24
+
+### Fixed
+
+- Long-form mood posts (a mood card plus real paragraphs) lost their emoji on the Stream. The generic stream card builds from post metadata and never read the mood-card block's attributes, so the emoji vanished from the feed item. The card now renders the emoji from the post's first mood-card block, ahead of its caption — a card saved without an explicit emoji shows the block's 😊 default, and a mood post with no mood card gets no invented one.
+- Mood posts arrived in RSS/Atom feeds as a stack of stray lines — the "Mood" kind label, the emoji alone, then the text — because feed readers flatten the card's block-level markup. In feeds the card now collapses to its essence: the emoji inline at the head of the post text, or a single "emoji note" paragraph when the card is the whole post. Excerpt feeds get the same treatment; web rendering is untouched.
+
 ## [1.7.0] - 2026-08-21
 
 ### Added
@@ -372,7 +379,10 @@ This project uses Semantic Versioning:
 - [Issues](https://github.com/courtneyr-dev/post-kinds-for-indieweb/issues)
 - [IndieWeb Wiki](https://indieweb.org/)
 
-[Unreleased]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.2...HEAD
+[Unreleased]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/courtneyr-dev/post-kinds-for-indieweb/compare/1.0.0...v1.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "post-kinds-for-indieweb-in-block-themes",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "post-kinds-for-indieweb-in-block-themes",
-			"version": "1.7.0",
+			"version": "1.7.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "post-kinds-for-indieweb-in-block-themes",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"description": "Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.",
 	"author": "Courtney Robertson",
 	"license": "GPL-2.0-or-later",

--- a/post-kinds-for-indieweb-in-block-themes.php
+++ b/post-kinds-for-indieweb-in-block-themes.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Post Kinds for IndieWeb in Block Themes
  * Plugin URI:        https://github.com/courtneyr-dev/post-kinds-for-indieweb
  * Description:       Modern block editor support for IndieWeb post kinds and microformats. A successor to the classic IndieWeb Post Kinds plugin.
- * Version:           1.7.0
+ * Version:           1.7.1
  * Requires at least: 7.0
  * Tested up to:      7.1
  * Requires PHP:      8.2
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'PKIW_VERSION', '1.7.0' );
+define( 'PKIW_VERSION', '1.7.1' );
 
 /**
  * Plugin directory path constant.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: indieweb, post-kinds, microformats, block-editor, scrobbling
 Requires at least: 7.0
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -175,6 +175,10 @@ Long-form guides — installation, settings, common tasks, troubleshooting, priv
 9. Standard.site record panel on a Bookmark Card, showing the cited page's own title, publication, description, and tags read from AT Protocol
 
 == Changelog ==
+
+= 1.7.1 =
+* Fixed: long mood posts lost their emoji on the Stream. The compact card now shows the emoji from the post's mood card.
+* Fixed: mood posts read as a stack of stray lines in feed readers. Feeds now show the emoji inline with the post text instead of the flattened card markup.
 
 = 1.7.0 =
 * Added: four more kinds — chicken, comics, collection, and presentation — bringing the total to 40.


### PR DESCRIPTION
Version bump + changelog for 1.7.1 — the two mood fixes already on main: feeds read as "emoji text" instead of a flattened card (#187), and long-form mood posts keep their emoji on the Stream card (#188). Header, PKIW_VERSION, Stable tag, and package.json all move to 1.7.1; the changelog also backfills the missing 1.6.0/1.7.0 compare links. Tag v1.7.1 follows the merge.